### PR TITLE
Fix: Nibabel Nifti and Analyze images do not pickle

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -890,23 +890,26 @@ class AnalyzeHeader(WrapStruct):
         return hdr, rep
 
 
+class ImageArrayProxy(ArrayProxy):
+    ''' Analyze-type implemention of array proxy protocol
+
+    The array proxy allows us to freeze the passed fileobj and
+    header such that it returns the expected data array.
+    '''
+    def _read_data(self):
+        fileobj = allopen(self.file_like)
+        data = self.header.data_from_fileobj(fileobj)
+        if isinstance(self.file_like, basestring): # filename
+            fileobj.close()
+        return data
+
+
 class AnalyzeImage(SpatialImage):
     header_class = AnalyzeHeader
     files_types = (('image','.img'), ('header','.hdr'))
     _compressed_exts = ('.gz', '.bz2')
 
-    class ImageArrayProxy(ArrayProxy):
-        ''' Analyze-type implemention of array proxy protocol
-
-        The array proxy allows us to freeze the passed fileobj and
-        header such that it returns the expected data array.
-        '''
-        def _read_data(self):
-            fileobj = allopen(self.file_like)
-            data = self.header.data_from_fileobj(fileobj)
-            if isinstance(self.file_like, basestring): # filename
-                fileobj.close()
-            return data
+    ImageArrayProxy = ImageArrayProxy
 
     def get_header(self):
         ''' Return header

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -9,6 +9,7 @@
 ''' Tests for nifti reading package '''
 from __future__ import with_statement
 import os
+import pickle
 
 from ..py3k import BytesIO, ZEROB, asbytes
 
@@ -654,3 +655,7 @@ def test_affines_init():
 
 
 
+def test_pickle():
+    # Smoketest that loaded nifti image do pickle
+    nim = load(image_file)
+    pickle.dumps(nim)


### PR DESCRIPTION
This is a fix for issue #77

I had a go at having other file formats pickle, but they all had open files, which do not pickle, so I gave up.
