### PR TITLE
removed dependence on functools.reduce

### DIFF
--- a/nibabel/eulerangles.py
+++ b/nibabel/eulerangles.py
@@ -84,7 +84,6 @@ The convention of rotation around ``z``, followed by rotation around
 '''
 
 import math
-from functools import reduce
 
 import numpy as np
 

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -153,7 +153,6 @@ __all__ = ['netcdf_file', 'netcdf_variable']
 
 
 from operator import mul
-from functools import reduce
 from mmap import mmap, ACCESS_READ
 
 import numpy as np


### PR DESCRIPTION
I guess this tiny one is for Matthew: There is a dependence on functools.reduce that make it incompatible with 2.5.
using python's default reduce insteed seems to be sufficient.
