### PR TITLE
RF: continue py3 update standarizing exceptions

### DIFF
--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -197,9 +197,8 @@ def main():
         verbose('Processing %s' % infile)
         try:
             proc_file(infile, opts)
-        except Exception:
-            err = sys.exc_info()[1]
-            errs.append('%s: %s' % (infile, err))
+        except Exception as e:
+            errs.append('%s: %s' % (infile, e))
 
     if len(errs):
         error('Caught %i exceptions. Dump follows:\n\n %s'

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -530,9 +530,8 @@ class AnalyzeHeader(WrapStruct):
                                            out_dtype,
                                            self.has_data_slope,
                                            self.has_data_intercept)
-        except WriterError:
-            msg = sys.exc_info()[1] # python 2 / 3 compatibility
-            raise HeaderTypeError(msg)
+        except WriterError as e:
+            raise HeaderTypeError(str(e))
         seek_tell(fileobj, self.get_data_offset())
         arr_writer.to_fileobj(fileobj)
         self.set_slope_inter(*get_slope_inter(arr_writer))

--- a/nibabel/data.py
+++ b/nibabel/data.py
@@ -288,13 +288,12 @@ def make_datasource(pkg_def, **kwargs):
     names = unix_relpath.split('/')
     try:
         pth = find_data_dir(data_path, *names)
-    except DataError:
-        exception = sys.exc_info()[1] # Python 2 and 3 compatibility
+    except DataError as e:
         pth = [pjoin(this_data_path, *names)
-                for this_data_path in data_path]
+               for this_data_path in data_path]
         pkg_hint = pkg_def.get('install hint', DEFAULT_INSTALL_HINT)
         msg = ('%s; Is it possible you have not installed a data package?' %
-               exception)
+               e)
         if 'name' in pkg_def:
             msg += '\n\nYou may need the package "%s"' % pkg_def['name']
         if not pkg_hint is None:
@@ -347,9 +346,8 @@ def datasource_or_bomber(pkg_def, **options):
     sys_relpath = os.path.sep.join(names)
     try:
         ds = make_datasource(pkg_def, **options)
-    except DataError:
-        exception = sys.exc_info()[1] # python 2 and 3 compatibility
-        return Bomber(sys_relpath, exception)
+    except DataError as e:
+        return Bomber(sys_relpath, str(e))
     # check version
     if (version is None or
         LooseVersion(ds.version) >= LooseVersion(version)):

--- a/nibabel/tests/test_scaling.py
+++ b/nibabel/tests/test_scaling.py
@@ -9,8 +9,6 @@
 ''' Test for scaling / rounding in volumeutils module '''
 from __future__ import division, print_function, absolute_import
 
-import sys
-
 import numpy as np
 
 from ..externals.six import BytesIO
@@ -236,9 +234,9 @@ def check_int_a2f(in_type, out_type):
     str_io = BytesIO()
     try:
         scale, inter, mn, mx = calculate_scale(data, out_type, True)
-    except ValueError:
+    except ValueError as e:
         if DEBUG:
-            print(in_type, out_type, sys.exc_info()[1])
+            print(in_type, out_type, e)
         return
     array_to_file(data, str_io, out_type, 0, inter, scale, mn, mx)
     data_back = array_from_file(data.shape, out_type, str_io)

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -711,10 +711,9 @@ def seek_tell(fileobj, offset):
     """
     try:
         fileobj.seek(offset)
-    except IOError:
-        msg = sys.exc_info()[1] # python 2 / 3 compatibility
+    except IOError as e:
         if fileobj.tell() != offset:
-            raise IOError(msg)
+            raise IOError(str(e))
 
 
 def apply_read_scaling(arr, slope = 1.0, inter = 0.0):
@@ -885,9 +884,8 @@ def calculate_scale(data, out_dtype, allow_intercept):
     from .arraywriters import make_array_writer, WriterError, get_slope_inter
     try:
         writer = make_array_writer(data, out_dtype, True, allow_intercept)
-    except WriterError:
-        msg = sys.exc_info()[1] # python 2 / 3 compatibility
-        raise ValueError(msg)
+    except WriterError as e:
+        raise ValueError(str(e))
     if out_dtype.kind in 'fc':
         return (1.0, 0.0, None, None)
     mn, mx = writer.finite_range()


### PR DESCRIPTION
We were using sys.exc_info to work around Python 2.5 / 3 compatibility; use the
new exception syntax, now we depend on Python 2.6
