### PR TITLE
Update nibabel/analyze.py

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -923,7 +923,7 @@ class AnalyzeImage(SpatialImage):
             file_map = self.file_map
         data = self.get_data()
         self.update_header()
-        hdr = self.get_header()
+        
         out_dtype = self.get_data_dtype()
         arr_writer = make_array_writer(data,
                                        out_dtype,
@@ -948,14 +948,19 @@ class AnalyzeImage(SpatialImage):
         #UPDATE SLOPE
         if hdr.has_data_slope and isinstance(hdr.get_slope_inter()[0], float):
            #SLOPE is used in a multiplicative way, thus the update below
-            slope *= hdr.get_slope_inter()[0]
+            slope_user = hdr.get_slope_inter()[0]
+        else:
+            slope_user = 1.0            
+        slope *= slope_user
         #UPDATE INTER
         if hdr.has_data_intercept and isinstance(hdr.get_slope_inter()[1], float):
             #INTER is used in an additive way, thus the update below
-            inter += hdr.get_slope_inter()[1]
-
+            inter_user = hdr.get_slope_inter()[1]
+        else:
+            inter_user = 0.0
+        inter += inter_user
         #SANITY CHECK FOR THE RESULTING INTER SCALE
-        if not np.all(np.isfinite(slope*data.flatten()+inter)):
+        if not np.all(np.isfinite(slope_user*data.flatten()+inter_user)):
          #THE MESSAGE could be more thought through
           raise ValueError('The user provided slope and intercept %s cause numerical under/over flow'%(str(hdr.get_slope_inter())))
         self._write_header(hdrf, hdr, slope, inter)


### PR DESCRIPTION
When creating a Nifti1Image and setting its slope and inter, this information is not saved to file.
Debugging the source code I noticed that this information is not used in the to_file_map method (analyze.py).
I modified the code to do just that.
