### PR TITLE
RF+BF: '' from `get_nibabel_data()` when missing

### DIFF
--- a/nibabel/tests/nibabel_data.py
+++ b/nibabel/tests/nibabel_data.py
@@ -8,7 +8,7 @@ from numpy.testing.decorators import skipif
 
 
 def get_nibabel_data():
-    """ Return path to nibabel-data or None if missing
+    """ Return path to nibabel-data or empty string if missing
 
     First use ``NIBABEL_DATA_DIR`` environment variable.
 
@@ -20,7 +20,7 @@ def get_nibabel_data():
         mod = __import__('nibabel')
         containing_path = dirname(dirname(realpath(mod.__file__)))
         nibabel_data = pjoin(containing_path, 'nibabel-data')
-    return nibabel_data if isdir(nibabel_data) else None
+    return nibabel_data if isdir(nibabel_data) else ''
 
 
 def needs_nibabel_data(subdir = None):
@@ -38,7 +38,7 @@ def needs_nibabel_data(subdir = None):
         Decorator skipping tests if required directory not present
     """
     nibabel_data = get_nibabel_data()
-    if nibabel_data is None:
+    if nibabel_data == '':
         return skipif(True, "Need nibabel-data directory for this test")
     if subdir is None:
         return skipif(False)

--- a/nibabel/tests/test_minc2_data.py
+++ b/nibabel/tests/test_minc2_data.py
@@ -25,9 +25,7 @@ from .. import load as top_load, Nifti1Image
 from nose.tools import assert_equal
 from numpy.testing import (assert_array_equal, assert_almost_equal)
 
-NIBABEL_DATA = get_nibabel_data()
-if NIBABEL_DATA is not None:
-    MINC2_PATH = pjoin(NIBABEL_DATA, 'nitest-minc2')
+MINC2_PATH = pjoin(get_nibabel_data(), 'nitest-minc2')
 
 
 def _make_affine(coses, zooms, starts):

--- a/nibabel/tests/test_nibabel_data.py
+++ b/nibabel/tests/test_nibabel_data.py
@@ -25,8 +25,8 @@ def test_get_nibabel_data():
     if isdir(local_data):
         assert_equal(nibd.get_nibabel_data(), local_data)
     else:
-        assert_equal(nibd.get_nibabel_data(), None)
+        assert_equal(nibd.get_nibabel_data(), '')
     nibd.environ['NIBABEL_DATA_DIR'] = 'not_a_path'
-    assert_equal(nibd.get_nibabel_data(), None)
+    assert_equal(nibd.get_nibabel_data(), '')
     nibd.environ['NIBABEL_DATA_DIR'] = MY_DIR
     assert_equal(nibd.get_nibabel_data(), MY_DIR)

--- a/nibabel/tests/test_parrec_data.py
+++ b/nibabel/tests/test_parrec_data.py
@@ -17,8 +17,7 @@ from nose.tools import assert_true, assert_false, assert_equal
 
 from numpy.testing import assert_almost_equal
 
-NIBABEL_DATA = get_nibabel_data()
-BALLS = None if NIBABEL_DATA is None else pjoin(NIBABEL_DATA, 'nitest-balls1')
+BALLS = pjoin(get_nibabel_data(), 'nitest-balls1')
 
 # Amount by which affine translation differs from NIFTI conversion
 AFF_OFF = [-0.93644031, -0.95572686, 0.03288748]


### PR DESCRIPTION
Return empty string from `get_nibabel_data()` if directory does not exist,
instead of None.

Doing this means we can use os.path.join on the output even if it the 
directory doesn't exist. The resulting filenames don't make sense, but the
decorator checks for this in any case, so the filenames don't get used.
