### PR TITLE
Better dicomwrapper get

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -108,18 +108,16 @@ class Wrapper(object):
     b_value = None
     b_vector = None
 
-    def __init__(self, dcm_data=None):
+    def __init__(self, dcm_data):
         ''' Initialize wrapper
 
         Parameters
         ----------
-        dcm_data : None or object, optional
-           object should allow attribute access.  Usually this will be
-           a ``dicom.dataset.Dataset`` object resulting from reading a
-           DICOM file.   If None, just make an empty dict.
+        dcm_data : object
+           object should allow 'get' and '__getitem__' access.  Usually this
+           will be a ``dicom.dataset.Dataset`` object resulting from reading a
+           DICOM file, but a dictionary should also work.
         '''
-        if dcm_data is None:
-            dcm_data = {}
         self.dcm_data = dcm_data
 
     @one_time
@@ -405,7 +403,7 @@ class SiemensWrapper(Wrapper):
     '''
     is_csa = True
 
-    def __init__(self, dcm_data=None, csa_header=None):
+    def __init__(self, dcm_data, csa_header=None):
         ''' Initialize Siemens wrapper
 
         The Siemens-specific information is in the `csa_header`, either
@@ -413,12 +411,11 @@ class SiemensWrapper(Wrapper):
 
         Parameters
         ----------
-        dcm_data : None or object, optional
-           object should allow attribute access.  If `csa_header` is
-           None, it should also be possible to extract a CSA header from
-           `dcm_data`. Usually this will be a ``dicom.dataset.Dataset``
-           object resulting from reading a DICOM file.  If None, we just
-           make an empty dict.
+        dcm_data : object
+           object should allow 'get' and '__getitem__' access.  If `csa_header`
+           is None, it should also be possible to extract a CSA header from
+           `dcm_data`. Usually this will be a ``dicom.dataset.Dataset`` object
+           resulting from reading a DICOM file.  A dict should also work.
         csa_header : None or mapping, optional
            mapping giving values for Siemens CSA image sub-header.  If
            None, we try and read the CSA information from `dcm_data`.
@@ -544,7 +541,7 @@ class MosaicWrapper(SiemensWrapper):
     '''
     is_mosaic = True
 
-    def __init__(self, dcm_data=None, csa_header=None, n_mosaic=None):
+    def __init__(self, dcm_data, csa_header=None, n_mosaic=None):
         ''' Initialize Siemens Mosaic wrapper
 
         The Siemens-specific information is in the `csa_header`, either
@@ -552,12 +549,11 @@ class MosaicWrapper(SiemensWrapper):
 
         Parameters
         ----------
-        dcm_data : None or object, optional
-           object should allow attribute access.  If `csa_header` is
-           None, it should also be possible for to extract a CSA header
-           from `dcm_data`. Usually this will be a
-           ``dicom.dataset.Dataset`` object resulting from reading a
-           DICOM file.  If None, just make an empty dict.
+        dcm_data : object
+           object should allow 'get' and '__getitem__' access.  If `csa_header`
+           is None, it should also be possible for to extract a CSA header from
+           `dcm_data`. Usually this will be a ``dicom.dataset.Dataset`` object
+           resulting from reading a DICOM file.  A dict should also work.
         csa_header : None or mapping, optional
            mapping giving values for Siemens CSA image sub-header.
         n_mosaic : None or int, optional

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -54,17 +54,18 @@ EXPECTED_PARAMS = [992.05050247, (0.00507649,
 def test_wrappers():
     # test direct wrapper calls
     # first with empty data
-    for maker, kwargs in ((didw.Wrapper,{}),
-                          (didw.SiemensWrapper, {}),
-                          (didw.MosaicWrapper, {'n_mosaic':10})):
-        dw = maker(**kwargs)
+    for maker, args in ((didw.Wrapper,({},)),
+                          (didw.SiemensWrapper, ({},)),
+                          (didw.MosaicWrapper, ({}, None, 10))):
+        dw = maker(*args)
         assert_equal(dw.get('InstanceNumber'), None)
         assert_equal(dw.get('AcquisitionNumber'), None)
         assert_raises(KeyError, dw.__getitem__, 'not an item')
         assert_raises(didw.WrapperError, dw.get_data)
         assert_raises(didw.WrapperError, dw.get_affine)
+        assert_raises(TypeError, maker)
     for klass in (didw.Wrapper, didw.SiemensWrapper):
-        dw = klass()
+        dw = klass({})
         assert_false(dw.is_mosaic)
     for maker in (didw.wrapper_from_data,
                   didw.Wrapper,
@@ -208,7 +209,7 @@ def test_vol_matching():
     assert_false(dw_siemens.is_same_series(dw_plain))
     # we can even make an empty wrapper.  This compares True against
     # itself but False against the others
-    dw_empty = didw.Wrapper()
+    dw_empty = didw.Wrapper({})
     assert_true(dw_empty.is_same_series(dw_empty))
     assert_false(dw_empty.is_same_series(dw_plain))
     assert_false(dw_plain.is_same_series(dw_empty))
@@ -226,7 +227,7 @@ def test_slice_indicator():
     z = dw_0.slice_indicator
     assert_false(z is None)
     assert_equal(z, dw_1000.slice_indicator)
-    dw_empty = didw.Wrapper()
+    dw_empty = didw.Wrapper({})
     assert_true(dw_empty.slice_indicator is None)
 
 


### PR DESCRIPTION
DICOM sprint - simplify the interface to dicomwrappers by making wrapper 'get' defer to self.dcm_data.get, and similarly for `__getitem__`.

Also - make the dcm_data a required input argument to the wrapper to be clear that it is required for sensible functioning of the object.
