### PR TITLE
WIP: expose dataobj, affine, header image properties

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -974,8 +974,8 @@ class AnalyzeImage(SpatialImage):
         # We need to update the header if the data shape has changed.  It's a
         # bit difficult to change the data shape using the standard API, but
         # maybe it happened
-        if not self._data is None and hdr.get_data_shape() != self._data.shape:
-            hdr.set_data_shape(self._data.shape)
+        if hdr.get_data_shape() != self._dataobj.shape:
+            hdr.set_data_shape(self._dataobj.shape)
         # If the affine is not None, and it is different from the main affine in
         # the header, update the heaader
         if self._affine is None:

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -16,8 +16,6 @@ The API is - at minimum:
   ``np.asarray(obj)``.  Specifically, if you pass a header into the the
   __init__, then modifying the original header will not affect the result of the
   array return.
-
-You might also want to implement ``state_stamper``
 """
 
 from .volumeutils import allopen
@@ -42,7 +40,6 @@ class ArrayProxy(object):
     def __init__(self, file_like, header):
         self.file_like = file_like
         self.header = header.copy()
-        self._data = None
         self._shape = header.get_data_shape()
 
     @property
@@ -50,16 +47,9 @@ class ArrayProxy(object):
         return self._shape
 
     def __array__(self):
-        ''' Cached read of data from file '''
-        if self._data is None:
-            self._data = self._read_data()
-        return self._data
-
-    def _read_data(self):
+        ''' Read of data from file '''
         fileobj = allopen(self.file_like)
         data = self.header.data_from_fileobj(fileobj)
         if isinstance(self.file_like, basestring):  # filename
             fileobj.close()
         return data
-
-

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -309,7 +309,6 @@ class EcatHeader(object):
         hdr_data['ecat_calibration_factor'] = 1.0 # scale factor
         return hdr_data
 
-
     def get_data_dtype(self):
         """ Get numpy dtype for data from header"""
         raise NotImplementedError("dtype is only valid from subheaders")
@@ -319,7 +318,6 @@ class EcatHeader(object):
         return self.__class__(
             self.binaryblock,
             self.endianness)
-
 
     def __eq__(self, other):
         """ checks for equality between two headers"""
@@ -720,11 +718,34 @@ class EcatSubHeader(object):
         return data
 
 
+class EcatImageArrayProxy(object):
+    ''' Ecat implemention of array proxy protocol
+
+    The array proxy allows us to freeze the passed fileobj and
+    header such that it returns the expected data array.
+    '''
+    def __init__(self, subheader):
+        self._subheader = subheader
+        self._data = None
+        x, y, z = subheader.get_shape()
+        nframes = subheader.get_nframes()
+        self.shape = (x, y, z, nframes)
+
+    def __array__(self):
+        ''' Read of data from file
+
+        This reads ALL FRAMES into one array, can be memory expensive use
+        subheader.data_from_fileobj(frame) for less memory intensive reads
+        '''
+        data = np.empty(self.shape)
+        frame_mapping = self._subheader._mlist.get_frame_order()
+        for i in sorted(frame_mapping):
+            data[:,:,:,i] = self._subheader.data_from_fileobj(frame_mapping[i][0])
+        return data
 
 
 class EcatImage(SpatialImage):
-    """This class returns a list of Ecat images,
-    with one image(hdr/data) per frame
+    """ Class returns a list of Ecat images, with one image(hdr/data) per frame
     """
     _header = EcatHeader
     header_class = _header
@@ -732,35 +753,10 @@ class EcatImage(SpatialImage):
     _mlist = EcatMlist
     files_types = (('image', '.v'), ('header', '.v'))
 
+    ImageArrayProxy = EcatImageArrayProxy
 
