### PR TITLE
added ecat test data set with negative values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "nibabel-data/nitest-minc2"]
 	path = nibabel-data/nitest-minc2
 	url = git://github.com/matthew-brett/nitest-minc2.git
+[submodule "nipy-ecattest"]
+	path = nibabel-data/nipy-ecattest
+	url = https://github.com/freec84/nipy-ecattest


### PR DESCRIPTION
I added a ecat7 file with negative values (transmission scan from ecat exac hr+ pet scanner) to the test data.
It seems that alls negative values are set to two times the maximum positive value when read  in with nibabel ecat load.