### PR TITLE
MRG: refactoring of ECAT for clarity

### DIFF
--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -360,7 +360,7 @@ def read_mlist(fileobj, endianness):
     * n_rows - number of mlist rows in this block (between ?0 and 31) (called
       `nused` in CTI code).
     """
-    dt = np.dtype(np.int32) # should this be uint32 given mlist dtype?
+    dt = np.dtype(np.int32)
     if not endianness is native_code:
         dt = dt.newbyteorder(endianness)
     mlists = []
@@ -369,7 +369,7 @@ def read_mlist(fileobj, endianness):
     while True:
         # Read block containing mlist entries
         fileobj.seek((mlist_block_no - 1) * BLOCK_SIZE) # fix 1-based indexing
-        dat = fileobj.read(128 * 32) # isn't this too long? Should be 512?
+        dat = fileobj.read(BLOCK_SIZE)
         rows = np.ndarray(shape=(32, 4), dtype=dt, buffer=dat)
         # First row special, points to next mlist entries if present
         n_unused, mlist_block_no, _, n_rows = rows[0]
@@ -381,8 +381,6 @@ def read_mlist(fileobj, endianness):
         mlist_index += n_rows
         if mlist_block_no <= 2: # should block_no in (1, 2) be an error?
             break
-    # Code in ``get_frame_order`` seems to imply ids can be < 0; is that
-    # true? Should the dtype be uint32 or int32?
     return np.row_stack(mlists)
 
 

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -13,28 +13,27 @@ An ECAT format image consists of:
 * a *main header*;
 * at least one *matrix list* (mlist);
 
-ECAT thinks of memory locations in terms of *records*.  One record is 512
-bytes.  Thus record 1 is at 0 bytes, record 2 at 512 bytes, and so on.
+ECAT thinks of memory locations in terms of *blocks*.  One block is 512
+bytes.  Thus block 1 starts at 0 bytes, block 2 at 512 bytes, and so on.
 
 The matrix list is an array with one row per frame in the data.
 
 Columns in the matrix list are:
 
 * 0 - Matrix identifier (frame number)
-* 1 - matrix data start record number (subheader stored here)
-* 2 - Last record number of matrix data block.
+* 1 - matrix data start block number (subheader followed by image data)
+* 2 - Last block number of matrix (image) data
 * 3 - Matrix status:
     * 1 - exists - rw
     * 2 - exists - ro
     * 3 - matrix deleted
 
 There is one sub-header for each image frame (or matrix in the terminology
-above).
+above).  A sub-header can also be called an *image header*.  The sub-header is
+one block (512 bytes), and the frame (image) data follows.
 
-A sub-header can also be called an *image header*.
-
-There is very little documentation of this format, and many of the comments in
-this code come from a combination of trial and error and wild speculation.
+There is very little documentation of the ECAT format, and many of the comments
+in this code come from a combination of trial and error and wild speculation.
 
 XMedcon can read and write ECAT 6 format, and read ECAT 7 format: see
 http://xmedcon.sourceforge.net and the ECAT files in the source of XMedCon,
@@ -55,9 +54,8 @@ from .arraywriters import make_array_writer
 from .wrapstruct import WrapStruct
 from .fileslice import canonical_slicers, predict_shape, slice2outax
 
-RECORD_BYTES = 512
+BLOCK_SIZE = 512
 
-MAINHDRSZ = 502
 main_header_dtd = [
     ('magic_number', '14S'),
     ('original_filename', '32S'),
@@ -332,35 +330,34 @@ def read_mlist(fileobj, endianness):
     mlist : (nframes, 4) ndarray
         matrix list is an array with ``nframes`` rows and columns:
 
-        * 0 - Matrix identifier.
-        * 1 - subheader record number
-        * 2 - Last record number of matrix data block.
+        * 0 - Matrix identifier (frame number)
+        * 1 - matrix data start block number (subheader followed by image data)
+        * 2 - Last block number of matrix (image) data
         * 3 - Matrix status:
-
-          * 1 - exists - rw
-          * 2 - exists - ro
-          * 3 - matrix deleted
+            * 1 - exists - rw
+            * 2 - exists - ro
+            * 3 - matrix deleted
 
     Notes
     -----
-    A 'record' or 'block' is 512 bytes.
+    A block is 512 bytes.
 
-    ``record_no`` in the code below is 1-based.  Record 1 is the main header,
-    and the mlist records start at record number 2.
+    ``block_no`` in the code below is 1-based.  block 1 is the main header,
+    and the mlist blocks start at block number 2.
 
-    The 512 bytes in an mlist record represents 32 rows of the int32 (nframes,
+    The 512 bytes in an mlist block contain 32 rows of the int32 (nframes,
     4) mlist matrix.
 
     The first row of these 32 looks like a special row.  The 4 values appear
     to be (respectively):
 
     * not sure - maybe negative number of mlist rows (out of 31) that are
-      blank and not used in this record.  Called `nfree` but unused in CTI
+      blank and not used in this block.  Called `nfree` but unused in CTI
       code;
-    * record_no - of next set of mlist entries or 2 if no more entries. We also
+    * block_no - of next set of mlist entries or 2 if no more entries. We also
       allow 1 or 0 to signal no more entries;
-    * <no idea>.  Called `prvblk` in CTI code, so maybe previous record no;
-    * n_rows - number of mlist rows in this record (between ?0 and 31) (called
+    * <no idea>.  Called `prvblk` in CTI code, so maybe previous block no;
+    * n_rows - number of mlist rows in this block (between ?0 and 31) (called
       `nused` in CTI code).
     """
     dt = np.dtype(np.int32) # should this be uint32 given mlist dtype?
