### PR TITLE
attempt to fix precision bug: stupid heuristic that might be wrong

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -163,9 +163,9 @@ class Wrapper(object):
         R[:,2] = s_norm
 
         precision = 1e-6
-        iop_val = self.get('ImageOrientationPatient')[0]
-        if hasattr(iop_val,'original_string'):
-            precision = 3**(-len(iop_val.original_string.lstrip('0.')))
+        iop_val = self.get('ImageOrientationPatient')
+        if iop_val!=None and hasattr(iop_val[0],'original_string'):
+            precision = 3**(-len(iop_val[0].original_string.lstrip('0.')))
         # check this is in fact a rotation matrix
         assert np.allclose(np.eye(3),
                            np.dot(R, R.T),


### PR DESCRIPTION
for issue: https://github.com/nipy/nibabel/issues/154
I added a (too) simple heuristic to guess precision of rotation matrix: based on the length of the string coding the value. 3 is because of the matrix size, so you can sum up to three time an error of 1e-(len(string)-1). is that ok? 
