### PR TITLE
BF - only update header if affine not close

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -1055,7 +1055,7 @@ class AnalyzeImage(SpatialImage):
         # the header, update the heaader
         if self._affine is None:
             return
-        if np.all(self._affine == hdr.get_best_affine()):
+        if np.allclose(self._affine, hdr.get_best_affine()):
             return
         RZS = self._affine[:3, :3]
         vox = np.sqrt(np.sum(RZS * RZS, axis=0))

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1432,7 +1432,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
         # the header, update the heaader
         if self._affine is None:
             return
-        if np.all(self._affine == hdr.get_best_affine()):
+        if np.allclose(self._affine, hdr.get_best_affine()):
             return
         # Set affine into sform with default code
         hdr.set_sform(self._affine, code='aligned')

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -211,6 +211,18 @@ class TestNifti1Image(tana.TestAnalyzeImage):
         assert_array_equal(hdr_back.get_sform(), exp_aff)
         assert_array_equal(hdr_back.get_qform(), exp_aff)
 
+    def test_header_update_affine(self):
+        # Test that updating occurs only if affine is not allclose
+        img = self.image_class(np.zeros((2,3,4)), np.eye(4))
+        hdr = img.get_header()
+        aff = img.get_affine()
+        aff[:] = np.diag([1.1, 1.1, 1.1, 1]) # inexact floats
+        hdr.set_qform(aff, 2)
+        hdr.set_sform(aff, 2)
+        img.update_header()
+        assert_equal(hdr['sform_code'], 2)
+        assert_equal(hdr['qform_code'], 2)
+
 
 class TestNifti1Pair(TestNifti1Image):
     # Run analyze-flavor spatialimage tests


### PR DESCRIPTION
Discussion at https://github.com/nipy/nibabel/issues/55. Because affine
in nifti1 stored as float32, using == to check if affine has changed
would give false positives, comparing to float64 input.  Brendan Moloney
kindly suggested allclose fix.