@@ -368,21 +365,21 @@ def read_mlist(fileobj, endianness):
         dt = dt.newbyteorder(endianness)
     mlists = []
     mlist_index = 0
-    mlist_record_no = 2  # 1-based indexing, record with first mlist
+    mlist_block_no = 2  # 1-based indexing, block with first mlist
     while True:
-        # Read record containing mlist entries
-        fileobj.seek((mlist_record_no - 1) * RECORD_BYTES) # fix 1-based indexing
+        # Read block containing mlist entries
+        fileobj.seek((mlist_block_no - 1) * BLOCK_SIZE) # fix 1-based indexing
         dat = fileobj.read(128 * 32) # isn't this too long? Should be 512?
         rows = np.ndarray(shape=(32, 4), dtype=dt, buffer=dat)
         # First row special, points to next mlist entries if present
-        n_unused, mlist_record_no, _, n_rows = rows[0]
+        n_unused, mlist_block_no, _, n_rows = rows[0]
         if not (n_unused + n_rows) == 31: # Some error condition here?
             mlist = []
             return mlist
         # Use all but first housekeeping row
         mlists.append(rows[1:n_rows+1])
         mlist_index += n_rows
-        if mlist_record_no <= 2: # should record_no in (1, 2) be an error?
+        if mlist_block_no <= 2: # should block_no in (1, 2) be an error?
             break
     # Code in ``get_frame_order`` seems to imply ids can be < 0; is that
     # true? Should the dtype be uint32 or int32?
@@ -481,8 +478,8 @@ def read_subheaders(fileobj, mlist, endianness):
     mlist : (nframes, 4) ndarray
         Columns are:
         * 0 - Matrix identifier.
-        * 1 - subheader record number
-        * 2 - Last record number of matrix data block.
+        * 1 - subheader block number
+        * 2 - Last block number of matrix data block.
         * 3 - Matrix status:
     endianness : {'<', '>'}
         little / big endian code
@@ -496,12 +493,12 @@ def read_subheaders(fileobj, mlist, endianness):
     dt = subhdr_dtype
     if not endianness is native_code:
         dt = dt.newbyteorder(endianness)
-    for mat_id, sh_recno, sh_last_recno, mat_stat in mlist:
-        if sh_recno == 0:
+    for mat_id, sh_blkno, sh_last_blkno, mat_stat in mlist:
+        if sh_blkno == 0:
             break
-        offset = (sh_recno - 1) * 512
+        offset = (sh_blkno - 1) * BLOCK_SIZE
         fileobj.seek(offset)
