### PR TITLE
MRG: change set of qform / sform into empty header

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1546,6 +1546,19 @@ class Nifti1PairHeader(Nifti1Header):
 class Nifti1Pair(analyze.AnalyzeImage):
     header_class = Nifti1PairHeader
 
+    def __init__(self, dataobj, affine, header=None,
+                 extra=None, file_map=None):
+        super(Nifti1Pair, self).__init__(dataobj,
+                                         affine,
+                                         header,
+                                         extra,
+                                         file_map)
+        # Force set of s/q form when header is None unless affine is also None
+        if header is None and not affine is None:
+            self._affine2header()
+    # Copy docstring
+    __init__.doc = analyze.AnalyzeImage.__init__.__doc__
+
     def _write_header(self, header_file, header, slope, inter):
         super(Nifti1Pair, self)._write_header(header_file,
                                               header,

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -213,10 +213,15 @@ class TestSpatialImage(TestCase):
         img = self.image_class(arr, None)
         assert_array_equal(img.get_data(), arr)
         assert_equal(img.get_affine(), None)
+
+    def test_default_header(self):
+        # Check default header is as expected
+        arr = np.arange(24, dtype=np.int16).reshape((2, 3, 4))
+        img = self.image_class(arr, None)
         hdr = self.image_class.header_class()
         hdr.set_data_shape(arr.shape)
         hdr.set_data_dtype(arr.dtype)
-        assert_equal(img.get_header(), hdr)
+        assert_equal(img.header, hdr)
 
     def test_data_api(self):
         # Test minimal api data object can initialize


### PR DESCRIPTION
Previously we left the sform and qform empty if the affine was None, or 
matched the default affine in the header when sform and qform are empty.

From discussion at gh-182 - set the qform and sform explicitly in the case of
header=None, using the default affine, to avoid the surprise of no qform /
sform after saving, when the input affine matches the default.
