### PR TITLE
ENH: Add image_like function for SpatialImages

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -72,6 +72,7 @@ from .minc1 import MincImage
 from .freesurfer import MGHImage
 from .funcs import (squeeze_image, concat_images, four_to_three,
                     as_closest_canonical)
+from .spatialimages import image_like
 from .orientations import (io_orientation, orientation_affine,
                            flip_axis, OrientationError,
                            apply_orientation, aff2axcodes)

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -634,3 +634,11 @@ class SpatialImage(DataobjImage):
         new_aff = self.affine.dot(inv_ornt_aff(ornt, self.shape))
 
         return self.__class__(t_arr, new_aff, self.header)
+
+
+def image_like(img, data):
+    ''' Create new SpatialImage with metadata of `img`, and data
+    contained in `data`.
+    '''
+    return img.__class__(data, img.affine, img.header.copy(),
+                         extra=img.extra.copy())

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -537,7 +537,7 @@ class SpatialImage(DataobjImage):
         return self.affine
 
     @classmethod
-    def from_image(klass, img):
+    def from_image(klass, img, data=None):
         ''' Class method to create new instance of own class from `img`
 
         Parameters
@@ -551,7 +551,7 @@ class SpatialImage(DataobjImage):
         cimg : ``spatialimage`` instance
            Image, of our own class
         '''
-        return klass(img.dataobj,
+        return klass(img.dataobj if data is None else data,
                      img.affine,
                      klass.header_class.from_header(img.header),
                      extra=img.extra.copy())
@@ -640,5 +640,4 @@ def image_like(img, data):
     ''' Create new SpatialImage with metadata of `img`, and data
     contained in `data`.
     '''
-    return img.__class__(data, img.affine, img.header.copy(),
-                         extra=img.extra.copy())
+    return img.from_image(img, data)

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from io import BytesIO
 from ..spatialimages import (SpatialHeader, SpatialImage, HeaderDataError,
-                             Header, ImageDataError)
+                             Header, ImageDataError, image_like)
 from ..imageclasses import spatial_axes_first
 
 from unittest import TestCase
@@ -659,3 +659,13 @@ def test_header_deprecated():
 
         MyHeader()
         assert_equal(len(w), 1)
+
+
+def test_image_like():
+    zeros = SpatialImage(np.zeros((2, 3, 4)), np.eye(4))
+    ones = image_like(zeros, np.ones((2, 3, 4)))
+
+    assert np.all(ones.dataobj != zeros.dataobj)
+    assert np.all(ones.affine == zeros.affine)
+    assert ones.header == zeros.header
+    assert ones.extra == zeros.extra


### PR DESCRIPTION
I often find myself just wanting to apply a function to data in an MGHImage or Nifti1Image without discarding the headers and just using x.get_data().

I've implemented this map as a separate function, but it could easily be a method in SpatialImage, allowing subclasses to be more particular about their mapping strategy. Basic test shows that mapping (+1) to an image containing zeros results in all ones.

Is this a thing people would find useful? I'm sure there's more work to be done to integrate it properly into the nibabel framework, but figured I'd start with a proof-of-concept.