-        tmpdat = fileobj.read(512)
+        tmpdat = fileobj.read(BLOCK_SIZE)
         sh = np.ndarray(shape=(), dtype=dt, buffer=tmpdat)
         subheaders.append(sh)
     return subheaders
@@ -520,14 +517,14 @@ class EcatMlist(object):
         Columns are:
 
         * 0 - Matrix identifier.
-        * 1 - subheader record number
-        * 2 - Last record number of matrix data block.
+        * 1 - subheader block number
+        * 2 - Last block number of matrix data block.
         * 3 - Matrix status:
           * 1 - exists - rw
           * 2 - exists - ro
           * 3 - matrix deleted
 
-        A record above is 512 bytes in the image data file
+        A block above is 512 bytes in the image data file
 
         Parameters
         -----------
@@ -631,7 +628,7 @@ class EcatSubHeader(object):
 
     def _get_frame_offset(self, frame=0):
         mlist = self._mlist._mlist
-        offset = (mlist[frame][1]) * 512
+        offset = (mlist[frame][1]) * BLOCK_SIZE
         return int(offset)
 
     def _get_oriented_data(self, raw_data, orientation=None):

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -13,11 +13,11 @@ import os
 import numpy as np
 
 from ..openers import Opener
-from ..ecat import EcatHeader, EcatMlist, EcatSubHeader, EcatImage
+from ..ecat import (EcatHeader, EcatSubHeader, EcatImage, read_mlist,
+                    get_frame_order, get_series_framenumbers)
 
 from unittest import TestCase
-from nose.tools import (assert_true, assert_false, assert_equal,
-                        assert_not_equal, assert_raises)
+from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
@@ -79,13 +79,12 @@ class TestEcatHeader(_TestWrapStructBase):
 
 class TestEcatMlist(TestCase):
     header_class = EcatHeader
-    mlist_class = EcatMlist
     example_file = ecat_file
 
     def test_mlist(self):
         fid = open(self.example_file, 'rb')
         hdr = self.header_class.from_fileobj(fid)
-        mlist =  self.mlist_class(fid, hdr)
+        mlist = read_mlist(fid, hdr.endianness)
         fid.seek(0)
         fid.seek(512)
         dat=fid.read(128*32)
@@ -95,68 +94,64 @@ class TestEcatMlist(TestCase):
         fid.close()
         #tests
         assert_true(mats['matlist'][0,0] +  mats['matlist'][0,3] == 31)
-        assert_true(mlist.get_frame_order()[0][0] == 0)
-        assert_true(mlist.get_frame_order()[0][1] == 16842758.0)
+        assert_true(get_frame_order(mlist)[0][0] == 0)
+        assert_true(get_frame_order(mlist)[0][1] == 16842758.0)
         # test badly ordered mlist
-        badordermlist = mlist
-        badordermlist._mlist = np.array([[  1.68427540e+07,   3.00000000e+00,
-                                            1.20350000e+04,   1.00000000e+00],
-                                         [  1.68427530e+07,   1.20360000e+04,
-                                            2.40680000e+04,   1.00000000e+00],
-                                         [  1.68427550e+07,   2.40690000e+04,
-                                            3.61010000e+04,   1.00000000e+00],
-                                         [  1.68427560e+07,   3.61020000e+04,
-                                            4.81340000e+04,   1.00000000e+00],
-                                         [  1.68427570e+07,   4.81350000e+04,
-                                            6.01670000e+04,   1.00000000e+00],
-                                         [  1.68427580e+07,   6.01680000e+04,
-                                            7.22000000e+04,   1.00000000e+00]])
+        badordermlist = np.array([[1.68427540e+07,   3.00000000e+00,
+                                   1.20350000e+04,   1.00000000e+00],
+                                  [1.68427530e+07,   1.20360000e+04,
+                                   2.40680000e+04,   1.00000000e+00],
+                                  [1.68427550e+07,   2.40690000e+04,
+                                   3.61010000e+04,   1.00000000e+00],
+                                  [1.68427560e+07,   3.61020000e+04,
+                                   4.81340000e+04,   1.00000000e+00],
+                                  [1.68427570e+07,   4.81350000e+04,
+                                   6.01670000e+04,   1.00000000e+00],
+                                  [1.68427580e+07,   6.01680000e+04,
+                                   7.22000000e+04,   1.00000000e+00]])
         with suppress_warnings():  # STORED order
