### PR TITLE
RF - remove deprecated get_shape for mgh format

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -556,10 +556,6 @@ class MGHImage(SpatialImage):
         '''
         header.writeftr_to(mghfile)
 
-    def get_shape(self):
-        ''' Return the shape of the data'''
-        return self._data.shape
-
     def get_affine(self):
         ''' Return the affine transform'''
         return self._header.get_vox2ras()


### PR DESCRIPTION
We just switched to using the 'shape' property instead, which results in the
same exact code.

@ksubramz - OK with you?  I think it doesn't change any output.
