### PR TITLE
RF: allow generic header to specify memory layout

### DIFF
--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -153,6 +153,7 @@ class HeaderTypeError(Exception):
 class Header(object):
     ''' Template class to implement header protocol '''
     default_x_flip = True
+    data_layout = 'F'
 
     def __init__(self,
                  data_dtype=np.float32,
@@ -247,7 +248,7 @@ class Header(object):
     get_best_affine = get_base_affine
 
     def data_to_fileobj(self, data, fileobj, rescale=True):
-        ''' Write image data to file in Fortran memory layout
+        ''' Write array data `data` as binary to `fileobj`
 
         Parameters
         ----------
@@ -261,15 +262,15 @@ class Header(object):
         '''
         data = np.asarray(data)
         dtype = self.get_data_dtype()
-        fileobj.write(data.astype(dtype).tostring(order='F'))
+        fileobj.write(data.astype(dtype).tostring(order=self.data_layout))
 
     def data_from_fileobj(self, fileobj):
-        ''' Read data in fortran order '''
+        ''' Read binary image data from `fileobj` '''
         dtype = self.get_data_dtype()
         shape = self.get_data_shape()
         data_size = int(np.prod(shape) * dtype.itemsize)
         data_bytes = fileobj.read(data_size)
-        return np.ndarray(shape, dtype, data_bytes, order='F')
+        return np.ndarray(shape, dtype, data_bytes, order=self.data_layout)
 
 
 def supported_np_types(obj):

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -157,26 +157,29 @@ def test_affine():
 
 
 def test_read_data():
-    hdr = Header(np.int32, shape=(1,2,3), zooms=(3.0, 2.0, 1.0))
-    fobj = BytesIO()
-    data = np.arange(6).reshape((1,2,3))
-    hdr.data_to_fileobj(data, fobj)
-    assert_equal(fobj.getvalue(),
-                 data.astype(np.int32).tostring(order='F'))
-    # data_to_fileobj accepts kwarg 'rescale', but no effect in this case
-    fobj.seek(0)
-    hdr.data_to_fileobj(data, fobj, rescale=True)
-    assert_equal(fobj.getvalue(),
-                 data.astype(np.int32).tostring(order='F'))
-    # data_to_fileobj can be a list
-    fobj.seek(0)
-    hdr.data_to_fileobj(data.tolist(), fobj, rescale=True)
-    assert_equal(fobj.getvalue(),
-                 data.astype(np.int32).tostring(order='F'))
-    # Read data back again
-    fobj.seek(0)
-    data2 = hdr.data_from_fileobj(fobj)
-    assert_array_equal(data, data2)
+    class CHeader(Header):
+        data_layout='C'
+    for klass, order in ((Header, 'F'), (CHeader, 'C')):
+        hdr = klass(np.int32, shape=(1,2,3), zooms=(3.0, 2.0, 1.0))
+        fobj = BytesIO()
+        data = np.arange(6).reshape((1,2,3))
+        hdr.data_to_fileobj(data, fobj)
+        assert_equal(fobj.getvalue(),
+                     data.astype(np.int32).tostring(order=order))
+        # data_to_fileobj accepts kwarg 'rescale', but no effect in this case
+        fobj.seek(0)
+        hdr.data_to_fileobj(data, fobj, rescale=True)
+        assert_equal(fobj.getvalue(),
+                     data.astype(np.int32).tostring(order=order))
+        # data_to_fileobj can be a list
+        fobj.seek(0)
+        hdr.data_to_fileobj(data.tolist(), fobj, rescale=True)
+        assert_equal(fobj.getvalue(),
+                     data.astype(np.int32).tostring(order=order))
+        # Read data back again
+        fobj.seek(0)
+        data2 = hdr.data_from_fileobj(fobj)
+        assert_array_equal(data, data2)
 
 
 class DataLike(object):


### PR DESCRIPTION
Just in case someone needs the generic header to write in C order rather than
F order.
