### PR TITLE
Bug/gifti hcp caret fixes

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -322,7 +322,7 @@ class GiftiDataArray(object):
                       str(self.num_dim), \
                       str(di), \
                       gifti_encoding_codes.specs[self.encoding], \
-                      gifti_endian_codes.giistring[self.endian], \
+                      gifti_endian_codes.specs[self.endian], \
                       self.ext_fname,
                       self.ext_offset,
                       )

--- a/nibabel/gifti/util.py
+++ b/nibabel/gifti/util.py
@@ -33,4 +33,4 @@ gifti_endian_codes = Recoder(
     ((0, "GIFTI_ENDIAN_UNDEF", "Undef", "undef"),
      (1, "GIFTI_ENDIAN_BIG", "BigEndian", "big"),
      (2, "GIFTI_ENDIAN_LITTLE", "LittleEndian", "little"),
-    ), fields = ('code', 'label', 'giistring', 'byteorder'))
+    ), fields = ('code', 'giistring','specs', 'byteorder'))


### PR DESCRIPTION
hcp workbench were not able to open gifti files generated by nibabel:
- endianness value not conform
- base64 in python < 3 add newlines which seems a problem for hcp tools, do not know about python3 base64.encodebytes output

@matthew-brett ?

https://github.com/nipy/nibabel/issues/230
