### PR TITLE
BF+TST - fix failed scalar write for float32

### DIFF
--- a/nibabel/tests/test_trackvis.py
+++ b/nibabel/tests/test_trackvis.py
@@ -85,6 +85,18 @@ def test_write_scalars_props():
     for actual, expected in zip(streams, back_streams):
         for a_el, e_el in zip(actual, expected):
             assert_array_equal(a_el, e_el)
+    # Also so if the datatype of points, scalars is already float32 (github
+    # issue #53)
+    out_f.seek(0)
+    streams = [(points.astype('f4'),
+                scalars.astype('f4'),
+                props.astype('f4'))]
+    tv.write(out_f, streams)
+    out_f.seek(0)
+    back_streams, hdr = tv.read(out_f)
+    for actual, expected in zip(streams, back_streams):
+        for a_el, e_el in zip(actual, expected):
+            assert_array_almost_equal(a_el, e_el)
 
 
 def streams_equal(stream1, stream2):

--- a/nibabel/trackvis.py
+++ b/nibabel/trackvis.py
@@ -399,7 +399,7 @@ def write(fileobj, streamlines,  hdr_mapping=None, endianness=None,
                                  % (n_pts, n_s))
             if scalars.dtype != f4dt:
                 scalars = scalars.astype(f4dt)
-                pts = np.c_[pts, scalars]
+            pts = np.c_[pts, scalars]
         fileobj.write(pts.tostring())
         if n_p == 0:
             if not (props is None or len(props) == 0):


### PR DESCRIPTION
As Marc Cote points out in github issue gh-53, if the scalars are
float32 type on input, they are not saved in the file correctly. This
adds a test for the issue, and closes gh-53
