### PR TITLE
ENH:  PAR/REC data ordering and b-vector normalization

### DIFF
--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -48,6 +48,12 @@ def get_opt_parser():
                    """Output bvals/bvecs files in addition to NIFTI
                    image.""")))
     p.add_option(
+        Option("--norm-bvs", action="store_true", dest="norm_bvs",
+               default=False,
+               help=one_line(
+                   """Normalize bvectors to 1.0, rescaling b-values
+                   appropriately.""")))
+    p.add_option(
         Option("-d", "--dwell-time", action="store_true", default=False,
                dest="dwell_time",
                help=one_line(
@@ -207,7 +213,7 @@ def proc_file(infile, opts):
                   offset=offset)
     # write out bvals/bvecs if requested
     if opts.bvs:
-        bvals, bvecs = pr_hdr.get_bvals_bvecs()
+        bvals, bvecs = pr_hdr.get_bvals_bvecs(normalize_bvecs=opts.norm_bvs)
         if (bvals, bvecs) == (None, None):
             verbose('No DTI volumes detected, bvals and bvecs not written')
         else:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -73,7 +73,7 @@ def get_opt_parser():
                    because it is not encoded in the PAR/REC format.""")))
     p.add_option(
         Option("-i", "--dimension-info", action="store_true", dest="dim_info",
-               default=True,
+               default=False,
                help=one_line(
                    """Export .PAR dimension labels corresponding to the fourth
                    dimension of the data.  The dimension info will be stored in
@@ -254,11 +254,8 @@ def proc_file(infile, opts):
 
     # export data labels varying along the 4th dimensions
     if opts.dim_info:
-        if pr_img.dataobj._dim_4_labels is not None:
-            labels = pr_img.header.get_dimension_labels(collapse_slices=True)
-        else:
-            labels = None
-        if labels is not None and len(labels) > 0:
+        labels = pr_img.header.get_dimension_labels(collapse_slices=True)
+        if len(labels) > 0:
             labels = convert_arrays_to_lists(labels)
             with open(basefilename + '.ordering.json', 'w') as fid:
                 json.dump(labels, fid, sort_keys=True, indent=4)

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -72,6 +72,17 @@ def get_opt_parser():
                    for --dwell-time. The field strength must be supplied
                    because it is not encoded in the PAR/REC format.""")))
     p.add_option(
+        Option("-i", "--dimension-info", action="store_true", dest="dim_info",
+               default=True,
+               help=one_line(
+                   """Export .PAR dimension labels corresponding to the fourth
+                   dimension of the data.  The dimension info will be stored in
+                   JSON format with a filename matching the input .PAR, but
+                   with the extension .ordering.json.  Only labels that vary
+                   along the 4th dimension are exported.  (e.g. for a single
+                   a single volume structural scan there are no dynamic labels
+                   and no output file will be created)""")))
+    p.add_option(
         Option("--origin", action="store", dest="origin", default="scanner",
                help=one_line(
                    """Reference point of the q-form transformation of the NIfTI
@@ -126,22 +137,14 @@ def error(msg, exit_code):
     sys.exit(exit_code)
 
 
-def sort_info_to_lists(sort_info):
-    sort_info = deepcopy(sort_info)
-    # convert from elements from numpy array to lists for easy JSON export
-    for key in sort_info:
-        ndim = sort_info[key].ndim
-        if ndim == 1:
-            sort_info[key] = list(sort_info[key])
-        elif ndim == 2:
-            k = sort_info[key]
-            k_list = []
-            for row in range(k.shape[0]):
-                k_list.append(list(k[row]))
-            sort_info[key] = k_list
-        else:
-            raise ValueError("only 1D and 2D arrays supported")
-    return sort_info
+def convert_arrays_to_lists(input_dict):
+    # convert dictionary of numpy arrays to a dictionary of lists
+    output_dict = deepcopy(input_dict)
+    for key, value in output_dict.items():
+        if not isinstance(value, np.ndarray):
+            raise ValueError("all dictionary entries must be numpy arrays")
+        output_dict[key] = value.tolist()
+    return output_dict
 
 
 def proc_file(infile, opts):
@@ -249,17 +252,16 @@ def proc_file(infile, opts):
                         fid.write('%s ' % val)
                     fid.write('\n')
 
-    opts.dim_info = True  # TODO: remove hard-coded value
-    if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
-        labels = pr_img.dataobj._dim_4_labels
-    elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
-        labels = pr_img.dataobj._dim_3_4_labels
-    else:
-        labels = None
-    if labels is not None and len(labels) > 0:
-        sort_info = sort_info_to_lists(labels)
-        with open(basefilename + '.ordering.json', 'w') as fid:
-            json.dump(sort_info, fid, sort_keys=True, indent=4)
+    # export data labels varying along the 4th dimensions
+    if opts.dim_info:
+        if pr_img.dataobj._dim_4_labels is not None:
+            labels = pr_img.header.get_dimension_labels(collapse_slices=True)
+        else:
+            labels = None
+        if labels is not None and len(labels) > 0:
+            labels = convert_arrays_to_lists(labels)
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(labels, fid, sort_keys=True, indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -9,6 +9,7 @@ import sys
 import os
 import gzip
 import json
+from copy import deepcopy
 import nibabel
 import nibabel.parrec as pr
 from nibabel.parrec import one_line
@@ -125,6 +126,24 @@ def error(msg, exit_code):
     sys.exit(exit_code)
 
 
+def sort_info_to_lists(sort_info):
+    sort_info = deepcopy(sort_info)
+    # convert from elements from numpy array to lists for easy JSON export
+    for key in sort_info:
+        ndim = sort_info[key].ndim
+        if ndim == 1:
+            sort_info[key] = list(sort_info[key])
+        elif ndim == 2:
+            k = sort_info[key]
+            k_list = []
+            for row in range(k.shape[0]):
+                k_list.append(list(k[row]))
+            sort_info[key] = k_list
+        else:
+            raise ValueError("only 1D and 2D arrays supported")
+    return sort_info
+
+
 def proc_file(infile, opts):
     # figure out the output filename, and see if it exists
     basefilename = splitext_addext(os.path.basename(infile))[0]
@@ -232,15 +251,15 @@ def proc_file(infile, opts):
 
     opts.dim_info = True  # TODO: remove hard-coded value
     if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
-        if len(list(pr_img.dataobj._dim_4_labels.keys())) > 0:
-            with open(basefilename + '.ordering.json', 'w') as fid:
-                json.dump(pr_img.dataobj._dim_4_labels, fid, sort_keys=True,
-                          indent=4)
+        labels = pr_img.dataobj._dim_4_labels
     elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
-        if len(list(pr_img.dataobj._dim_3_4_labels.keys())) > 0:
-            with open(basefilename + '.ordering.json', 'w') as fid:
-                json.dump(pr_img.dataobj._dim_3_4_labels, fid, sort_keys=True,
-                          indent=4)
+        labels = pr_img.dataobj._dim_3_4_labels
+    else:
+        labels = None
+    if labels is not None and len(labels) > 0:
+        sort_info = sort_info_to_lists(labels)
+        with open(basefilename + '.ordering.json', 'w') as fid:
+            json.dump(sort_info, fid, sort_keys=True, indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -8,6 +8,7 @@ import numpy as np
 import sys
 import os
 import gzip
+import json
 import nibabel
 import nibabel.parrec as pr
 from nibabel.parrec import one_line
@@ -228,6 +229,18 @@ def proc_file(infile, opts):
                     for val in row:
                         fid.write('%s ' % val)
                     fid.write('\n')
+
+    opts.dim_info = True  # TODO: remove hard-coded value
+    if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
+        if len(list(pr_img.dataobj._dim_4_labels.keys())) > 0:
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(pr_img.dataobj._dim_4_labels, fid, sort_keys=True,
+                          indent=4)
+    elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
+        if len(list(pr_img.dataobj._dim_3_4_labels.keys())) > 0:
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(pr_img.dataobj._dim_3_4_labels, fid, sort_keys=True,
+                          indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -411,7 +411,7 @@ def parse_PAR_header(fobj):
     -------
     general_info : dict
         Contains all "General Information" from the header file
-    image_info : ndarray
+    image_defs : ndarray
         Structured array with fields giving all "Image information" in the
         header
     """
@@ -489,7 +489,7 @@ class PARRECArrayProxy(object):
             True gives the same behavior as ``mmap='c'``.  If `file_like`
             cannot be memory-mapped, ignore `mmap` value and read array from
             file.
-        scaling : {'fp', 'dv'}, optional, keyword only
+        scaling : {'fp', 'dv', None}, optional, keyword only
             Type of scaling to use - see header ``get_data_scaling`` method.
         """
         if mmap not in (True, False, 'c', 'r'):
@@ -499,8 +499,11 @@ class PARRECArrayProxy(object):
         self._shape = header.get_data_shape()
         self._dtype = header.get_data_dtype()
         self._slice_indices = header.get_sorted_slice_indices()
-        self._mmap=mmap
-        self._slice_scaling = header.get_data_scaling(scaling)
+        self._mmap = mmap
+        if scaling is None:
+            self._slice_scaling = None
+        else:
+            self._slice_scaling = header.get_data_scaling(scaling)
         self._rec_shape = header.get_rec_shape()
 
     @property
@@ -878,7 +881,7 @@ class PARRECHeader(Header):
             slope = 1.0 / scale_slope
             intercept = rescale_intercept / (rescale_slope * scale_slope)
         else:
-            raise ValueError("Unknown scling method '%s'." % method)
+            raise ValueError("Unknown scaling method '%s'." % method)
         reorder = self.get_sorted_slice_indices()
         slope = slope[reorder]
         intercept = intercept[reorder]
@@ -948,7 +951,7 @@ class PARRECImage(SpatialImage):
         permit_truncated : {False, True}, optional, keyword-only
             If False, raise an error for an image where the header shows signs
             that fewer slices / volumes were recorded than were expected.
-        scaling : {'dv', 'fp'}, optional, keyword-only
+        scaling : {'dv', 'fp', None}, optional, keyword-only
             Scaling method to apply to data (see
             :meth:`PARRECHeader.get_data_scaling`).
         """
@@ -982,7 +985,7 @@ class PARRECImage(SpatialImage):
         permit_truncated : {False, True}, optional, keyword-only
             If False, raise an error for an image where the header shows signs
             that fewer slices / volumes were recorded than were expected.
-        scaling : {'dv', 'fp'}, optional, keyword-only
+        scaling : {'dv', 'fp', None}, optional, keyword-only
             Scaling method to apply to data (see
             :meth:`PARRECHeader.get_data_scaling`).
         """

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -673,7 +673,7 @@ class PARRECHeader(Header):
         if normalize_bvecs:
             # scale bvals by the norms of the bvecs then normalize any nonzero
             # bvecs
-            bvec_norms = np.linalg.norm(bvecs, axis=1)
+            bvec_norms = np.sqrt(np.sum(bvecs*bvecs, axis=1))
             non_unity_indices = np.where(np.abs(bvec_norms - 1.0) > 1e-2)[0]
             if len(non_unity_indices) > 0:
                 warnings.warn('Not all bvecs were normalized to 1.0. '

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -994,10 +994,9 @@ class PARRECHeader(Header):
         if collapse_slices:
             dynamic_keys.remove('slice number')
 
-        # remove any dynamic keys that may not be implemented in older .PAR
-        # versions
+        # remove dynamic keys that may not be present in older .PAR versions
         for key in dynamic_keys:
-            if key not in image_defs:
+            if key not in image_defs.dtype.fields:
                 dynamic_keys.remove(key)
 
         non_unique_keys = []
@@ -1031,7 +1030,8 @@ class PARRECHeader(Header):
                 sort_info[key] = image_defs[key][sorted_indices][sl1_indices]
             else:
                 value = image_defs[key][sorted_indices]
-                sort_info[key] = value.reshape(self.shape[2:])
+                sort_info[key] = value.reshape(self.get_data_shape()[2:],
+                                               order='F')
         return sort_info
 
 

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -621,8 +621,14 @@ class PARRECHeader(Header):
         """Echo train length of the recording"""
         return self.general_info['epi_factor']
 
-    def get_q_vectors(self):
+    def get_q_vectors(self, normalize_bvecs=False):
         """Get Q vectors from the data
+
+        Parameters
+        ----------
+        normalize_bvecs : bool, optional
+            whether to scale the b-values by the norm of the b_vectors and then
+            renormalize any non-zero b_vectors to 1.0.
 
         Returns
         -------
@@ -630,7 +636,7 @@ class PARRECHeader(Header):
             Array of q vectors (bvals * bvecs), or None if not a diffusion
             acquisition.
         """
-        bvals, bvecs = self.get_bvals_bvecs()
+        bvals, bvecs = self.get_bvals_bvecs(normalize_bvecs=normalize_bvecs)
         if bvals is None and bvecs is None:
             return None
         return bvecs * bvals[:, np.newaxis]

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1001,9 +1001,8 @@ class PARRECHeader(Header):
             dynamic_keys.remove('slice number')
 
         # remove dynamic keys that may not be present in older .PAR versions
-        for key in dynamic_keys:
-            if key not in image_defs.dtype.fields:
-                dynamic_keys.remove(key)
+        dynamic_keys = [d for d in dynamic_keys if d in
+                        image_defs.dtype.fields]
 
         non_unique_keys = []
         for key in dynamic_keys:

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -175,7 +175,7 @@ def test_header_dimension_labels():
     # check volume labels
     vol_labels = hdr.get_dimension_labels()
     assert_equal(list(vol_labels.keys()), ['dynamic scan number'])
-    assert_equal(vol_labels['dynamic scan number'], [1, 2, 3])
+    assert_array_equal(vol_labels['dynamic scan number'], [1, 2, 3])
     # check that output is ndarray rather than list
     assert_true(isinstance(vol_labels['dynamic scan number'], np.ndarray))
     # check case with individual slice labels

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -342,7 +342,7 @@ def test_diffusion_parameters():
     bvals_norm, bvecs_norm = dti_hdr.get_bvals_bvecs(normalize_bvecs=True)
     # bvecs were already normalized, so expect their values to remain unchanged
     assert_almost_equal(bvecs_norm, DTI_PAR_BVECS[:, [2, 0, 1]])
-    bnorm = np.sqrt(np.sum(bvecs_norm**2, axis=1))
+    bnorm = np.sqrt(np.sum(bvecs_norm*bvecs_norm, axis=1))
     # all bvals where bvecs = [0, 0, 0] got set to 0?
     assert_equal(np.abs(bvals_norm[bnorm == 0]).sum(), 0)
     # all other bvals should not have changed

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -176,9 +176,11 @@ def test_header_dimension_labels():
     vol_labels = hdr.get_dimension_labels()
     assert_equal(list(vol_labels.keys()), ['dynamic scan number'])
     assert_equal(vol_labels['dynamic scan number'], [1, 2, 3])
+    # check that output is ndarray rather than list
+    assert_true(isinstance(vol_labels['dynamic scan number'], np.ndarray))
     # check case with individual slice labels
     slice_vol_labels = hdr.get_dimension_labels(collapse_slices=False)
-    # verify the expected keys are present
+    # verify that both expected keys are present
     assert_true('slice number' in slice_vol_labels)
     assert_true('dynamic scan number' in slice_vol_labels)
     # verify shape of labels matches final dimensions of data

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -345,7 +345,7 @@ def test_diffusion_parameters():
     bnorm = np.linalg.norm(bvecs_norm, axis=1)
     # all bvals where bvecs = [0, 0, 0] got set to 0?
     assert_equal(np.abs(bvals_norm[bnorm == 0]).sum(), 0)
-    # the other b-vectors were already normalized and should not have changed
+    # all other bvals should not have changed
     assert_almost_equal(bvals_norm[bnorm > 0],
                         np.asarray(DTI_PAR_BVALS)[bnorm > 0])
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -520,6 +520,9 @@ class FakeHeader(object):
         n_slices = np.prod(self._shape[2:])
         return self._shape[:2] + (n_slices,)
 
+    def sorted_labels(self, sorted_indices, collapse_slices):
+        return np.arange(self._shape[-1])
+
 
 def test_parrec_proxy():
     # Test PAR / REC proxy class, including mmap flags

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -342,7 +342,7 @@ def test_diffusion_parameters():
     bvals_norm, bvecs_norm = dti_hdr.get_bvals_bvecs(normalize_bvecs=True)
     # bvecs were already normalized, so expect their values to remain unchanged
     assert_almost_equal(bvecs_norm, DTI_PAR_BVECS[:, [2, 0, 1]])
-    bnorm = np.linalg.norm(bvecs_norm, axis=1)
+    bnorm = np.sqrt(np.sum(bvecs_norm**2, axis=1))
     # all bvals where bvecs = [0, 0, 0] got set to 0?
     assert_equal(np.abs(bvals_norm[bnorm == 0]).sum(), 0)
     # all other bvals should not have changed

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -338,6 +338,16 @@ def test_diffusion_parameters():
     assert_almost_equal(bvecs, DTI_PAR_BVECS[:, [2, 0, 1]])
     # Check q vectors
     assert_almost_equal(dti_hdr.get_q_vectors(), bvals[:, None] * bvecs)
+    # test bval/bvec normalization
+    bvals_norm, bvecs_norm = dti_hdr.get_bvals_bvecs(normalize_bvecs=True)
+    # bvecs were already normalized, so expect their values to remain unchanged
+    assert_almost_equal(bvecs_norm, DTI_PAR_BVECS[:, [2, 0, 1]])
+    bnorm = np.linalg.norm(bvecs_norm, axis=1)
+    # all bvals where bvecs = [0, 0, 0] got set to 0?
+    assert_equal(np.abs(bvals_norm[bnorm == 0]).sum(), 0)
+    # the other b-vectors were already normalized and should not have changed
+    assert_almost_equal(bvals_norm[bnorm > 0],
+                        np.asarray(DTI_PAR_BVALS)[bnorm > 0])
 
 
 def test_null_diffusion_params():

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -170,6 +170,22 @@ def test_header_scaling():
     assert_false(np.all(fp_scaling == dv_scaling))
 
 
+def test_header_dimension_labels():
+    hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
+    # check volume labels
+    vol_labels = hdr.get_dimension_labels()
+    assert_equal(list(vol_labels.keys()), ['dynamic scan number'])
+    assert_equal(vol_labels['dynamic scan number'], [1, 2, 3])
+    # check case with individual slice labels
+    slice_vol_labels = hdr.get_dimension_labels(collapse_slices=False)
+    # verify the expected keys are present
+    assert_true('slice number' in slice_vol_labels)
+    assert_true('dynamic scan number' in slice_vol_labels)
+    # verify shape of labels matches final dimensions of data
+    assert_equal(slice_vol_labels['slice number'].shape,
+                 hdr.get_data_shape()[2:])
+
+
 def test_orientation():
     hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
     assert_array_equal(HDR_DEFS['slice orientation'], 1)


### PR DESCRIPTION
Additional PAR/REC functionality was added (building upon the recent merge of #253, #261 and #264 as implemented by @matthew-brett and @Eric89GXL)

Aside from a couple of minor fixes, there are two new features added:

**1.) ability to normalize b-values & b-vectors**

The --norm-bvs argument to parrec2nii enables the auto-scaling, otherwise the old behavior is maintained.  If all b-vectors were properly normalized to 1.0 and the b-values were stored correctly, this new functionality is not be needed, so it is disabled by default.

I implemented this because I have some datasets where the .PAR header came from a custom pulse sequence where the b-value label was left at 3000 for all volumes (even the b=0 ones!), and the only way to determine the b=0 volumes was that the gradient vector is [0, 0, 0] for these.  Scaling the b-values by the norm of the gradient vector gives the proper b-value array.  (I did not rescale the b-values/vectors for arrays where the norm was within [1.0 +/- 1e-2] to avoid causing the b-value array to have non-unique but nearly identical b-values such as [2999.99, 3000.01, etc] due to numerical precision of the stored b-vector arrays.)

The non-normalized behavior is still required for other cases, e.g. when using a product DWI sequence with 15 different b-values and requesting only the trace volumes to be stored.  In this case, the gradient vectors will all be [0, 0, 0], but the b-values are an array of 15 unique values.  If the norm of the gradient vectors had been used, this would have caused the b-value array to return all zeros instead of the appropriate values.

**2.) store the labels corresponding to the fourth data dimension**
I think something along these lines is extremely important and would be interested on feedback on how best to implement it.  For now, I search through a set of potentially varying image_defs keys such as "label type", "echo number", etc.  For any that have non-unique values, I maintain a dictionary with the corresponding indices.  This dictionary can then be used later by the user to provide custom resorting of the data or reshaping to >4D, etc.  I did not implement any custom resorting options within the classes, but for now just write out the dictionary of orderings out to a .json file in parrec2nii and leave it up to the user to resort in the desired manner.  

An example of where this is useful can be illustrated for a simple ASL experiment with 8 dynamics and 2 label types (dataobj.shape[3] = 16).  Without labeling along the fourth dimension, we will not know which volumes correspond to `label type = 1` and which correspond to `label type = 2` (i.e. control vs. tag volumes).  One logical data ordering for the 16 total volumes is:

{
    "dynamic scan number": [
        1,
        1,
        2,
        2,
        3,
        3,
        4,
        4,
        5,
        5,
        6,
        6,
        7,
        7,
        8,
        8
    ],
    "label type": [
        1,
        2,
        1,
        2,
        1,
        2,
        1,
        2,
        1,
        2,
        1,
        2,
        1,
        2,
        1,
        2
    ]
}

However depending on how the data was exported, the ordering within the .PAR could equally well have been:

{
    "dynamic scan number": [
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8,
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8
    ],
    "label type": [
        1,
        1,
        1,
        1,
        1,
        1,
        1,
        1,
        2,
        2,
        2,
        2,
        2,
        2,
        2,
        2
    ]
}

Without saving some sort of ordering info along with the .nii, there is no clean way to tell these two cases apart and properly process the resulting .nii files.  I doubt json is the optimal way to do this, but it is easily readable and illustrates the desired functionality.  I am certainly open to other suggestions.  The .json output corresponds to the new `PARRECArrayProxy._dim_4_labels` property.

The `sorted_labels` function of the `PARRECHeader` also has the ability to include per-slice info such as slice angulation, and store this into `PARRECArrayProxy._dim_3_4_labels`.  This allows .PAR/.REC files corresponding to scans such as 3-plane localizers, etc. to have the raw array data be read in along with its corresponding dimension info.  These volumes with varying slice angulation still cannot be read into a PARRECImage object, though, because `PARRECArrayProxy.get_slice_orientation` only allows unique values for slice angulation so that a unique affine can be determined for the `PARRECImage`.