-            assert_true(badordermlist.get_frame_order()[0][0] == 1)
+            assert_true(get_frame_order(badordermlist)[0][0] == 1)
 
     def test_mlist_errors(self):
         fid = open(self.example_file, 'rb')
         hdr = self.header_class.from_fileobj(fid)
         hdr['num_frames'] = 6
-        mlist =  self.mlist_class(fid, hdr)    
-        mlist._mlist = np.array([[  1.68427540e+07,   3.00000000e+00,
-                                    1.20350000e+04,   1.00000000e+00],
-                                 [  1.68427530e+07,   1.20360000e+04,
-                                    2.40680000e+04,   1.00000000e+00],
-                                 [  1.68427550e+07,   2.40690000e+04,
-                                    3.61010000e+04,   1.00000000e+00],
-                                 [  1.68427560e+07,   3.61020000e+04,
-                                    4.81340000e+04,   1.00000000e+00],
-                                 [  1.68427570e+07,   4.81350000e+04,
-                                    6.01670000e+04,   1.00000000e+00],
-                                 [  1.68427580e+07,   6.01680000e+04,
-                                    7.22000000e+04,   1.00000000e+00]])        
+        mlist = read_mlist(fid, hdr.endianness)
+        mlist = np.array([[1.68427540e+07,   3.00000000e+00,
+                           1.20350000e+04,   1.00000000e+00],
+                          [1.68427530e+07,   1.20360000e+04,
+                           2.40680000e+04,   1.00000000e+00],
+                          [1.68427550e+07,   2.40690000e+04,
+                           3.61010000e+04,   1.00000000e+00],
+                          [1.68427560e+07,   3.61020000e+04,
+                           4.81340000e+04,   1.00000000e+00],
+                          [1.68427570e+07,   4.81350000e+04,
+                           6.01670000e+04,   1.00000000e+00],
+                          [1.68427580e+07,   6.01680000e+04,
+                           7.22000000e+04,   1.00000000e+00]])
         with suppress_warnings():  # STORED order
-            series_framenumbers = mlist.get_series_framenumbers()
+            series_framenumbers = get_series_framenumbers(mlist)
         # first frame stored was actually 2nd frame acquired
         assert_true(series_framenumbers[0] == 2)
         order = [series_framenumbers[x] for x in sorted(series_framenumbers)]
         # true series order is [2,1,3,4,5,6], note counting starts at 1
         assert_true(order == [2, 1, 3, 4, 5, 6])
-        mlist._mlist[0,0] = 0
+        mlist[0,0] = 0
         with suppress_warnings():
-            frames_order = mlist.get_frame_order()
+            frames_order = get_frame_order(mlist)
         neworder =[frames_order[x][0] for x in sorted(frames_order)] 
         assert_true(neworder == [1, 2, 3, 4, 5])
         with suppress_warnings():
-            assert_raises(IOError,
-                          mlist.get_series_framenumbers)
-        
-        
+            assert_raises(IOError, get_series_framenumbers, mlist)
+
 
 class TestEcatSubHeader(TestCase):
     header_class = EcatHeader
-    mlist_class = EcatMlist
     subhdr_class = EcatSubHeader
     example_file = ecat_file
     fid = open(example_file, 'rb')
     hdr = header_class.from_fileobj(fid)
-    mlist =  mlist_class(fid, hdr)
+    mlist = read_mlist(fid, hdr.endianness)
     subhdr = subhdr_class(hdr, mlist, fid)
 
     def test_subheader_size(self):
@@ -269,5 +264,5 @@ class TestEcatImage(TestCase):
 
     def test_mlist_regreesion(self):
         # Test mlist is as same as for nibabel 1.3.0
-        assert_array_equal(self.img.get_mlist()._mlist,
+        assert_array_equal(self.img.get_mlist(),
                            [[16842758, 3, 3011, 1]])


### PR DESCRIPTION
Remove EcatMlist class for clarity.

Specify mlist as int32, data type from CTI sources.

Rewrite docstrings with better understanding of code.