### PR TITLE
NF - .get() for wrapstruct to provide the same convenience as dict's .get

### DIFF
--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -165,6 +165,11 @@ class _TestWrapStructBase(TestCase):
         assert_equal(keys, list(hdr_dt.names))
         for key, val in hdr.items():
             assert_array_equal(hdr[key], val)
+        # verify that .get operates as destined
+        assert_equal(hdr.get('nonexistent key'), None)
+        assert_equal(hdr.get('nonexistent key', 'default'), 'default')
+        assert_equal(hdr.get(keys[0]), vals[0])
+        assert_equal(hdr.get(keys[0], 'default'), vals[0])
 
     def test_endianness_ro(self):
         # endianness is a read only property

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -341,6 +341,10 @@ class WrapStruct(object):
         ''' Return items from structured data'''
         return zip(self.keys(), self.values())
 
+    def get(self, k, d=None):
+        ''' Return value for the key k if present or d otherwise'''
+        return (k in self.keys()) and self._structarr[k] or d
+
     def check_fix(self, logger=None, error_level=None):
         ''' Check structured data with checks '''
         if logger is None:


### PR DESCRIPTION
Since there is .keys, .values, I think it is only sensible to seek having .get()

NB my original intent for it was to access slice_dim, which is actually accessible via get_dim_info
