### PR TITLE
BF: fix invalid call to parent in minc classes

### DIFF
--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .externals.netcdf import netcdf_file
 
-from .spatialimages import SpatialImage
+from .spatialimages import Header, SpatialImage
 from .fileslice import canonical_slicers
 
 from .deprecated import FutureWarningMixin
@@ -263,6 +263,19 @@ class MincImageArrayProxy(object):
         return self.minc_file.get_scaled_data(sliceobj)
 
 
+class MincHeader(Header):
+    # We don't use the data layout - this just in case we do later
+    data_layout = 'C'
+
+    def data_to_fileobj(self, data, fileobj, rescale=True):
+        """ See Header class for an implementation we can't use """
+        raise NotImplementedError
+
+    def data_from_fileobj(self, fileobj):
+        """ See Header class for an implementation we can't use """
+        raise NotImplementedError
+
+
 class Minc1Image(SpatialImage):
     ''' Class for MINC 1 format images
 
@@ -270,6 +283,7 @@ class Minc1Image(SpatialImage):
     MINC header type - and reads the relevant information from the MINC file on
     load.
     '''
+    header_class = MincHeader
     files_types = (('image', '.mnc'),)
     _compressed_exts = ('.gz', '.bz2')
 

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -13,6 +13,7 @@ import gzip
 import bz2
 import warnings
 import types
+from io import BytesIO
 
 import numpy as np
 
@@ -20,7 +21,7 @@ from .. import load, Nifti1Image
 from ..externals.netcdf import netcdf_file
 from ..deprecated import ModuleProxy
 from .. import minc1
-from ..minc1 import Minc1File, Minc1Image
+from ..minc1 import Minc1File, Minc1Image, MincHeader
 
 from nose.tools import (assert_true, assert_equal, assert_false, assert_raises)
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -197,5 +198,27 @@ class TestMinc1File(_TestMincFile):
                     del img
 
 
+# Test the Minc header
+def test_header_data_io():
+    bio = BytesIO()
+    hdr = MincHeader()
+    arr = np.arange(24).reshape((2, 3, 4))
+    assert_raises(NotImplementedError, hdr.data_to_fileobj, arr, bio)
+    assert_raises(NotImplementedError, hdr.data_from_fileobj, bio)
+
+
 class TestMinc1Image(tsi.TestSpatialImage):
     image_class = Minc1Image
+    eg_images = (pjoin(data_path, 'tiny.mnc'),)
+    module = minc1
+
+    def test_data_to_from_fileobj(self):
+        # Check data_from_fileobj of header raises an error
+        for fpath in self.eg_images:
+            img = self.module.load(fpath)
+            bio = BytesIO()
+            arr = np.arange(24).reshape((2, 3, 4))
+            assert_raises(NotImplementedError,
+                          img.header.data_to_fileobj, arr, bio)
+            assert_raises(NotImplementedError,
+                          img.header.data_from_fileobj, bio)

--- a/nibabel/tests/test_minc2.py
+++ b/nibabel/tests/test_minc2.py
@@ -71,3 +71,5 @@ if have_h5py:
 
     class TestMinc2Image(tm2.TestMinc1Image):
         image_class = Minc2Image
+        eg_images = (pjoin(data_path, 'small.mnc'),)
+        module = minc2


### PR DESCRIPTION
It was possible to call `data_from_fileobj` and `data_to_fileobj` from a 
generic Header object, and the MINC classes use that object, so these could
cause confusion by making invalid calls.  Raise NotImplementedError to reduce
potential confusion.
