### PR TITLE
RF - refactor ability to load compressed .mgz file

### DIFF
--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -122,3 +122,20 @@ def bad_dtype_mgh():
 def test_bad_dtype_mgh():
     # Now test the above function
     assert_raises(MGHError, bad_dtype_mgh)
+
+
+def test_filename_exts():
+    # Test acceptable filename extensions
+    v = np.ones((7, 13, 3, 22)).astype(np.uint8)
+    # form a MGHImage object using data
+    # and the default affine matrix (Note the "None")
+    img = MGHImage(v, None)
+    # Check if these extensions allow round trip
+    for ext in ('.mgh', '.mgz', '.mgh.gz'):
+        with InTemporaryDirectory():
+            fname = 'tmpname' + ext
+            save(img, fname)
+            # read from the tmp file and see if it checks out
+            img_back = load(fname)
+            assert_array_equal(img_back.get_data(), v)
+            del img_back


### PR DESCRIPTION
Check for .mgz extension directly before calling parent method. This
allows people to use .mgh.gz files if they want.  If that's not a good
feature, the compressed_exts class attribute could be () to disallow
this.

For @ksubramz I think.
