### PR TITLE
RF: change absolute to relative imports

### DIFF
--- a/nibabel/eulerangles.py
+++ b/nibabel/eulerangles.py
@@ -339,7 +339,7 @@ def quat2euler(q):
     large.
     '''
     # delayed import to avoid cyclic dependencies
-    import nibabel.quaternions as nq
+    from . import quaternions as nq
     return mat2euler(nq.quat2mat(q))
 
 
@@ -373,7 +373,7 @@ def euler2angle_axis(z=0, y=0, x=0):
     True
     '''
     # delayed import to avoid cyclic dependencies
-    import nibabel.quaternions as nq
+    from . import quaternions as nq
     return nq.quat2angle_axis(euler2quat(z, y, x))
 
 
@@ -411,6 +411,6 @@ def angle_axis2euler(theta, vector, is_normalized=False):
     repetition is large.
     '''
     # delayed import to avoid cyclic dependencies
-    import nibabel.quaternions as nq
+    from . import quaternions as nq
     M = nq.angle_axis2mat(theta, vector, is_normalized)
     return mat2euler(M)

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -4,7 +4,7 @@ from os.path import join as pjoin
 import getpass
 import time
 
-from nibabel.tmpdirs import InTemporaryDirectory
+from ...tmpdirs import InTemporaryDirectory
 
 from nose.tools import assert_true
 import numpy as np

--- a/nibabel/nicom/dicomreaders.py
+++ b/nibabel/nicom/dicomreaders.py
@@ -5,6 +5,7 @@ import glob
 
 import numpy as np
 
+from .. import Nifti1Image
 from .dicomwrappers import (wrapper_from_data, wrapper_from_file)
 
 
@@ -28,13 +29,12 @@ def mosaic_to_nii(dcm_data):
     img : ``Nifti1Image``
        Nifti image object
     '''
-    import nibabel as nib
     dcm_w = wrapper_from_data(dcm_data)
     if not dcm_w.is_mosaic:
         raise DicomReadError('data does not appear to be in mosaic format')
     data = dcm_w.get_data()
     aff = np.dot(DPCS_TO_TAL, dcm_w.get_affine())
-    return nib.Nifti1Image(data, aff)
+    return Nifti1Image(data, aff)
 
 
 def read_mosaic_dwi_dir(dicom_path, globber='*.dcm', dicom_kwargs=None):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -27,14 +27,11 @@ from ..optpkg import optional_package
 _, have_scipy, _ = optional_package('scipy')
 _, have_h5py, _ = optional_package('h5py')
 
-from nibabel import (AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage,
-                     Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
-                     MGHImage, Minc1Image, Minc2Image)
-from nibabel.spatialimages import SpatialImage
-from nibabel.ecat import EcatImage
-from nibabel import minc1
-from nibabel import minc2
-from nibabel import parrec
+from .. import (AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage,
+                Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
+                MGHImage, Minc1Image, Minc2Image)
+from ..spatialimages import SpatialImage
+from .. import minc1, minc2, parrec
 
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_raises,
@@ -372,7 +369,7 @@ class TestPARRECAPI(LoadImageAPI):
 
 # ECAT is a special case and needs more thought
 # class TestEcatAPI(TestAnalyzeAPI):
-#     image_maker = EcatImage
+#     image_maker = ecat.EcatImage
 #     has_scaling = True
 #     can_save = True
 #    standard_extension = '.v'

--- a/nibabel/tests/test_parrec_data.py
+++ b/nibabel/tests/test_parrec_data.py
@@ -7,7 +7,7 @@ from os.path import join as pjoin, basename, splitext, exists
 
 import numpy as np
 
-import nibabel as nib
+from .. import load as top_load
 from ..parrec import load
 
 from .nibabel_data import get_nibabel_data, needs_nibabel_data
@@ -39,7 +39,7 @@ def test_loading():
         # Compare against NIFTI if present
         nifti_fname = pjoin(BALLS, 'NIFTI', par_root + '.nii.gz')
         if exists(nifti_fname):
-            nimg = nib.load(nifti_fname)
+            nimg = top_load(nifti_fname)
             assert_almost_equal(nimg.affine[:3, :3], pimg.affine[:3, :3], 3)
             # The translation part is always off by the same ammout
             aff_off = pimg.affine[:3, 3] - nimg.affine[:3, 3]
@@ -61,5 +61,5 @@ def test_fieldmap():
     fieldmap_par = pjoin(BALLS, 'PARREC', 'fieldmap.PAR')
     fieldmap_nii = pjoin(BALLS, 'NIFTI', 'fieldmap.nii.gz')
     pimg = load(fieldmap_par)
-    nimg = nib.load(fieldmap_nii)
+    nimg = top_load(fieldmap_nii)
     raise SkipTest('Fieldmap remains puzzling')


### PR DESCRIPTION
Use relative imports for nibabel modules.
