### PR TITLE
RF: check separately for Nones to avoid warning

### DIFF
--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -208,7 +208,7 @@ def proc_file(infile, opts):
     # write out bvals/bvecs if requested
     if opts.bvs:
         bvals, bvecs = pr_hdr.get_bvals_bvecs()
-        if (bvals, bvecs) == (None, None):
+        if bvals is None and bvecs is None:
             verbose('No DTI volumes detected, bvals and bvecs not written')
         else:
             verbose('Writing .bvals and .bvecs files')


### PR DESCRIPTION
Avoid future warning by checking for two Nones with separate if clauses.
