### PR TITLE
BF: work around np.allclose float128 bug

### DIFF
--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -5,9 +5,11 @@ import sys
 
 from warnings import warn, simplefilter
 
-from ..testing import catch_warn_reset
+import numpy as np
 
-from nose.tools import assert_equal
+from ..testing import catch_warn_reset, assert_allclose_safely
+
+from nose.tools import assert_equal, assert_raises
 
 
 def assert_warn_len_equal(mod, n_in_context):
@@ -46,3 +48,39 @@ def test_catch_warn_reset():
         simplefilter('ignore')
         warn('Another warning')
     assert_warn_len_equal(my_mod, 2)
+
+
+def test_assert_allclose_safely():
+    # Test the safe version of allclose
+    assert_allclose_safely([1, 1], [1, 1])
+    assert_allclose_safely(1, 1)
+    assert_allclose_safely(1, [1, 1])
+    assert_allclose_safely([1, 1], 1 + 1e-6)
+    assert_raises(AssertionError, assert_allclose_safely, [1, 1], 1 + 1e-4)
+    # Broadcastable matrices
+    a = np.ones((2, 3))
+    b = np.ones((3, 2, 3))
+    eps = np.finfo(np.float).eps
+    a[0, 0] = 1 + eps
+    assert_allclose_safely(a, b)
+    a[0, 0] = 1 + 1.1e-5
+    assert_raises(AssertionError, assert_allclose_safely, a, b)
+    # Nans in same place
+    a[0, 0] = np.nan
+    b[:, 0, 0] = np.nan
+    assert_allclose_safely(a, b)
+    # Never equal with nans present, if not matching nans
+    assert_raises(AssertionError,
+                  assert_allclose_safely, a, b,
+                  match_nans=False)
+    b[0, 0, 0] = 1
+    assert_raises(AssertionError, assert_allclose_safely, a, b)
+    # Test allcloseness of inf, especially np.float128 infs
+    for dtt in (np.float32, np.float64, np.float128):
+        a = np.array([-np.inf, 1, np.inf], dtype=dtt)
+        b = np.array([-np.inf, 1, np.inf], dtype=dtt)
+        assert_allclose_safely(a, b)
+        b[1] = 0
+        assert_raises(AssertionError, assert_allclose_safely, a, b)
+    # Empty compares equal to empty
+    assert_allclose_safely([], [])


### PR DESCRIPTION
Numpy 1.9.2 allclose thinks that np.inf in float128 precision is not allclose
to itself.  Work round with expanded assert_allclose_safely function.

See: http://nipy.bic.berkeley.edu/builders/nibabel-py2.7-osx-10.6/builds/178/steps/shell_4/logs/stdio for resulting error, maybe fixed by this PR.