### PR TITLE
TST: fix failing doctests on windows 64 bit

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -962,11 +962,11 @@ class AnalyzeImage(SpatialImage):
         >>> affine = np.diag([1.0,2.0,3.0,1.0])
         >>> img = AnalyzeImage(data, affine)
         >>> hdr = img.get_header()
-        >>> img.shape
-        (2, 3, 4)
+        >>> img.shape == (2, 3, 4)
+        True
         >>> img.update_header()
-        >>> hdr.get_data_shape()
-        (2, 3, 4)
+        >>> hdr.get_data_shape() == (2, 3, 4)
+        True
         >>> hdr.get_zooms()
         (1.0, 2.0, 3.0)
         '''

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -797,11 +797,11 @@ class EcatImage(SpatialImage):
         >>> ecat_file = os.path.join(nibabel_dir,'tests','data','tinypet.v')
         >>> img = ecat.load(ecat_file)
         >>> frame0 = img.get_frame(0)
-        >>> frame0.shape
-        (10, 10, 3)
+        >>> frame0.shape == (10, 10, 3)
+        True
         >>> data4d = img.get_data()
-        >>> data4d.shape
-        (10, 10, 3, 1)
+        >>> data4d.shape == (10, 10, 3, 1)
+        True
         """
         self._subheader = subheader
         self._mlist = mlist

--- a/nibabel/eulerangles.py
+++ b/nibabel/eulerangles.py
@@ -116,8 +116,8 @@ def euler2mat(z=0, y=0, x=0):
     >>> yrot = -0.1
     >>> xrot = 0.2
     >>> M = euler2mat(zrot, yrot, xrot)
-    >>> M.shape
-    (3, 3)
+    >>> M.shape == (3, 3)
+    True
 
     The output rotation matrix is equal to the composition of the
     individual rotations

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -122,8 +122,8 @@ To read the NetCDF file we just created:
     >>> time = f.variables['time']
     >>> time.units  #23dt next : bytes
     'days since 2008-01-01'
-    >>> print time.shape
-    (10,)
+    >>> time.shape == (10,)
+    True
     >>> print time[-1]
     9
     >>> f.close()

--- a/nibabel/funcs.py
+++ b/nibabel/funcs.py
@@ -39,33 +39,33 @@ def squeeze_image(img):
     >>> data = np.arange(np.prod(shape)).reshape(shape)
     >>> affine = np.eye(4)
     >>> img = nf.Nifti1Image(data, affine)
-    >>> img.shape
-    (10, 20, 30, 1, 1)
+    >>> img.shape == (10, 20, 30, 1, 1)
+    True
     >>> img2 = squeeze_image(img)
-    >>> img2.shape
-    (10, 20, 30)
+    >>> img2.shape == (10, 20, 30)
+    True
 
     If the data are 3D then last dimensions of 1 are ignored
 
     >>> shape = (10,1,1)
     >>> data = np.arange(np.prod(shape)).reshape(shape)
     >>> img = nf.ni1.Nifti1Image(data, affine)
-    >>> img.shape
-    (10, 1, 1)
+    >>> img.shape == (10, 1, 1)
+    True
     >>> img2 = squeeze_image(img)
-    >>> img2.shape
-    (10, 1, 1)
+    >>> img2.shape == (10, 1, 1)
+    True
 
     Only *final* dimensions of 1 are squeezed
 
     >>> shape = (1, 1, 5, 1, 2, 1, 1)
     >>> data = data.reshape(shape)
     >>> img = nf.ni1.Nifti1Image(data, affine)
-    >>> img.shape
-    (1, 1, 5, 1, 2, 1, 1)
+    >>> img.shape == (1, 1, 5, 1, 2, 1, 1)
+    True
     >>> img2 = squeeze_image(img)
-    >>> img2.shape
-    (1, 1, 5, 1, 2)
+    >>> img2.shape == (1, 1, 5, 1, 2)
+    True
     '''
     klass = img.__class__
     shape = img.shape


### PR DESCRIPTION
It seems that on windows 64 bit, Christophe Gohlke binaries, numpy
shape values come out as Long objects rather than python ints.
