### PR TITLE
BF - only check dtype min-max is clip is needed

### DIFF
--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -300,6 +300,14 @@ class TestAnalyzeHeader(_TestWrapStructBase):
         _write_data(hdr, data, S3)
         data_back = hdr.data_from_fileobj(S3)
         assert_false(np.allclose(data, data_back))
+        # Test RGB image
+        dtype = np.dtype([('R', 'uint8'), ('G', 'uint8'), ('B', 'uint8')])
+        data = np.ones((1, 2, 3), dtype)
+        hdr.set_data_dtype(dtype)
+        S4 = BytesIO()
+        hdr.data_to_fileobj(data, S4)
+        data_back = hdr.data_from_fileobj(S4)
+        assert_array_equal(data, data_back)
 
     def test_datatype(self):
         ehdr = self.header_class()

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -601,7 +601,8 @@ def array_to_file(data, fileobj, out_dtype=None, offset=0,
     if not needs_f2i:
         # Apply min max thresholding the standard way
         needs_pre_clip = (mn, mx) != (None, None)
-        mn, mx = _dt_min_max(in_dtype, mn, mx)
+        if needs_pre_clip:
+            mn, mx = _dt_min_max(in_dtype, mn, mx)
     else: # We do need float to int machinery
         # Replace Nones in (mn, mx) with type min / max if necessary
         dt_mnmx = _dt_min_max(in_dtype, mn, mx)
@@ -670,6 +671,8 @@ def _dt_min_max(dtype_like, mn, mx):
     elif dt.kind in 'iu':
         info = np.iinfo(dt)
         mnmx = (info.min, info.max)
+    else:
+        raise NotImplementedError("unknown dtype")
     return mnmx[0] if mn is None else mn, mnmx[1] if mx is None else mx
 
 


### PR DESCRIPTION
min-max check fails on RGB data, only check if clip is needed.
