### PR TITLE
BF - avoid test failures from DFT on Windows

### DIFF
--- a/nibabel/tests/test_dft.py
+++ b/nibabel/tests/test_dft.py
@@ -1,6 +1,7 @@
 """ Testing dft
 """
 
+import os
 from os.path import join as pjoin, dirname
 import StringIO
 
@@ -9,16 +10,23 @@ import numpy as np
 from .. import dft
 from .. import nifti1
 
+from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 # Shield optional package imports
 from ..optpkg import optional_package
 # setup_module will raise SkipTest if no dicom to import
-dicom, have_dicom, setup_module = optional_package('dicom')
+dicom, have_dicom, _ = optional_package('dicom')
 PImage, have_pil, _ = optional_package('PIL.Image')
 pil_test = np.testing.dec.skipif(not have_pil, 'could not import PIL.Image')
 
 data_dir = pjoin(dirname(__file__), 'data')
+
+def setup_module():
+    if os.name == 'nt':
+        raise SkipTest('FUSE not available for windows, skipping dft tests')
+    if not have_dicom:
+        raise SkipTest('Need pydicom for dft tests, skipping')
 
 
 def test_init():


### PR DESCRIPTION
dft was failing on Windows because of the module-level use of os.getuid.
Replace with getuser.getpass, and avoid creating database when importing
in Windows.  Skip tests under Windows.

I haven't tested this on Windows yet - but this just to check if I'm on the right track.
