### PR TITLE
Track changes made to the header (NOT YET FOR MERGE)

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -918,7 +918,7 @@ class AnalyzeImage(SpatialImage):
         inter = (np.asscalar(hdr['scl_inter']) if hdr.has_data_intercept
                  else np.nan)
         # Check whether to calculate slope / inter
-        # import pydb; pydb.debugger()
+        print "MODIFIED: ", hdr.modified
         scale_me = np.all(np.isnan((slope, inter)))
         if scale_me:
             arr_writer = make_array_writer(data,
@@ -929,7 +929,7 @@ class AnalyzeImage(SpatialImage):
             arr_writer = ArrayWriter(data, out_dtype, check_scaling=False)
         hdr_fh, img_fh = self._get_fileholders(file_map)
         # Check if hdr and img refer to same file; this can happen with odd
-        # analyze images but most often this is because it's a single nifti file
+        # analyze images but most often this fis because it's a single nifti file
         hdr_img_same = hdr_fh.same_file_as(img_fh)
         hdrf = hdr_fh.get_prepare_fileobj(mode='wb')
         if hdr_img_same:

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -220,7 +220,8 @@ class EcatHeader(WrapStruct):
     def __init__(self,
                  binaryblock=None,
                  endianness=None,
-                 check=True):
+                 check=True,
+                 modified=None):
         """Initialize Ecat header from bytes object
 
         Parameters
@@ -235,7 +236,8 @@ class EcatHeader(WrapStruct):
             Whether to check and fix header for errors.  No checks currently
             implemented, so value has no effect.
         """
-        super(EcatHeader, self).__init__(binaryblock, endianness, check)
+        super(EcatHeader, self).__init__(binaryblock, endianness, check,
+                                         modified=modified)
 
     @classmethod
     def guessed_endian(klass, hdr):

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -567,12 +567,14 @@ class Nifti1Header(SpmAnalyzeHeader):
                  binaryblock=None,
                  endianness=None,
                  check=True,
-                 extensions=()):
+                 extensions=(),
+                 modified=None):
         ''' Initialize header from binary data block and extensions
         '''
         super(Nifti1Header, self).__init__(binaryblock,
                                            endianness,
-                                           check)
+                                           check,
+                                           modified=modified)
         self.extensions = self.exts_klass(extensions)
 
     def copy(self):
@@ -584,7 +586,8 @@ class Nifti1Header(SpmAnalyzeHeader):
             self.binaryblock,
             self.endianness, 
             False,
-            self.extensions)
+            self.extensions, # TODO: shouldn't they be copied here?
+            modified=self.modified.copy())
 
     @classmethod
     def from_fileobj(klass, fileobj, endianness=None, check=True):
