### PR TITLE
add mailmap file for better shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,3 +3,4 @@ Michael Hanke <mhanke-guest@82381867-18eb-0310-98a2-9474e637aba2>
 Michael Hanke <michaelhanke@mvpa1.dartmouth.edu>
 Yaroslav Halchenko <debian@onerussian.com>
 Yaroslav Halchenko <yoh-guest@82381867-18eb-0310-98a2-9474e637aba2>
+Bertrand Thirion <bertrand.thirion@inria.fr> bthirion <bertrand.thirion@inria.fr>


### PR DESCRIPTION
The .mailmap file maps multiple identities onto unique identifiers.

See also: man git-shortlog

Old:

   509  Matthew Brett
   287  Michael Hanke
    68  mhanke-guest
    57  Stephan Gerhard
    16  Christopher Burns
    16  Jarrod Millman
     9  yoh-guest
     4  Ian Nimmo-Smith
     4  Yaroslav Halchenko
     1  Thomas Ballinger
     1  bthirion

New:

   509  Matthew Brett
   355  Michael Hanke
    57  Stephan Gerhard
    16  Christopher Burns
    16  Jarrod Millman
    13  Yaroslav Halchenko
     4  Ian Nimmo-Smith
     1  Thomas Ballinger
     1  Valentin Haenel
     1  bthirion
