### PR TITLE
attempt for RealWorldValueMapping rescale support in Wrapper

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -362,10 +362,8 @@ class Wrapper(object):
                 mpseq = self.get('RealWorldValueMappings',None)
             if mpseq != None and len(mpseq)>0:
                 mpseq = mpseq[0]
-                if mpseq.has_key('RealWorldValueSlope'):
-                    scale = mpseq.RealWorldValueSlope
-                if mpseq.has_key('RealWorldValueIntercept'):
-                    offset = mpseq.RealWorldValueIntercept
+                scale = mpseq.get('RealWorldValueSlope',1)
+                offset = mpseq.get('RealWorldValueIntercept',0)
         # a little optimization.  If we are applying either the scale or
         # the offset, we need to allow upcasting to float.
         if scale != 1:


### PR DESCRIPTION
I do have dicoms (from ADNI) that don't have RescaleSlope/Intercept but RealWorldValueMappingSequence and the pixel values matters as these are real/imaginary parts of Philips fieldmaps but it depends on the scanner/software.
I modified the Wrapper._scale_data to use this to rescale the data properly but I do not know the exact specification of such value mapping and there seems to also exists an alternative LUT data.
The RealWorldValueMappingSequence can also contains multiple mappings which is not handled here.
