### PR TITLE
Add ecat to the list of known imageclasses to ease loading with .load()

### DIFF
--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -14,6 +14,7 @@ from .nifti1 import Nifti1Pair, Nifti1Image
 from .minc import MincImage
 from .freesurfer import MGHImage
 from .volumeutils import Recoder
+from .ecat import EcatImage
 
 # If we don't have scipy, then we cannot write SPM format files
 try:
@@ -52,11 +53,16 @@ class_map = {
     'mgh':{'class': MGHImage,
            'ext': '.mgh',
            'has_affine': True,
-           'rw':True},
+           'rw': True},
     'mgz':{'class': MGHImage,
            'ext': '.mgz',
            'has_affine': True,
-           'rw':True}}
+           'rw': True},
+    'ecat':{'class': EcatImage,
+           'ext': '.v',
+           'has_affine': True,
+           'rw': False},
+    }
 
 
 
@@ -66,4 +72,6 @@ ext_map = Recoder((
     ('nifti_pair', '.img', '.hdr'),
     ('minc', '.mnc'),
     ('mgh', '.mgh'),
-    ('mgz', '.mgz')))
+    ('mgz', '.mgz'),
+    ('ecat', '.v'),
+    ))

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -37,7 +37,7 @@ def load(filename):
     except KeyError:
         raise ImageFileError('Cannot work out file type of "%s"' %
                              filename)
-    if ext in ('.nii', '.mnc', '.mgh', '.mgz'):
+    if ext in ('.nii', '.mnc', '.mgh', '.mgz', '.v'):
         klass = class_map[img_type]['class']
     else:
         # might be nifti pair or analyze of some sort


### PR DESCRIPTION
I am not sure if that is a logical thing to do -- just did it while testing nib-ls  so decided to "ask" with this PR