@@ -653,7 +656,6 @@ class Nifti1Header(SpmAnalyzeHeader):
     @classmethod
     def from_header(klass, header=None, check=True):
         ''' Class method to create header from another header
-
         Extend Analyze header copy by copying extensions from other Nifti types.
 
         Parameters

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1055,6 +1055,9 @@ def test_nifti_extensions():
     assert_true(exts_container.count('comment') == 2)
     assert_true(exts_container.count('afni') == 1)
     assert_true((exts_container.get_sizeondisk()) % 16 == 0)
+    # Test that from_header copy constructor could populate new extensions
+    hdr2 = Nifti1Header.from_header(hdr)
+    assert_equal(len(hdr2.extensions), 3)
     # delete one
     del exts_container[1]
     assert_true(exts_container.get_codes() == [6, 4])

--- a/nibabel/tests/test_nifti2.py
+++ b/nibabel/tests/test_nifti2.py
@@ -95,10 +95,20 @@ class TestNifti2General(TestNifti1General):
     module = nifti2
     example_file = image_file
 
-
-def test_nifti12_conversion():
+def check_nifti12_conversion(in_type, out_type, exts):
     shape = (2, 3, 4)
     dtype_type = np.int64
+    in_hdr = in_type()
+    in_hdr.set_data_shape(shape)
+    in_hdr.set_data_dtype(dtype_type)
+    in_hdr.extensions[:] = exts
+    out_hdr = out_type.from_header(in_hdr)
+    assert_equal(out_hdr.get_data_shape(), shape)
+    assert_equal(out_hdr.get_data_dtype(), dtype_type)
+    assert_equal(in_hdr.extensions, out_hdr.extensions)
+
+
+def test_nifti12_conversion():
     ext1 = Nifti1Extension(6, b'My comment')
     ext2 = Nifti1Extension(6, b'Fresh comment')
     for in_type, out_type in ((Nifti1Header, Nifti2Header),
@@ -107,11 +117,4 @@ def test_nifti12_conversion():
                               (Nifti2Header, Nifti1Header),
                               (Nifti2PairHeader, Nifti1Header),
                               (Nifti2PairHeader, Nifti1PairHeader)):
-        in_hdr = in_type()
-        in_hdr.set_data_shape(shape)
-        in_hdr.set_data_dtype(dtype_type)
-        in_hdr.extensions[:] = [ext1, ext2]
-        out_hdr = out_type.from_header(in_hdr)
-        assert_equal(out_hdr.get_data_shape(), shape)
-        assert_equal(out_hdr.get_data_dtype(), dtype_type)
-        assert_equal(in_hdr.extensions, out_hdr.extensions)
+        yield check_nifti12_conversion, in_type, out_type, [ext1, ext2]

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -249,6 +249,7 @@ class ScalingMixin(object):
         aff = np.eye(4)
         # Implicit header gives scale-me scaling
         img = img_class(arr, aff)
+        assert_equal(img.header.modified, set())
         self.assert_scale_me_scaling(img.header)
         # Input header scaling reset when creating image
         hdr = img.header

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -69,6 +69,8 @@ class _TestWrapStructBase(TestCase):
         # You can also pass in a check flag, without data this has no
         # effect
         hdr = self.header_class(check=False)
+        # And no fields were modified so far
+        assert_equal(hdr.modified, set())
 
     def _set_something_into_hdr(self, hdr):
         # Called from test_bytes test method.  Specific to the header data type
@@ -389,9 +391,12 @@ class TestMyWrapStruct(_TestWrapStructBase):
         hdr2 = hdr.copy()
         assert_equal(hdr, hdr2)
         self._set_something_into_hdr(hdr)
+        assert_equal(hdr.modified, set(['a_str']))
+        assert_equal(hdr2.modified, set())
         assert_not_equal(hdr, hdr2)
         self._set_something_into_hdr(hdr2)
         assert_equal(hdr, hdr2)
+        assert_equal(hdr2.modified, set(['a_str']))
 
     def test_copy(self):
         hdr = self.header_class()
@@ -399,8 +404,11 @@ class TestMyWrapStruct(_TestWrapStructBase):
         assert_equal(hdr, hdr2)
         self._set_something_into_hdr(hdr)
         assert_not_equal(hdr, hdr2)
+        assert_equal(hdr.modified, set(['a_str']))
+        assert_equal(hdr2.modified, set([]))
         self._set_something_into_hdr(hdr2)
         assert_equal(hdr, hdr2)
+        assert_equal(hdr2.modified, set(['a_str']))
 
     def test_checks(self):
         # Test header checks
@@ -411,11 +419,27 @@ class TestMyWrapStruct(_TestWrapStructBase):
         # An integer should be 1
         hdr = hdr_t.copy()
         hdr['an_integer'] = 2
+        assert_equal(hdr.modified, set(['an_integer']))
         assert_equal(self._dxer(hdr), 'an_integer should be 1')
         # String should be lower case
         hdr = hdr_t.copy()
         hdr['a_str'] = 'My Name'
         assert_equal(self._dxer(hdr), 'a_str should be lower case')
+
+    def test_modified(self):
+        hdr = self.header_class()
+        assert_equal(hdr.modified, set([]))
+        hdr['an_integer'] = 1
+        assert_equal(hdr.modified, set(['an_integer']))
+        hdr2 = hdr.copy()
+        hdr2['a_str'] = 0
+        assert_equal(hdr.modified, set(['an_integer']))
+        assert_equal(hdr2.modified, set(['an_integer', 'a_str']))
+        hdr.reset_modified()
+        assert_equal(hdr.modified, set([]))
+        assert_equal(hdr2.modified, set(['an_integer', 'a_str']))
+        hdr2.reset_modified()
+        assert_equal(hdr2.modified, set())
 
     def test_log_checks(self):
         # Test logging, fixing, errors for header checking

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -157,21 +157,18 @@ class WrapStruct(object):
         array(1, dtype=int16)
         '''
 
-        if modified is None:
-            modified = set()
-        elif not isinstance(modified, set):
-            modified = set(modified) # to guarantee the proper type
-        self._modified = modified  # which fields were modified
-
+        self._modified = set()  # Blank set so "constructor" functionality works
         if binaryblock is None:
             self._structarr = self.__class__.default_structarr(endianness)
+            self._set_modified(modified)
             return
+
         # check size
         if len(binaryblock) != self.template_dtype.itemsize:
             raise WrapStructError('Binary block is wrong size')
         wstr = np.ndarray(shape=(),
-                         dtype=self.template_dtype,
-                         buffer=binaryblock)
+                          dtype=self.template_dtype,
+                          buffer=binaryblock)
         if endianness is None:
             endianness = self.__class__.guessed_endian(wstr)
         else:
@@ -179,12 +176,20 @@ class WrapStruct(object):
         if endianness != native_code:
             dt = self.template_dtype.newbyteorder(endianness)
             wstr = np.ndarray(shape=(),
-                             dtype=dt,
-                             buffer=binaryblock)
+                              dtype=dt,
+                              buffer=binaryblock)
         self._structarr = wstr.copy()
         if check:
             self.check_fix()
+        self._set_modified(modified)
         return
+
+    def _set_modified(self, modified):
+        if modified is None:
+            modified = set()
+        elif not isinstance(modified, set):
+            modified = set(modified) # to guarantee the proper type
+        self._modified = modified  # which fields were modified
 
     @classmethod
     def from_fileobj(klass, fileobj, endianness=None, check=True):


### PR DESCRIPTION
as promised decided to give a try but as you can see -- not completed (yet).

Notes:
- `modified` in constructor of the header is probably not needed and logic to assign/reset those should go into corresponding (constructor) methods
- if to proceed this way, then all constructors for headers (and might also be for images) need to "finish" resetting the `modified` set in the header to indicate that initialization has finished
- not sure now if it is the right way to go ;)  you might cherry pick 453796e though ;-)
