### PR TITLE
COMPAT: add back img._data property for now

### DIFF
--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -329,6 +329,14 @@ class SpatialImage(object):
         self._data_cache = None
 
     @property
+    def _data(self):
+        warnings.warn('Please use ``dataobj`` instead of ``_data``; '
+                      'We will remove this wrapper for ``_data`` soon',
+                      FutureWarning,
+                      stacklevel=2)
+        return self._dataobj
+
+    @property
     def dataobj(self):
         return self._dataobj
 

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -1,6 +1,8 @@
 """ Validate image API """
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 import numpy as np
 
 try:
@@ -173,7 +175,18 @@ class TestAnalyzeAPI(ValidateAPI):
             img.uncache()
             assert_array_equal(img.get_data(), 42)
         # Read only
-        assert_raises(AttributeError, setattr, img, 'dataobj', np.eye(4))
+        assert_raises(AttributeError,
+                      setattr, img, 'dataobj', params['data'])
+
+    def validate_data_deprecated(self, imaker, params):
+        # Check _data property still exists, but raises warning
+        img = imaker()
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            assert_array_equal(img._data, params['data'])
+            assert_equal(warns.pop(0).category, FutureWarning)
+        assert_raises(AttributeError,
+                      setattr, img, '_data', params['data'])
 
     def validate_filenames(self, imaker, params):
         # Validate the filename, file_map interface


### PR DESCRIPTION
The recent refactor removed the `_data` attribute, but sure enough, nipy
was depending on it.  Add back `_data` but put in a FutureWarning.  Test.
