### PR TITLE
BF: slice normal computing with wrong orientation

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -139,7 +139,8 @@ class Wrapper(object):
         iop = self.image_orient_patient
         if iop is None:
             return None
-        return np.cross(*iop.T[:])
+        # iop[:, 0] is column index cosine, iop[:, 1] is row index cosine
+        return np.cross(iop[:, 1], iop[:, 0])
 
     @one_time
     def rotation_matrix(self):

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -154,7 +154,23 @@ def test_orthogonal():
     assert  np.allclose(np.eye(3),
                         np.dot(R, R.T),
                         atol=1e-6)
-                    
+
+
+@dicom_test
+def test_rotation_matrix():
+    # Test rotation matrix and slice normal
+    class FakeData(dict): pass
+    d = FakeData()
+    d.ImageOrientationPatient = [0, 1, 0, 1, 0, 0]
+    dw = didw.wrapper_from_data(d)
+    assert_array_equal(dw.rotation_matrix, np.eye(3))
+    d.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
+    dw = didw.wrapper_from_data(d)
+    assert_array_equal(dw.rotation_matrix, [[0, 1, 0],
+                                            [1, 0, 0],
+                                            [0, 0, -1]])
+
+
 @dicom_test
 def test_use_csa_sign():
     #Test that we get the same slice normal, even after swapping the iop 


### PR DESCRIPTION
I was computing the slice normal on reversed column and row vectors; fix
and test.
