### PR TITLE
BF+TST: test /fix for signed int data type

### DIFF
--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -152,14 +152,19 @@ subheader_dtd = [
 subhdr_dtype = np.dtype(subheader_dtd)
 
 # Ecat Data Types
+# See:
+# http://www.turkupetcentre.net/software/libdoc/libtpcimgio/ecat7_8h_source.html#l00060
+# and:
+# http://www.turkupetcentre.net/software/libdoc/libtpcimgio/ecat7r_8c_source.html#l00717
 _dtdefs = ( # code, name, equivalent dtype
-    (1, 'ECAT7_BYTE', np.uint8),
-    (2, 'ECAT7_VAXI2', np.int16),
-    (3, 'ECAT7_VAXI4', np.int32),
-    (4, 'ECAT7_VAXR4', np.float32),
-    (5, 'ECAT7_IEEER4', np.float32),
-    (6, 'ECAT7_SUNI2', np.int16),
-    (7, 'ECAT7_SUNI4', np.int32))
+           (1, 'ECAT7_BYTE', np.uint8),
+           # Byte signed? https://github.com/nipy/nibabel/pull/302/files#r28275780
+           (2, 'ECAT7_VAXI2', np.int16),
+           (3, 'ECAT7_VAXI4', np.int32),
+           (4, 'ECAT7_VAXR4', np.float32),
+           (5, 'ECAT7_IEEER4', np.float32),
+           (6, 'ECAT7_SUNI2', np.int16),
+           (7, 'ECAT7_SUNI4', np.int32))
 data_type_codes = make_dt_codes(_dtdefs)
 
 

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -155,10 +155,10 @@ subhdr_dtype = np.dtype(subheader_dtd)
 _dtdefs = ( # code, name, equivalent dtype
     (1, 'ECAT7_BYTE', np.uint8),
     (2, 'ECAT7_VAXI2', np.int16),
-    (3, 'ECAT7_VAXI4', np.float32),
+    (3, 'ECAT7_VAXI4', np.int32),
     (4, 'ECAT7_VAXR4', np.float32),
     (5, 'ECAT7_IEEER4', np.float32),
-    (6, 'ECAT7_SUNI2', np.uint16),
+    (6, 'ECAT7_SUNI2', np.int16),
     (7, 'ECAT7_SUNI4', np.int32))
 data_type_codes = make_dt_codes(_dtdefs)
 

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -172,7 +172,7 @@ class TestEcatSubHeader(TestCase):
                                   np.array([ 2.20241979, 2.20241979, 3.125,  1.]))
         assert_equal(self.subhdr.get_zooms()[0], 2.20241978764534)
         assert_equal(self.subhdr.get_zooms()[2], 3.125)
-        assert_equal(self.subhdr._get_data_dtype(0),np.uint16)
+        assert_equal(self.subhdr._get_data_dtype(0), np.int16)
         #assert_equal(self.subhdr._get_frame_offset(), 1024)
         assert_equal(self.subhdr._get_frame_offset(), 1536)
         dat = self.subhdr.raw_data_from_fileobj()

--- a/nibabel/tests/test_ecat_data.py
+++ b/nibabel/tests/test_ecat_data.py
@@ -1,0 +1,52 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the NiBabel package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+""" Test we can correctly import example ECAT files
+"""
+from __future__ import print_function, absolute_import
+
+import os
+from os.path import join as pjoin
+
+import numpy as np
+
+from .nibabel_data import get_nibabel_data, needs_nibabel_data
+from ..ecat import load
+
+from nose.tools import assert_equal
+from numpy.testing import (assert_array_equal, assert_almost_equal)
+
+ECAT_TEST_PATH = pjoin(get_nibabel_data(), 'nipy-ecattest')
+
+
+class TestNegatives(object):
+    opener = staticmethod(load)
+    example_params = dict(
+        fname = os.path.join(ECAT_TEST_PATH, 'ECAT7_testcaste_neg_values.v'),
+        shape = (256, 256, 63, 1),
+        type = np.int16,
+        # These values from freec64
+        min = -0.00061576,
+        max =  0.19215,
+        mean = 0.04933,
+        # unit: 1/cm
+    )
+
+    @needs_nibabel_data('nitest-minc2')
+    def test_load(self):
+        # Check highest level load of minc works
+        img = self.opener(self.example_params['fname'])
+        assert_equal(img.shape, self.example_params['shape'])
+        assert_equal(img.get_data_dtype(0).type, self.example_params['type'])
+        # Check correspondence of data and recorded shape
+        data = img.get_data()
+        assert_equal(data.shape, self.example_params['shape'])
+        # min, max, mean values from given parameters
+        assert_almost_equal(data.min(), self.example_params['min'], 4)
+        assert_almost_equal(data.max(), self.example_params['max'], 4)
+        assert_almost_equal(data.mean(), self.example_params['mean'], 4)


### PR DESCRIPTION
We were incorrectly loading signed ints as unsigned; fix and test.

See : https://github.com/nipy/nibabel/pull/297 for motivation.