-    class ImageArrayProxy(object):
-        ''' Ecat implemention of array proxy protocol
-
-        The array proxy allows us to freeze the passed fileobj and
-        header such that it returns the expected data array.
-        '''
-        def __init__(self, subheader):
-            self._subheader = subheader
-            self._data = None
-            x, y, z = subheader.get_shape()
-            nframes = subheader.get_nframes()
-            self.shape = (x, y, z, nframes)
-
-        def __array__(self):
-            ''' Cached read of data from file
-            This reads ALL FRAMES into one array, can be memory expensive
-            use subheader.data_from_fileobj(frame) for less memory intensive
-            reads
-            '''
-            if self._data is None:
-                self._data = np.empty(self.shape)
-                frame_mapping = self._subheader._mlist.get_frame_order()
-                for i in sorted(frame_mapping):
-                    self._data[:,:,:,i] = self._subheader.data_from_fileobj(frame_mapping[i][0])
-            return self._data
-
-    def __init__(self, data, affine, header,
-                 subheader, mlist ,
+    def __init__(self, dataobj, affine, header,
+                 subheader, mlist,
                  extra = None, file_map = None):
         """ Initialize Image
 
@@ -771,7 +767,7 @@ class EcatImage(SpatialImage):
 
         Parameters
         ----------
-        data : None or array-like
+        data : array-like
             image data
         affine : None or (4,4) array-like
             homogeneous affine giving relationship between voxel coords and
@@ -805,12 +801,12 @@ class EcatImage(SpatialImage):
         """
         self._subheader = subheader
         self._mlist = mlist
-        self._data = data
+        self._dataobj = dataobj
         if not affine is None:
             # Check that affine is array-like 4,4.  Maybe this is too strict at
             # this abstract level, but so far I think all image formats we know
             # do need 4,4.
-            affine = np.asarray(affine)
+            affine = np.array(affine, dtype=np.float64, copy=True)
             if not affine.shape == (4,4):
                 raise ValueError('Affine should be shape 4,4')
         self._affine = affine
@@ -822,17 +818,8 @@ class EcatImage(SpatialImage):
             file_map = self.__class__.make_file_map()
         self.file_map = file_map
 
-    def _set_header(self, header):
-        self._header = header
-
-    def get_data(self):
-        """returns scaled data for all frames in a numpy array
-        returns as a 4D array """
-        if self._data is None:
-            raise ImageDataError('No data in this image')
-        return np.asanyarray(self._data)
-
-    def get_affine(self):
+    @property
+    def affine(self):
         if not self._subheader._check_affines():
             warnings.warn('Affines different across frames, loading affine from FIRST frame',
                           UserWarning )
@@ -874,7 +861,6 @@ class EcatImage(SpatialImage):
     @classmethod
     def from_filespec(klass, filespec):
         return klass.from_filename(filespec)
-
 
     @staticmethod
     def _get_fileholders(file_map):

--- a/nibabel/minc.py
+++ b/nibabel/minc.py
@@ -183,6 +183,21 @@ class MincFile(object):
         return self._normalize(data)
 
 
+class MincImageArrayProxy(object):
+    ''' Minc implemention of array proxy protocol
+
+    The array proxy allows us to freeze the passed fileobj and
+    header such that it returns the expected data array.
+    '''
+    def __init__(self, minc_file):
+        self.minc_file = minc_file
+        self.shape = minc_file.get_data_shape()
+
+    def __array__(self):
+        ''' Read of data from file '''
+        return self.minc_file.get_scaled_data()
+
+
 class MincImage(SpatialImage):
     ''' Class for MINC images
 
@@ -193,22 +208,7 @@ class MincImage(SpatialImage):
     files_types = (('image', '.mnc'),)
     _compressed_exts = ('.gz', '.bz2')
 
-    class ImageArrayProxy(object):
-        ''' Minc implemention of array proxy protocol
-
-        The array proxy allows us to freeze the passed fileobj and
-        header such that it returns the expected data array.
-        '''
-        def __init__(self, minc_file):
-            self.minc_file = minc_file
-            self._data = None
-            self.shape = minc_file.get_data_shape()
-
-        def __array__(self):
-            ''' Cached read of data from file '''
-            if self._data is None:
-                self._data = self.minc_file.get_scaled_data()
-            return self._data
+    ImageArrayProxy = MincImageArrayProxy
 
     @classmethod
     def from_file_map(klass, file_map):

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -22,6 +22,7 @@ import copy
 from .spatialimages import SpatialImage, Header
 from .eulerangles import euler2mat
 from .volumeutils import Recoder
+from .arrayproxy import ArrayProxy
 
 # PAR header versions we claim to understand
 supported_versions = ['V4.2']
@@ -580,23 +581,7 @@ class PARRECImage(SpatialImage):
     header_class = PARRECHeader
     files_types = (('image', '.rec'), ('header', '.par'))
 
-    class ImageArrayProxy(object):
-        def __init__(self, rec_fobj, hdr):
-            self._rec_fobj = rec_fobj
-            self._hdr = hdr
-            self._data = None
-
-        def __array__(self):
-            ''' Cached read of data from file '''
-            if self._data is None:
-                self._data = self._hdr.data_from_fileobj(self._rec_fobj)
-            return self._data
-
-        @property
-        def shape(self):
-            # embedded header knows it, without having to touch the data
-            return self._hdr.get_data_shape()
-
+    ImageArrayProxy = ArrayProxy
 
     @classmethod
     def from_file_map(klass, file_map):

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -220,10 +220,35 @@ class TestEcatImage(TestCase):
         dat = self.img.get_data()
         # Make a new one to test arrayproxy
         img = self.image_class.load(self.example_file)
-        # Maybe we will promote _data to public, but I know this looks bad
-        secret_data = img._data
-        data2 = np.array(secret_data)
+        data_prox = img.dataobj
+        data2 = np.array(data_prox)
         assert_array_equal(data2, dat)
         # Check it rereads
-        data3 = np.array(secret_data)
+        data3 = np.array(data_prox)
         assert_array_equal(data3, dat)
+
+    def test_isolation(self):
+        # Test image isolated from external changes to affine
+        img_klass = self.image_class
+        arr, aff, hdr, sub_hdr, mlist = (self.img.get_data(),
+                                         self.img.affine,
+                                         self.img.header,
+                                         self.img.get_subheaders(),
+                                         self.img.get_mlist())
+        img = img_klass(arr, aff, hdr, sub_hdr, mlist)
+        assert_array_equal(img.affine, aff)
+        aff[0,0] = 99
+        assert_false(np.all(img.affine == aff))
+
+    def test_float_affine(self):
+        # Check affines get converted to float
+        img_klass = self.image_class
+        arr, aff, hdr, sub_hdr, mlist = (self.img.get_data(),
+                                         self.img.affine,
+                                         self.img.header,
+                                         self.img.get_subheaders(),
+                                         self.img.get_mlist())
+        img = img_klass(arr, aff.astype(np.float32), hdr, sub_hdr, mlist)
+        assert_equal(img.get_affine().dtype, np.dtype(np.float64))
+        img = img_klass(arr, aff.astype(np.int16), hdr, sub_hdr, mlist)
+        assert_equal(img.get_affine().dtype, np.dtype(np.float64))


### PR DESCRIPTION
As threatened on the list, expose the image data container directly as
`dataobj`.  Move the code for caching the read data out of the image
proxy objects and into the image classes.

Expose `affine` and `header` properties, add docstrings for `get_affine`
and `get_header` to warn of pending deprecation.

@cindeem @fmorency @hanke @ksubramz - please scan these changes - I've touched all of analyze, ecat, parrrec and mghformat here.
