### PR TITLE
RF+DOC: refactor Analyze-type header conversion

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -402,10 +402,6 @@ class MGHHeader(object):
         hdr_data['mrparms'] = np.array([0, 0, 0, 0])
         return hdr_data
 
-    def _set_format_specifics(self):
-        ''' Set MGH specific header stuff'''
-        self._header_data['version'] = 1
-
     def _set_affine_default(self, hdr):
         ''' If  goodRASFlag is 0, return the default delta, Mdc and Pxyz_c
         '''

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1466,14 +1466,17 @@ class Nifti1Header(SpmAnalyzeHeader):
         t_code = unit_codes[t]
         self.structarr['xyzt_units'] = xyz_code + t_code
 
-    def _set_format_specifics(self):
-        ''' Utility routine to set format specific header stuff '''
-        if self.is_single:
-            self._structarr['magic'] = self.single_magic
-            if self._structarr['vox_offset'] < self.single_vox_offset:
-                self._structarr['vox_offset'] = self.single_vox_offset
-        else:
-            self._structarr['magic'] = self.pair_magic
+    def _clean_after_mapping(self):
+        ''' Set format-specific stuff after converting header from mapping
+
+        Clean up header after it has been initialized from an
+        ``as_analyze_map`` method of another header type
+
+        See :meth:`nibabel.analyze.AnalyzeHeader._clean_after_mapping` for a
+        more detailed description.
+        '''
+        self._structarr['magic'] = (self.single_magic if self.is_single
+                                    else self.pair_magic)
 
     ''' Checks only below here '''
 


### PR DESCRIPTION
Refactor header conversion routine to use basic conversions always, and then
mapping if available.

Document the `as_analyze_map` interface in docstring.

Add `as_analyze_map` tests and as API documentation.

Rename `_set_format_specifics` to `_after_mapping_cleanup` to make clear
that the routine is to set needed default after creating a header from a
mapping.

Remove unused `_set_format_specifics` from freesurfer.
