### PR TITLE
DOC Use HTTPS for outside scripts/forms

### DIFF
--- a/doc/source/_templates/indexsidebar.html
+++ b/doc/source/_templates/indexsidebar.html
@@ -6,7 +6,7 @@
     <li><a href="http://mail.scipy.org/pipermail/nipy-devel">Mailing list archive</a></li>
 </ul>
 
-<script type="text/javascript" src="http://www.ohloh.net/projects/480908/widgets/project_partner_badge"></script>
+<script type="text/javascript" src="https://www.ohloh.net/projects/480908/widgets/project_partner_badge"></script>
 
 <h3>Search mailing list archive</h3>
 <script type="text/javascript">
@@ -15,7 +15,7 @@
     curobj.q.value="site:mail.scipy.org/pipermail/nipy-devel/ "+curobj.userquery.value
 }
 </script>
-<form action="http://www.google.com/search" method="get" onSubmit="mlsearch(this)">
+<form action="https://www.google.com/search" method="get" onSubmit="mlsearch(this)">
 <input name="userquery" size="18" type="text" /> <input type="submit" value="Go" />
 <input name="q" type="hidden" />
 </form>

--- a/doc/source/_templates/indexsidebar.html
+++ b/doc/source/_templates/indexsidebar.html
@@ -1,8 +1,8 @@
 <h3>Quick links</h3>
 
 <ul>
-    <li><a href="http://pypi.python.org/pypi/nibabel">Nibabel pypi</a></li>
-    <li><a href="http://github.com/nipy/nibabel">Git repository</a></li>
+    <li><a href="https://pypi.python.org/pypi/nibabel">Nibabel pypi</a></li>
+    <li><a href="https://github.com/nipy/nibabel">Git repository</a></li>
     <li><a href="http://mail.scipy.org/pipermail/nipy-devel">Mailing list archive</a></li>
 </ul>
 

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -4,7 +4,7 @@
 {% block rootrellink %}
   <li><a href="http://nipy.org/">Community</a> |&nbsp;</li>
   <li><a href="{{ pathto('index') }}">NiBabel Home</a> |&nbsp;</li>
-  <li><a href="http://projects.scipy.org/mailman/listinfo/nipy-devel">Mailing list</a> |&nbsp;</li>
+  <li><a href="http://mail.scipy.org/mailman/listinfo/nipy-devel">Mailing list</a> |&nbsp;</li>
   <li><a href="legal.html">License</a> |&nbsp;</li>
 {% endblock %}
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -252,7 +252,7 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/': None}
 
 # Config of plot_directive
 plot_include_source = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -216,6 +216,7 @@ html_show_sourcelink = True
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'nibabeldoc'
 
+mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/doc/source/devel/data_pkg_design.rst
+++ b/doc/source/devel/data_pkg_design.rst
@@ -288,7 +288,7 @@ There is an example nipy data package ``nipy-examplepkg`` in the
 ``examples`` directory of the NIPY repository.
 
 The machinery for creating and maintaining data packages is available at
-http://github.com/nipy/data-packaging.
+https://github.com/nipy/data-packaging.
 
 See the ``README.txt`` file there for more information.
 

--- a/doc/source/devel/data_pkg_discuss.rst
+++ b/doc/source/devel/data_pkg_discuss.rst
@@ -275,7 +275,7 @@ Issues
 ******
 
 From a brief scan of the `debian package management documentation
-<http://www.debian.org/doc/manuals/debian-reference/ch02.en.html>`_.
+<https://www.debian.org/doc/manuals/debian-reference/ch02.en.html>`_.
 
 Dependency management
 =====================
@@ -292,7 +292,7 @@ Authentication and validation
 For dependency and validation, see the `Debian secure apt`_ page. One related
 proposal would be:
 
-.. _Debian secure apt: http://wiki.debian.org/SecureApt
+.. _Debian secure apt: https://wiki.debian.org/SecureApt
 
 * Each package instantiation would carry a table of checksums for the files
   within.  Someone using this instantiation would check the checksums to confirm

--- a/doc/source/devel/make_release.rst
+++ b/doc/source/devel/make_release.rst
@@ -256,6 +256,6 @@ Release checklist
 
 * Announce to the mailing lists.
 
-.. _setuptools intro: http://packages.python.org/an_example_pypi_project/setuptools.html
+.. _setuptools intro: https://pythonhosted.org/an_example_pypi_project/setuptools.html
 
 .. include:: ../links_names.txt

--- a/doc/source/devel/make_release.rst
+++ b/doc/source/devel/make_release.rst
@@ -180,14 +180,14 @@ Release checklist
 
 * Force builds of the win32 and amd64 binaries from the buildbot. Go to pages:
 
-  * http://nipy.bic.berkeley.edu/builders/nibabel-bdist32-27
-  * http://nipy.bic.berkeley.edu/builders/nibabel-bdist32-34
-  * http://nipy.bic.berkeley.edu/builders/nibabel-bdist64-27
+  * https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-27
+  * https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-34
+  * https://nipy.bic.berkeley.edu/builders/nibabel-bdist64-27
 
   For each of these, enter the revision number (e.g. "2.0.0") in the field
   "Revision to build". Then get the built binaries in:
 
-  * http://nipy.bic.berkeley.edu/nibabel-dist
+  * https://nipy.bic.berkeley.edu/nibabel-dist
 
   and upload them to pypi with the admin files interface.
 

--- a/doc/source/dicom/dcm2nii_algorithms.rst
+++ b/doc/source/dicom/dcm2nii_algorithms.rst
@@ -9,7 +9,7 @@ by Chris Rorden, in Delphi (object orientated pascal).  It's part of
 Chris' popular mricron_ collection of programs.  The source appears to
 be best found on the `mricron NITRC site`_.  It's BSD_ licensed. 
 
-.. _mricron NITRC site: http://www.nitrc.org/projects/mricron
+.. _mricron NITRC site: https://www.nitrc.org/projects/mricron
 
 These are working notes looking at Chris' algorithms for working with
 DICOM.

--- a/doc/source/dicom/dicom_info.rst
+++ b/doc/source/dicom/dicom_info.rst
@@ -37,7 +37,7 @@ Here is a selected list of other tools and relevant resources:
   headers, and has been tested with Philips, GE and Siemens data. It's
   not clear whether it yet supports the :ref:`dicom-mosaic`.  BSD_ style
   license.
-* The famous Philips cookbook: http://www.archive.org/details/DicomCookbook
+* The famous Philips cookbook: https://www.archive.org/details/DicomCookbook
 * http://dicom.online.fr/fr/dicomlinks.htm
 
 ===============

--- a/doc/source/gitwash/development_workflow.rst
+++ b/doc/source/gitwash/development_workflow.rst
@@ -150,7 +150,7 @@ Ask for your changes to be reviewed or merged
 When you are ready to ask for someone to review your code and consider a merge:
 
 #. Go to the URL of your forked repo, say
-   ``http://github.com/your-user-name/nibabel``.
+   ``https://github.com/your-user-name/nibabel``.
 #. Use the 'Switch Branches' dropdown menu near the top left of the page to
    select the branch with your changes:
 
@@ -183,7 +183,7 @@ Delete a branch on github
    git push origin :my-unwanted-branch
 
 (Note the colon ``:`` before ``test-branch``.  See also:
-http://github.com/guides/remove-a-remote-branch
+https://github.com/guides/remove-a-remote-branch
 
 Several people sharing a single repository
 ------------------------------------------
@@ -195,7 +195,7 @@ share it via github.
 First fork nibabel into your account, as from :ref:`forking`.
 
 Then, go to your forked repository github page, say
-``http://github.com/your-user-name/nibabel``
+``https://github.com/your-user-name/nibabel``
 
 Click on the 'Admin' button, and add anyone else to the repo as a
 collaborator:

--- a/doc/source/gitwash/forking_hell.rst
+++ b/doc/source/gitwash/forking_hell.rst
@@ -5,9 +5,9 @@ Making your own copy (fork) of nibabel
 ==========================================
 
 You need to do this only once.  The instructions here are very similar
-to the instructions at http://help.github.com/forking/ |emdash| please see
-that page for more detail.  We're repeating some of it here just to give the
-specifics for the nibabel_ project, and to suggest some default names.
+to the instructions at https://help.github.com/articles/fork-a-repo/ |emdash|
+please see that page for more detail.  We're repeating some of it here just to
+give the specifics for the nibabel_ project, and to suggest some default names.
 
 Set up and configure a github account
 =====================================

--- a/doc/source/gitwash/git_install.rst
+++ b/doc/source/gitwash/git_install.rst
@@ -21,6 +21,6 @@ See the git page for the most recent information.
 
 Have a look at the github install help pages available from `github help`_
 
-There are good instructions here: http://book.git-scm.com/2_installing_git.html
+There are good instructions here: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 
 .. include:: links.inc

--- a/doc/source/gitwash/git_links.inc
+++ b/doc/source/gitwash/git_links.inc
@@ -12,22 +12,22 @@
 .. _git: https://git-scm.com/
 .. _github: https://github.com
 .. _github help: https://help.github.com
-.. _msysgit: http://code.google.com/p/msysgit/downloads/list
+.. _msysgit: https://msysgit.github.io/
 .. _git-osx-installer: https://code.google.com/p/git-osx-installer/downloads/list
-.. _subversion: http://subversion.tigris.org/
+.. _subversion: https://subversion.apache.org/
 .. _git cheat sheet: https://github.com/guides/git-cheat-sheet
 .. _pro git book: https://progit.org/
 .. _git svn crash course: https://git-scm.com/course/svn.html
-.. _learn.github: http://learn.github.com/
+.. _learn.github: https://guides.github.com/
 .. _network graph visualizer: https://github.com/blog/39-say-hello-to-the-network-graph-visualizer
 .. _git user manual: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html
 .. _git tutorial: https://www.kernel.org/pub/software/scm/git/docs/gittutorial.html
-.. _git community book: http://book.git-scm.com/
+.. _git community book: https://git-scm.com/book/en/v2
 .. _git ready: http://www.gitready.com/
 .. _git casts: http://www.gitcasts.com/
 .. _Fernando's git page: http://www.fperez.org/py4science/git.html
 .. _git magic: http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html
-.. _git concepts: http://www.eecs.harvard.edu/~cduan/technical/git/
+.. _git concepts: http://www.sbf5.com/~cduan/technical/git/
 .. _git clone: https://www.kernel.org/pub/software/scm/git/docs/git-clone.html
 .. _git checkout: https://www.kernel.org/pub/software/scm/git/docs/git-checkout.html
 .. _git commit: https://www.kernel.org/pub/software/scm/git/docs/git-commit.html
@@ -43,13 +43,13 @@
 .. _git config: https://www.kernel.org/pub/software/scm/git/docs/git-config.html
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
-.. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git 
+.. _tangled working copy problem: http://2ndscale.com/rtomayko/2008/the-thing-about-git
 .. _git management: http://kerneltrap.org/Linux/Git_Management
 .. _linux git workflow: https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
-.. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
-.. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html
-.. _rebase without tears: http://matthew-brett.github.com/pydagogue/rebase_without_tears.html
+.. _git foundation: https://matthew-brett.github.io/pydagogue/foundation.html
+.. _deleting master on github: https://matthew-brett.github.io/pydagogue/gh_delete_master.html
+.. _rebase without tears: https://matthew-brett.github.io/pydagogue/rebase_without_tears.html
 .. _resolving a merge: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#resolving-a-merge
 .. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
 

--- a/doc/source/gitwash/git_links.inc
+++ b/doc/source/gitwash/git_links.inc
@@ -9,52 +9,52 @@
    nipy, NIPY, Nipy, etc...
 
 .. git stuff
-.. _git: http://git-scm.com/
-.. _github: http://github.com
-.. _github help: http://help.github.com
+.. _git: https://git-scm.com/
+.. _github: https://github.com
+.. _github help: https://help.github.com
 .. _msysgit: http://code.google.com/p/msysgit/downloads/list
-.. _git-osx-installer: http://code.google.com/p/git-osx-installer/downloads/list
+.. _git-osx-installer: https://code.google.com/p/git-osx-installer/downloads/list
 .. _subversion: http://subversion.tigris.org/
-.. _git cheat sheet: http://github.com/guides/git-cheat-sheet
-.. _pro git book: http://progit.org/
-.. _git svn crash course: http://git-scm.com/course/svn.html
+.. _git cheat sheet: https://github.com/guides/git-cheat-sheet
+.. _pro git book: https://progit.org/
+.. _git svn crash course: https://git-scm.com/course/svn.html
 .. _learn.github: http://learn.github.com/
-.. _network graph visualizer: http://github.com/blog/39-say-hello-to-the-network-graph-visualizer
-.. _git user manual: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html
-.. _git tutorial: http://www.kernel.org/pub/software/scm/git/docs/gittutorial.html
+.. _network graph visualizer: https://github.com/blog/39-say-hello-to-the-network-graph-visualizer
+.. _git user manual: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html
+.. _git tutorial: https://www.kernel.org/pub/software/scm/git/docs/gittutorial.html
 .. _git community book: http://book.git-scm.com/
 .. _git ready: http://www.gitready.com/
 .. _git casts: http://www.gitcasts.com/
 .. _Fernando's git page: http://www.fperez.org/py4science/git.html
 .. _git magic: http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html
 .. _git concepts: http://www.eecs.harvard.edu/~cduan/technical/git/
-.. _git clone: http://www.kernel.org/pub/software/scm/git/docs/git-clone.html
-.. _git checkout: http://www.kernel.org/pub/software/scm/git/docs/git-checkout.html
-.. _git commit: http://www.kernel.org/pub/software/scm/git/docs/git-commit.html
-.. _git push: http://www.kernel.org/pub/software/scm/git/docs/git-push.html
-.. _git pull: http://www.kernel.org/pub/software/scm/git/docs/git-pull.html
-.. _git add: http://www.kernel.org/pub/software/scm/git/docs/git-add.html
-.. _git status: http://www.kernel.org/pub/software/scm/git/docs/git-status.html
-.. _git diff: http://www.kernel.org/pub/software/scm/git/docs/git-diff.html
-.. _git log: http://www.kernel.org/pub/software/scm/git/docs/git-log.html
-.. _git branch: http://www.kernel.org/pub/software/scm/git/docs/git-branch.html
-.. _git remote: http://www.kernel.org/pub/software/scm/git/docs/git-remote.html
-.. _git rebase: http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html
-.. _git config: http://www.kernel.org/pub/software/scm/git/docs/git-config.html
+.. _git clone: https://www.kernel.org/pub/software/scm/git/docs/git-clone.html
+.. _git checkout: https://www.kernel.org/pub/software/scm/git/docs/git-checkout.html
+.. _git commit: https://www.kernel.org/pub/software/scm/git/docs/git-commit.html
+.. _git push: https://www.kernel.org/pub/software/scm/git/docs/git-push.html
+.. _git pull: https://www.kernel.org/pub/software/scm/git/docs/git-pull.html
+.. _git add: https://www.kernel.org/pub/software/scm/git/docs/git-add.html
+.. _git status: https://www.kernel.org/pub/software/scm/git/docs/git-status.html
+.. _git diff: https://www.kernel.org/pub/software/scm/git/docs/git-diff.html
+.. _git log: https://www.kernel.org/pub/software/scm/git/docs/git-log.html
+.. _git branch: https://www.kernel.org/pub/software/scm/git/docs/git-branch.html
+.. _git remote: https://www.kernel.org/pub/software/scm/git/docs/git-remote.html
+.. _git rebase: https://www.kernel.org/pub/software/scm/git/docs/git-rebase.html
+.. _git config: https://www.kernel.org/pub/software/scm/git/docs/git-config.html
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git 
 .. _git management: http://kerneltrap.org/Linux/Git_Management
-.. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
+.. _linux git workflow: https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
 .. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html
 .. _rebase without tears: http://matthew-brett.github.com/pydagogue/rebase_without_tears.html
-.. _resolving a merge: http://www.kernel.org/pub/software/scm/git/docs/user-manual.html#resolving-a-merge
+.. _resolving a merge: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#resolving-a-merge
 .. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
 
 .. other stuff
-.. _python: http://www.python.org
+.. _python: https://www.python.org
 
 .. |emdash| unicode:: U+02014
 

--- a/doc/source/gitwash/known_projects.inc
+++ b/doc/source/gitwash/known_projects.inc
@@ -1,17 +1,17 @@
 .. Known projects
 
 .. PROJECTNAME placeholders
-.. _PROJECTNAME: http://neuroimaging.scipy.org
+.. _PROJECTNAME: http://nipy.org
 .. _`PROJECTNAME github`: https://github.com/nipy
-.. _`PROJECTNAME mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
+.. _`PROJECTNAME mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. numpy
-.. _numpy: hhttp://numpy.scipy.org
+.. _numpy: http://www.numpy.org
 .. _`numpy github`: https://github.com/numpy/numpy
 .. _`numpy mailing list`: http://mail.scipy.org/mailman/listinfo/numpy-discussion
 
 .. scipy
-.. _scipy: http://www.scipy.org
+.. _scipy: https://www.scipy.org
 .. _`scipy github`: https://github.com/scipy/scipy
 .. _`scipy mailing list`: http://mail.scipy.org/mailman/listinfo/scipy-dev
 
@@ -21,7 +21,7 @@
 .. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. ipython
-.. _ipython: http://ipython.scipy.org
+.. _ipython: https://ipython.org
 .. _`ipython github`: https://github.com/ipython/ipython
 .. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
 

--- a/doc/source/gitwash/known_projects.inc
+++ b/doc/source/gitwash/known_projects.inc
@@ -2,40 +2,40 @@
 
 .. PROJECTNAME placeholders
 .. _PROJECTNAME: http://neuroimaging.scipy.org
-.. _`PROJECTNAME github`: http://github.com/nipy
+.. _`PROJECTNAME github`: https://github.com/nipy
 .. _`PROJECTNAME mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
 
 .. numpy
 .. _numpy: hhttp://numpy.scipy.org
-.. _`numpy github`: http://github.com/numpy/numpy
+.. _`numpy github`: https://github.com/numpy/numpy
 .. _`numpy mailing list`: http://mail.scipy.org/mailman/listinfo/numpy-discussion
 
 .. scipy
 .. _scipy: http://www.scipy.org
-.. _`scipy github`: http://github.com/scipy/scipy
+.. _`scipy github`: https://github.com/scipy/scipy
 .. _`scipy mailing list`: http://mail.scipy.org/mailman/listinfo/scipy-dev
 
 .. nipy
 .. _nipy: http://nipy.org/nipy
-.. _`nipy github`: http://github.com/nipy/nipy
+.. _`nipy github`: https://github.com/nipy/nipy
 .. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. ipython
 .. _ipython: http://ipython.scipy.org
-.. _`ipython github`: http://github.com/ipython/ipython
+.. _`ipython github`: https://github.com/ipython/ipython
 .. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
 
 .. dipy
 .. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
+.. _`dipy github`: https://github.com/Garyfallidis/dipy
 .. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. nibabel
 .. _nibabel: http://nipy.org/nibabel
-.. _`nibabel github`: http://github.com/nipy/nibabel
+.. _`nibabel github`: https://github.com/nipy/nibabel
 .. _`nibabel mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. marsbar
 .. _marsbar: http://marsbar.sourceforge.net
-.. _`marsbar github`: http://github.com/matthew-brett/marsbar
+.. _`marsbar github`: https://github.com/matthew-brett/marsbar
 .. _`MarsBaR mailing list`: https://lists.sourceforge.net/lists/listinfo/marsbar-users

--- a/doc/source/links_names.txt
+++ b/doc/source/links_names.txt
@@ -14,25 +14,25 @@
 
 .. nibabel
 .. _nibabel: http://nipy.org/nibabel
-.. _`nibabel github`: http://github.com/nipy/nibabel
+.. _`nibabel github`: https://github.com/nipy/nibabel
 .. _`nibabel mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-.. _nibabel pypi: http://pypi.python.org/pypi/nibabel
-.. _nibabel issues: http://github.com/nipy/nibabel/issues
-.. _nibabel github issues: http://github.com/nipy/nibabel/issues
+.. _nibabel pypi: https://pypi.python.org/pypi/nibabel
+.. _nibabel issues: https://github.com/nipy/nibabel/issues
+.. _nibabel github issues: https://github.com/nipy/nibabel/issues
 .. _nibabel wiki: https://github.com/nipy/nibabel.wiki
-.. _nibabel on travis: http://travis-ci.org/nipy/nibabel
+.. _nibabel on travis: https://travis-ci.org/nipy/nibabel
 
 .. other related projects
 .. _nipy community: http://nipy.org
 .. _nipy: http://nipy.org/nipy
 .. _`Brain Imaging Center`: http://bic.berkeley.edu/
 .. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
+.. _`dipy github`: https://github.com/Garyfallidis/dipy
 .. _nibabel: http://nipy.org/nibabel
 .. _nipy development guidelines: http://nipy.org/devel
-.. _`nipy github`: http://github.com/nipy/nipy
-.. _nipy buildbot: http://nipy.bic.berkeley.edu
-.. _travis-ci: http://travis-ci.org
+.. _`nipy github`: https://github.com/nipy/nipy
+.. _nipy buildbot: https://nipy.bic.berkeley.edu
+.. _travis-ci: https://travis-ci.org
 .. _nibotmi: https://github.com/nipy/nibotmi
 
 .. Documentation tools
@@ -44,16 +44,16 @@
 .. _IPython notebook viewer: http://nbviewer.ipython.org
 
 .. Licenses
-.. _GPL: http://www.gnu.org/licenses/gpl.html
+.. _GPL: https://www.gnu.org/licenses/gpl.html
 .. _BSD: http://www.opensource.org/licenses/bsd-license.php
-.. _LGPL: http://www.gnu.org/copyleft/lesser.html
+.. _LGPL: https://www.gnu.org/copyleft/lesser.html
 .. _MIT License: http://www.opensource.org/licenses/mit-license.php
 .. _PDDL 1.0: http://opendatacommons.org/licenses/pddl/1.0/
 .. _CC0: http://opendefinition.org/licenses/cc-zero
 
 
 .. Installation
-.. _pypi: http://pypi.python.org/pypi
+.. _pypi: https://pypi.python.org/pypi
 
 .. Working process
 .. _pynifti: http://niftilib.sourceforge.net/pynifti/
@@ -72,8 +72,8 @@
 .. _pychecker: http://pychecker.sourceforge.net/
 .. _pylint: http://www.logilab.org/project/pylint
 .. _pyflakes: http://divmod.org/trac/wiki/DivmodPyflakes
-.. _virtualenv: http://pypi.python.org/pypi/virtualenv
-.. _github: http://github.com
+.. _virtualenv: https://pypi.python.org/pypi/virtualenv
+.. _github: https://github.com
 .. _flymake: http://flymake.sourceforge.net/
 .. _rope: http://rope.sourceforge.net/
 .. _pymacs: http://pymacs.progiciels-bpi.ca/pymacs.html
@@ -83,13 +83,13 @@
 .. _doctest-mode: http://www.cis.upenn.edu/~edloper/projects/doctestmode/
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose
 .. _`python coverage tester`: http://nedbatchelder.com/code/modules/coverage.html
-.. _bitbucket: http://bitbucket.org
+.. _bitbucket: https://bitbucket.org
 
 .. Other python projects
 .. _numpy: http://www.scipy.org/NumPy
-.. _scipy: http://www.scipy.org
+.. _scipy: https://www.scipy.org
 .. _ipython: http://ipython.scipy.org
-.. _`ipython github`: http://github.com/ipython/ipython
+.. _`ipython github`: https://github.com/ipython/ipython
 .. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
 .. _`ipython manual`: http://ipython.scipy.org/doc/manual/html
 .. _matplotlib: http://matplotlib.sourceforge.net
@@ -97,11 +97,11 @@
 .. _EPD: http://www.enthought.com/products/epd.php
 .. _ETS: http://code.enthought.com/projects/tool-suite.php
 .. _`Enthought Tool Suite`: http://code.enthought.com/projects/tool-suite.php
-.. _python: http://www.python.org
+.. _python: https://www.python.org
 .. _mayavi: http://mayavi.sourceforge.net/
 .. _sympy: http://code.google.com/p/sympy/
 .. _networkx: http://networkx.lanl.gov/
-.. _setuptools: http://pypi.python.org/pypi/setuptools
+.. _setuptools: https://pypi.python.org/pypi/setuptools
 .. _distribute: http://packages.python.org/distribute
 .. _pip: https://pip.readthedocs.org/en/latest
 .. _pip install instructions:
@@ -117,20 +117,20 @@
 .. _pydicom: http://code.google.com/p/pydicom/
 
 .. Not so python imaging projects
-.. _matlab: http://www.mathworks.com
+.. _matlab: https://www.mathworks.com
 .. _spm: http://www.fil.ion.ucl.ac.uk/spm
 .. _spm8: http://www.fil.ion.ucl.ac.uk/spm/software/spm8
 .. _eeglab: http://sccn.ucsd.edu/eeglab
 .. _AFNI: http://afni.nimh.nih.gov/afni
 .. _FSL: http://www.fmrib.ox.ac.uk/fsl
-.. _FreeSurfer: http://surfer.nmr.mgh.harvard.edu
+.. _FreeSurfer: https://surfer.nmr.mgh.harvard.edu
 .. _voxbo: http://www.voxbo.org
 .. _mricron: http://www.cabiatl.com/mricro/mricron
 .. _slicer: http://www.slicer.org/
 
 .. File formats
 .. _DICOM: http://medical.nema.org/
-.. _`wikipedia DICOM`: http://en.wikipedia.org/wiki/Digital_Imaging_and_Communications_in_Medicine
+.. _`wikipedia DICOM`: https://en.wikipedia.org/wiki/Digital_Imaging_and_Communications_in_Medicine
 .. _GDCM: http://sourceforge.net/apps/mediawiki/gdcm
 .. _DICOM standard : http://medical.nema.org/standard.html
 .. _PS 3.1: http://medical.nema.org/Dicom/2011/11_01pu.pdf
@@ -162,67 +162,67 @@
 .. _Nrrd: http://teem.sourceforge.net/nrrd/format.html
 
 .. General software
-.. _gcc: http://gcc.gnu.org
-.. _xcode: http://developer.apple.com/TOOLS/xcode
+.. _gcc: https://gcc.gnu.org
+.. _xcode: https://developer.apple.com/TOOLS/xcode
 .. _mingw: http://www.mingw.org
-.. _cygwin: http://cygwin.com
-.. _macports: http://www.macports.org/
+.. _cygwin: https://cygwin.com
+.. _macports: https://www.macports.org/
 .. _VTK: http://www.vtk.org/
 .. _ITK: http://www.itk.org/
 .. _swig: http://www.swig.org
 
 .. version control
-.. _git: http://git-scm.com
-.. _mercurial: http://mercurial.selenic.com
+.. _git: https://git-scm.com
+.. _mercurial: https://mercurial.selenic.com
 .. _bzr: http://bazaar.canonical.com
-.. _subversion: http://subversion.apache.org
+.. _subversion: https://subversion.apache.org
 
 .. Functional imaging labs
 .. _`functional imaging laboratory`: http://www.fil.ion.ucl.ac.uk
 .. _FMRIB: http://www.fmrib.ox.ac.uk
 
 .. Other organizations
-.. _enthought: <http://www.enthought.com>
+.. _enthought: <https://www.enthought.com>
 .. _kitware: http://www.kitware.com
 .. _NeuroDebian: http://neuro.debian.net
 .. _nibabel NeuroDebian: http://neuro.debian.net/pkgs/python-nibabel.html
-.. _nitrc: http://www.nitrc.org
+.. _nitrc: https://www.nitrc.org
 
 .. General information links
-.. _`wikipedia FMRI`: http://en.wikipedia.org/wiki/Functional_magnetic_resonance_imaging
-.. _`wikipedia PET`: http://en.wikipedia.org/wiki/Positron_emission_tomography
+.. _`wikipedia FMRI`: https://en.wikipedia.org/wiki/Functional_magnetic_resonance_imaging
+.. _`wikipedia PET`: https://en.wikipedia.org/wiki/Positron_emission_tomography
 .. _ANALYZE: http://www.grahamwideman.com/gw/brain/analyze/formatdoc.htm
 .. _NIfTI1: http://nifti.nimh.nih.gov/nifti-1/
 .. _NIfTI2: http://nifti.nimh.nih.gov/nifti-2/
 .. _MINC: http://wiki.bic.mni.mcgill.ca/index.php/MINC
-.. _GIFTI: http://www.nitrc.org/projects/gifti
+.. _GIFTI: https://www.nitrc.org/projects/gifti
 .. _MINC1:
     https://en.wikibooks.org/wiki/MINC/Reference/MINC1_File_Format_Reference
 .. _MINC2:
     https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference
 
 .. Mathematical methods
-.. _`wikipedia ICA`: http://en.wikipedia.org/wiki/Independent_component_analysis
-.. _`wikipedia PCA`: http://en.wikipedia.org/wiki/Principal_component_analysis
+.. _`wikipedia ICA`: https://en.wikipedia.org/wiki/Independent_component_analysis
+.. _`wikipedia PCA`: https://en.wikipedia.org/wiki/Principal_component_analysis
 
 .. Mathematical ideas
-.. _`wikipedia spherical coordinate system`: http://en.wikipedia.org/wiki/Spherical_coordinate_system
+.. _`wikipedia spherical coordinate system`: https://en.wikipedia.org/wiki/Spherical_coordinate_system
 .. _`mathworld spherical coordinate system`: http://mathworld.wolfram.com/SphericalCoordinates.html
-.. _`wikipedia affine`: http://en.wikipedia.org/wiki/Affine_transformation
-.. _`wikipedia affine transform`: http://en.wikipedia.org/wiki/Affine_transformation
-.. _`wikipedia linear transform`: http://en.wikipedia.org/wiki/Linear_transformation
-.. _`wikipedia rotation matrix`: http://en.wikipedia.org/wiki/Rotation_matrix
-.. _`wikipedia homogenous coordinates`: http://en.wikipedia.org/wiki/Homogeneous_coordinates
-.. _`wikipedia axis angle`: http://en.wikipedia.org/wiki/Axis_angle
-.. _`wikipedia Euler angles`: http://en.wikipedia.org/wiki/Euler_angles
+.. _`wikipedia affine`: https://en.wikipedia.org/wiki/Affine_transformation
+.. _`wikipedia affine transform`: https://en.wikipedia.org/wiki/Affine_transformation
+.. _`wikipedia linear transform`: https://en.wikipedia.org/wiki/Linear_transformation
+.. _`wikipedia rotation matrix`: https://en.wikipedia.org/wiki/Rotation_matrix
+.. _`wikipedia homogenous coordinates`: https://en.wikipedia.org/wiki/Homogeneous_coordinates
+.. _`wikipedia axis angle`: https://en.wikipedia.org/wiki/Axis_angle
+.. _`wikipedia Euler angles`: https://en.wikipedia.org/wiki/Euler_angles
 .. _`Mathworld Euler angles`: http://mathworld.wolfram.com/EulerAngles.html
-.. _`wikipedia quaternion`: http://en.wikipedia.org/wiki/Quaternion
-.. _`wikipedia shear matrix`: http://en.wikipedia.org/wiki/Shear_matrix
-.. _`wikipedia reflection`: http://en.wikipedia.org/wiki/Reflection_(mathematics)
-.. _`wikipedia direction cosine`: http://en.wikipedia.org/wiki/Direction_cosine
+.. _`wikipedia quaternion`: https://en.wikipedia.org/wiki/Quaternion
+.. _`wikipedia shear matrix`: https://en.wikipedia.org/wiki/Shear_matrix
+.. _`wikipedia reflection`: https://en.wikipedia.org/wiki/Reflection_(mathematics)
+.. _`wikipedia direction cosine`: https://en.wikipedia.org/wiki/Direction_cosine
 
 .. Programming ideas
-.. _proxy: http://en.wikipedia.org/wiki/Proxy_pattern
+.. _proxy: https://en.wikipedia.org/wiki/Proxy_pattern
 
 .. philosophy
 .. _0SAGA: http://nipyworld.blogspot.com/2010/11/0saga-software-model.html

--- a/doc/source/links_names.txt
+++ b/doc/source/links_names.txt
@@ -37,8 +37,8 @@
 
 .. Documentation tools
 .. _graphviz: http://www.graphviz.org/
-.. _Sphinx: http://sphinx.pocoo.org/
-.. _`Sphinx reST`: http://sphinx.pocoo.org/rest.html
+.. _Sphinx: http://sphinx-doc.org/
+.. _`Sphinx reST`: http://sphinx-doc.org/rest.html
 .. _reST: http://docutils.sourceforge.net/rst.html
 .. _docutils: http://docutils.sourceforge.net
 .. _IPython notebook viewer: http://nbviewer.ipython.org
@@ -63,16 +63,16 @@
 .. _sourceforge: http://nipy.sourceforge.net/
 .. _`nipy launchpad`: https://launchpad.net/nipy
 .. _launchpad: https://launchpad.net/
-.. _`nipy trunk`: http://code.launchpad.net/~nipy-developers/nipy/trunk
-.. _`nipy mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
-.. _`nipy bugs`: https://bugs.launchpad.net/nipy
-.. _sourceforge download page: http://sourceforge.net/projects/nipy/files
+.. _`nipy trunk`: https://github.com/nipy/nipy/tree/master
+.. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
+.. _`nipy bugs`: https://github.com/nipy/nipy/issues
+.. _sourceforge download page: https://github.com/nipy/nipy/releases
 
 .. Code support stuff
 .. _pychecker: http://pychecker.sourceforge.net/
-.. _pylint: http://www.logilab.org/project/pylint
-.. _pyflakes: http://divmod.org/trac/wiki/DivmodPyflakes
-.. _virtualenv: https://pypi.python.org/pypi/virtualenv
+.. _pylint: https://bitbucket.org/logilab/pylint/
+.. _pyflakes: https://github.com/pyflakes/pyflakes
+.. _virtualenv: https://virtualenv.pypa.io/en/latest/
 .. _github: https://github.com
 .. _flymake: http://flymake.sourceforge.net/
 .. _rope: http://rope.sourceforge.net/
@@ -80,41 +80,41 @@
 .. _ropemacs: http://rope.sourceforge.net/ropemacs.html
 .. _ECB: http://ecb.sourceforge.net/
 .. _emacs_python_mode: http://www.emacswiki.org/cgi-bin/wiki/PythonMode
-.. _doctest-mode: http://www.cis.upenn.edu/~edloper/projects/doctestmode/
+.. _doctest-mode: http://ed.loper.org/projects/doctestmode/
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose
-.. _`python coverage tester`: http://nedbatchelder.com/code/modules/coverage.html
+.. _`python coverage tester`: http://nedbatchelder.com/code/coverage/
 .. _bitbucket: https://bitbucket.org
 
 .. Other python projects
-.. _numpy: http://www.scipy.org/NumPy
+.. _numpy: http://www.numpy.org
 .. _scipy: https://www.scipy.org
-.. _ipython: http://ipython.scipy.org
+.. _ipython: https://ipython.org
 .. _`ipython github`: https://github.com/ipython/ipython
 .. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
-.. _`ipython manual`: http://ipython.scipy.org/doc/manual/html
-.. _matplotlib: http://matplotlib.sourceforge.net
+.. _`ipython manual`: https://ipython.org/ipython-doc/stable/index.html
+.. _matplotlib: http://matplotlib.org/
 .. _pythonxy: http://www.pythonxy.com
-.. _EPD: http://www.enthought.com/products/epd.php
-.. _ETS: http://code.enthought.com/projects/tool-suite.php
-.. _`Enthought Tool Suite`: http://code.enthought.com/projects/tool-suite.php
+.. _EPD: https://www.enthought.com/products/epd/
+.. _ETS: http://code.enthought.com/
+.. _`Enthought Tool Suite`: http://code.enthought.com/
 .. _python: https://www.python.org
 .. _mayavi: http://mayavi.sourceforge.net/
-.. _sympy: http://code.google.com/p/sympy/
-.. _networkx: http://networkx.lanl.gov/
+.. _sympy: http://www.sympy.org/
+.. _networkx: https://networkx.github.io/
 .. _setuptools: https://pypi.python.org/pypi/setuptools
-.. _distribute: http://packages.python.org/distribute
+.. _distribute: https://pythonhosted.org/distribute
 .. _pip: https://pip.readthedocs.org/en/latest
 .. _pip install instructions:
    https://pip.readthedocs.org/en/latest/installing.html
 .. _twine: https://pypi.python.org/pypi/twine
-.. _datapkg: http://okfn.org/projects/datapkg
-.. _python imaging library: http://www.pythonware.com
+.. _datapkg: https://pythonhosted.org/datapkg/
+.. _python imaging library: http://pythonware.com/products/pil/
 
 .. Python imaging projects
 .. _PyMVPA: http://www.pymvpa.org
 .. _BrainVISA: http://brainvisa.info
 .. _anatomist: http://brainvisa.info
-.. _pydicom: http://code.google.com/p/pydicom/
+.. _pydicom: http://www.pydicom.org/
 
 .. Not so python imaging projects
 .. _matlab: https://www.mathworks.com
@@ -124,14 +124,14 @@
 .. _AFNI: http://afni.nimh.nih.gov/afni
 .. _FSL: http://www.fmrib.ox.ac.uk/fsl
 .. _FreeSurfer: https://surfer.nmr.mgh.harvard.edu
-.. _voxbo: http://www.voxbo.org
-.. _mricron: http://www.cabiatl.com/mricro/mricron
+.. _voxbo: https://www.nitrc.org/projects/voxbo/
+.. _mricron: http://www.mccauslandcenter.sc.edu/mricro/mricron/
 .. _slicer: http://www.slicer.org/
 
 .. File formats
 .. _DICOM: http://medical.nema.org/
 .. _`wikipedia DICOM`: https://en.wikipedia.org/wiki/Digital_Imaging_and_Communications_in_Medicine
-.. _GDCM: http://sourceforge.net/apps/mediawiki/gdcm
+.. _GDCM: http://gdcm.sourceforge.net/wiki/
 .. _DICOM standard : http://medical.nema.org/standard.html
 .. _PS 3.1: http://medical.nema.org/Dicom/2011/11_01pu.pdf
 .. _PS 3.2: http://medical.nema.org/Dicom/2011/11_02pu.pdf
@@ -194,7 +194,7 @@
 .. _ANALYZE: http://www.grahamwideman.com/gw/brain/analyze/formatdoc.htm
 .. _NIfTI1: http://nifti.nimh.nih.gov/nifti-1/
 .. _NIfTI2: http://nifti.nimh.nih.gov/nifti-2/
-.. _MINC: http://wiki.bic.mni.mcgill.ca/index.php/MINC
+.. _MINC: https://www.mcgill.ca/bic/software/minc
 .. _GIFTI: https://www.nitrc.org/projects/gifti
 .. _MINC1:
     https://en.wikibooks.org/wiki/MINC/Reference/MINC1_File_Format_Reference

--- a/doc/source/notebooks/ata_error.ipynb
+++ b/doc/source/notebooks/ata_error.ipynb
@@ -204,7 +204,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "$\\Sigma_i r_{i, k}$ is the column sum for column $k$ of $R$.  We know that the column $L^2$ norms of $R$ are each 1.  We know $\\|x\\|_1 \\leq \\sqrt{n}\\|x\\|_2$ - http://en.wikipedia.org/wiki/Lp_space. Therefore the column sums must be $\\le \\sqrt{N}$.  Therefore the maximum error for the diagonal of $T$ is $\\sqrt{N} 2\\delta$."
+      "$\\Sigma_i r_{i, k}$ is the column sum for column $k$ of $R$.  We know that the column $L^2$ norms of $R$ are each 1.  We know $\\|x\\|_1 \\leq \\sqrt{n}\\|x\\|_2$ - https://en.wikipedia.org/wiki/Lp_space. Therefore the column sums must be $\\le \\sqrt{N}$.  Therefore the maximum error for the diagonal of $T$ is $\\sqrt{N} 2\\delta$."
      ]
     },
     {

--- a/doc/source/notebooks/ata_error.ipynb
+++ b/doc/source/notebooks/ata_error.ipynb
@@ -225,7 +225,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Now consider the floating point calculation error.  This depends on the floating point representation we use for the calculations. Let $\\epsilon = x-1$ where $x$ is the smallest number greater than 1 that is representable in our floating point format (see http://matthew-brett.github.com/pydagogue/floating_error.html). The largest error for a calculation resulting in a value near 1 is $\\frac{\\epsilon}{2}$. For the diagonal values, the calculation error will be the error for the $r_{i,*} r_{i, *}'$ dot product.  This comprises $N$ scalar products with results each bounded by 1 ($r_{i, j} r_{i, j}$) followed by $N-1$ sums each bounded by 1.  Maximum error is therefore $(2N-1) \\frac{\\epsilon}{2}$ = $\\frac{5}{2} \\epsilon$ where $N=3$."
+      "Now consider the floating point calculation error.  This depends on the floating point representation we use for the calculations. Let $\\epsilon = x-1$ where $x$ is the smallest number greater than 1 that is representable in our floating point format (see https://matthew-brett.github.io/pydagogue/floating_error.html). The largest error for a calculation resulting in a value near 1 is $\\frac{\\epsilon}{2}$. For the diagonal values, the calculation error will be the error for the $r_{i,*} r_{i, *}'$ dot product.  This comprises $N$ scalar products with results each bounded by 1 ($r_{i, j} r_{i, j}$) followed by $N-1$ sums each bounded by 1.  Maximum error is therefore $(2N-1) \\frac{\\epsilon}{2}$ = $\\frac{5}{2} \\epsilon$ where $N=3$."
      ]
     },
     {

--- a/doc/source/old/format_design.txt
+++ b/doc/source/old/format_design.txt
@@ -9,9 +9,9 @@
 The Image object contains (*has a*) Format object.
 
 The Image and the Format objects form a `bridge pattern
-<http://en.wikipedia.org/wiki/Bridge_pattern>`_.  In the `wikipedia
+<https://en.wikipedia.org/wiki/Bridge_pattern>`_.  In the `wikipedia
 diagram
-<http://en.wikipedia.org/wiki/File:Bridge_UML_class_diagram.svg>`_ the
+<https://en.wikipedia.org/wiki/File:Bridge_UML_class_diagram.svg>`_ the
 Image class plays the role of the Abstraction, and the Format plays the
 role of the implementor.
 

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -79,7 +79,7 @@ def float_to_int(arr, int_type, nan2zero=True, infmax=False):
     Hence we threshold at ``shared_min`` and ``shared_max`` to avoid casting to
     values that are undefined.
 
-    See: http://en.wikipedia.org/wiki/C99 . There are links to the C99 standard
+    See: https://en.wikipedia.org/wiki/C99 . There are links to the C99 standard
     from that page.
     """
     arr = np.asarray(arr)
@@ -601,7 +601,7 @@ def int_abs(arr):
 def floor_log2(x):
     """ floor of log2 of abs(`x`)
 
-    Embarrassingly, from http://en.wikipedia.org/wiki/Binary_logarithm
+    Embarrassingly, from https://en.wikipedia.org/wiki/Binary_logarithm
 
     Parameters
     ----------

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -215,7 +215,7 @@ def type_info(np_type):
     Notes
     -----
     You might be thinking that ``np.finfo`` does this job, and it does, except
-    for PPC long doubles (http://projects.scipy.org/numpy/ticket/2077) and
+    for PPC long doubles (https://github.com/numpy/numpy/issues/2669) and
     float96 on Windows compiled with Mingw. This routine protects against such
     errors in ``np.finfo`` by only accepting values that we know are likely to
     be correct.
@@ -285,7 +285,7 @@ def type_info(np_type):
         # seems to break here too, so we need to use np.longdouble and
         # complexify
         two = np.longdouble(2)
-        # See: http://matthew-brett.github.com/pydagogue/floating_point.html
+        # See: https://matthew-brett.github.io/pydagogue/floating_point.html
         max_val = (two ** 113 - 1) / (two ** 112) * two ** 16383
         if np_type is np.longcomplex:
             max_val += 0j

--- a/nibabel/data.py
+++ b/nibabel/data.py
@@ -189,8 +189,8 @@ def get_data_path():
     because Debian has patched distutils in Python 2.6 to do default
     distutils installs there:
 
-    * http://www.debian.org/doc/packaging-manuals/python-policy/ap-packaging_tools.html#s-distutils
-    * http://www.mail-archive.com/debian-python@lists.debian.org/msg05084.html
+    * https://www.debian.org/doc/packaging-manuals/python-policy/ap-packaging_tools.html#s-distutils
+    * https://www.mail-archive.com/debian-python@lists.debian.org/msg05084.html
     '''
     paths = []
     try:

--- a/nibabel/eulerangles.py
+++ b/nibabel/eulerangles.py
@@ -10,8 +10,8 @@
 
 See:
 
-* http://en.wikipedia.org/wiki/Rotation_matrix
-* http://en.wikipedia.org/wiki/Euler_angles
+* https://en.wikipedia.org/wiki/Rotation_matrix
+* https://en.wikipedia.org/wiki/Euler_angles
 * http://mathworld.wolfram.com/EulerAngles.html
 
 See also: *Representing Attitude with Euler Angles and Quaternions: A
@@ -61,7 +61,7 @@ rotation matrix, we need to define:
   vectors move within the axis frame (extrinsic)
 * the handedness of the coordinate system
 
-See: http://en.wikipedia.org/wiki/Rotation_matrix#Ambiguities
+See: https://en.wikipedia.org/wiki/Rotation_matrix#Ambiguities
 
 We are using the following conventions:
 
@@ -295,7 +295,7 @@ def euler2quat(z=0, y=0, x=0):
     2. Generated formulae from 1.) for quaternions corresponding to
        theta radians rotations about ``x, y, z`` axes
     3. Apply quaternion multiplication formula -
-       http://en.wikipedia.org/wiki/Quaternions#Hamilton_product - to
+       https://en.wikipedia.org/wiki/Quaternions#Hamilton_product - to
        formulae from 2.) to give formula for combined rotations.
     '''
     z = z/2.0

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -105,7 +105,7 @@ class netcdf_file(object):
     version : {1, 2}, optional
         version of netcdf to read / write, where 1 means *Classic
         format* and 2 means *64-bit offset format*.  Default is 1.  See
-        `here <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf/Which-Format.html>`_
+        `here <https://www.unidata.ucar.edu/software/netcdf/docs/netcdf/Which-Format.html>`_
         for more info.
 
     Notes
@@ -117,7 +117,7 @@ class netcdf_file(object):
     NetCDF files are a self-describing binary data format. The file contains
     metadata that describes the dimensions and variables in the file. More
     details about NetCDF files can be found `here
-    <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`_. There
+    <https://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`_. There
     are three main sections to a NetCDF data structure:
 
     1. Dimensions
@@ -562,7 +562,7 @@ class netcdf_file(object):
         for var in range(count):
             (name, dimensions, shape, attributes,
              typecode, size, dtype_, begin_, vsize) = self._read_var()
-            # http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
+            # https://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
             # Note that vsize is the product of the dimension lengths
             # (omitting the record dimension) and the number of bytes
             # per value (determined from the type), increased to the

--- a/nibabel/externals/tests/test_netcdf.py
+++ b/nibabel/externals/tests/test_netcdf.py
@@ -72,7 +72,7 @@ def test_read_write_files():
         # mmap.  When n * n_bytes(var_type) is not divisible by 4, this
         # raised an error in pupynere 1.0.12 and scipy rev 5893, because
         # calculated vsize was rounding up in units of 4 - see
-        # http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
+        # https://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html
         fobj = open('simple.nc', 'rb')
         with netcdf_file(fobj) as f:
             # by default, don't use mmap for file-like

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -241,7 +241,7 @@ def write_annot(filepath, labels, ctab, names):
     """Write out a Freesurfer annotation file.
 
     See:
-    http://ftp.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
+    https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
 
     Parameters
     ----------

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -20,7 +20,7 @@ from ..arrayproxy import ArrayProxy
 from ..keywordonly import kw_only_meth
 
 # mgh header
-# See http://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat
+# See https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat
 DATA_OFFSET = 284
 # Note that mgh data is strictly big endian ( hence the > sign )
 header_dtd = [
@@ -253,7 +253,7 @@ class MGHHeader(object):
 
     def get_vox2ras_tkr(self):
         ''' Get the vox2ras-tkr transform. See "Torig" here:
-                http://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems
+                https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems
         '''
         ds = np.array(self._header_data['delta'])
         ns = (np.array(self._header_data['dims'][:3]) * ds) / 2.0

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -49,7 +49,7 @@ def read_data_block(encoding, endian, ordering, datatype, shape, data):
     elif enclabel == 'B64GZ':
         # GIFTI_ENCODING_B64GZ
         # convert to bytes array for python 3.2
-        # http://diveintopython3.org/strings.html#byte-arrays
+        # http://www.diveintopython3.net/strings.html#byte-arrays
         dec = base64.b64decode(data.encode('ascii'))
         zdec = zlib.decompress(dec)
         dt = data_type_codes.type[datatype]

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -55,10 +55,10 @@ DICOM_.  NiBabel is the successor of PyNIfTI_.
 .. _MINC2:
     https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference
 .. _PyNIfTI: http://niftilib.sourceforge.net/pynifti/
-.. _GIFTI: http://www.nitrc.org/projects/gifti
-.. _MGH: http://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat
+.. _GIFTI: https://www.nitrc.org/projects/gifti
+.. _MGH: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat
 .. _ECAT: http://xmedcon.sourceforge.net/Docs/Ecat
-.. _Freesurfer: http://surfer.nmr.mgh.harvard.edu
+.. _Freesurfer: https://surfer.nmr.mgh.harvard.edu
 .. _DICOM: http://medical.nema.org/
 
 The various image format classes give full or selective access to header (meta)
@@ -88,7 +88,7 @@ You can find our sources and single-click downloads:
 * Download `current development version`_ as a zip file;
 * Downloads of all `available releases`_.
 
-.. _main repository: http://github.com/nipy/nibabel
+.. _main repository: https://github.com/nipy/nibabel
 .. _Documentation: http://nipy.org/nibabel
 .. _current release: https://pypi.python.org/pypi/nibabel
 .. _current development version: https://github.com/nipy/nibabel/archive/master.zip
@@ -113,7 +113,7 @@ MAINTAINER_EMAIL    = "nipy-devel@neuroimaging.scipy.org"
 DESCRIPTION         = description
 LONG_DESCRIPTION    = long_description
 URL                 = "http://nipy.org/nibabel"
-DOWNLOAD_URL        = "http://github.com/nipy/nibabel"
+DOWNLOAD_URL        = "https://github.com/nipy/nibabel"
 LICENSE             = "MIT license"
 CLASSIFIERS         = CLASSIFIERS
 AUTHOR              = "Matthew Brett, Michael Hanke, Stephan Gerhard"

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -68,7 +68,7 @@ Website
 =======
 
 Current documentation on nibabel can always be found at the `NIPY nibabel
-website <http://nipy.org/nibabel>`_.
+website <https://nipy.github.io/nibabel>`_.
 
 Mailing Lists
 =============
@@ -89,7 +89,7 @@ You can find our sources and single-click downloads:
 * Downloads of all `available releases`_.
 
 .. _main repository: https://github.com/nipy/nibabel
-.. _Documentation: http://nipy.org/nibabel
+.. _Documentation: https://nipy.github.io/nibabel
 .. _current release: https://pypi.python.org/pypi/nibabel
 .. _current development version: https://github.com/nipy/nibabel/archive/master.zip
 .. _available releases: https://github.com/nipy/nibabel/releases
@@ -112,7 +112,7 @@ MAINTAINER          = "Matthew Brett, Michael Hanke and Eric Larson"
 MAINTAINER_EMAIL    = "nipy-devel@neuroimaging.scipy.org"
 DESCRIPTION         = description
 LONG_DESCRIPTION    = long_description
-URL                 = "http://nipy.org/nibabel"
+URL                 = "https://nipy.github.io/nibabel"
 DOWNLOAD_URL        = "https://github.com/nipy/nibabel"
 LICENSE             = "MIT license"
 CLASSIFIERS         = CLASSIFIERS

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -68,7 +68,7 @@ def guessed_image_type(filename):
         klass = class_map[img_type]['class']
     elif lext == '.mnc':
         # Look for HDF5 signature for MINC2
-        # http://www.hdfgroup.org/HDF5/doc/H5.format.html
+        # https://www.hdfgroup.org/HDF5/doc/H5.format.html
         with Opener(filename) as fobj:
             signature = fobj.read(4)
             klass = Minc2Image if signature == b'\211HDF' else Minc1Image

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -73,7 +73,7 @@ class Minc1File(object):
     def _get_dimensions(self, var):
         # Dimensions for a particular variable
         # Differs for MINC1 and MINC2 - see:
-        # http://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Associating_HDF5_dataspaces_with_MINC_dimensions
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Associating_HDF5_dataspaces_with_MINC_dimensions
         return var.dimensions
 
     def get_data_dtype(self):

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -29,7 +29,7 @@ _dt_dict = {
     ('i','signed__'): np.int32,
     }
 
-# See http://www.bic.mni.mcgill.ca/software/minc/minc1_format/node15.html
+# See https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#MINC_specific_convenience_functions
 _default_dir_cos = {
     'xspace': [1,0,0],
     'yspace': [0,1,0],
@@ -52,12 +52,12 @@ class Minc1File(object):
         self._image = mincfile.variables['image']
         self._dim_names = self._image.dimensions
         # The code below will error with vector_dimensions.  See:
-        # http://www.bic.mni.mcgill.ca/software/minc/minc1_format/node3.html
-        # http://www.bic.mni.mcgill.ca/software/minc/prog_guide/node11.html
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#An_Introduction_to_NetCDF
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#Image_dimensions
         self._dims = [self._mincfile.variables[s]
                       for s in self._dim_names]
         # We don't currently support irregular spacing
-        # http://www.bic.mni.mcgill.ca/software/minc/minc1_format/node15.html
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#MINC_specific_convenience_functions
         for dim in self._dims:
             if dim.spacing != b'regular__':
                 raise ValueError('Irregular spacing not supported')
@@ -65,7 +65,7 @@ class Minc1File(object):
                              if name.endswith('space')]
         # the MINC standard appears to allow the following variables to
         # be undefined.
-        # http://www.bic.mni.mcgill.ca/software/minc/minc1_format/node16.html
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#Image_conversion_variables
         # It wasn't immediately obvious what the defaults were.
         self._image_max = self._mincfile.variables['image-max']
         self._image_min = self._mincfile.variables['image-min']
@@ -150,7 +150,7 @@ class Minc1File(object):
     def _normalize(self, data, sliceobj=()):
         """ Apply scaling to image data `data` already sliced with `sliceobj`
 
-        http://www.bic.mni.mcgill.ca/software/minc/prog_guide/node13.html
+        https://en.wikibooks.org/wiki/MINC/Reference/MINC1-programmers-guide#Pixel_values_and_real_values
 
         MINC normalization uses "image-min" and "image-max" variables to
         map the data from the valid range of the image to the range

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -58,7 +58,7 @@ class Minc2File(Minc1File):
         dimensions = minc_part['dimensions']
         self._dims = [Hdf5Bunch(dimensions[s]) for s in self._dim_names]
         # We don't currently support irregular spacing
-        # http://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Dimension_variable_attributes
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Dimension_variable_attributes
         for dim in self._dims:
             if dim.spacing != b'regular__':
                 raise ValueError('Irregular spacing not supported')
@@ -70,7 +70,7 @@ class Minc2File(Minc1File):
     def _get_dimensions(self, var):
         # Dimensions for a particular variable
         # Differs for MINC1 and MINC2 - see:
-        # http://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Associating_HDF5_dataspaces_with_MINC_dimensions
+        # https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Associating_HDF5_dataspaces_with_MINC_dimensions
         try:
             dimorder = var.attrs['dimorder'].decode()
         except KeyError: # No specified dimensions

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -235,7 +235,7 @@ intent_codes = Recoder((
     (2005, 'shape', (), "NIFTI_INTENT_SHAPE"),
     # The codes below appear on the CIFTI page, but don't appear to have reached
     # the nifti standard as of 19 August 2013
-    # http://www.nitrc.org/plugins/mwiki/index.php/cifti:ConnectivityMatrixFileFormats
+    # https://www.nitrc.org/plugins/mwiki/index.php/cifti:ConnectivityMatrixFileFormats
     (3001, 'dense connectivity', (), 'NIFTI_INTENT_CONNECTIVITY_DENSE'),
     (3002, 'dense time connectivity', (),
      'NIFTI_INTENT_CONNECTIVITY_DENSE_TIME'),
@@ -697,7 +697,7 @@ class Nifti1Header(SpmAnalyzeHeader):
         -----
         Allows for freesurfer hack for large vectors described in
         https://github.com/nipy/nibabel/issues/100 and
-        http://code.google.com/p/fieldtrip/source/browse/trunk/external/freesurfer/save_nifti.m?spec=svn5022&r=5022#77
+        https://code.google.com/p/fieldtrip/source/browse/trunk/external/freesurfer/save_nifti.m?spec=svn5022&r=5022#77
         '''
         shape = super(Nifti1Header, self).get_data_shape()
         # Apply freesurfer hack for vector
@@ -724,7 +724,7 @@ class Nifti1Header(SpmAnalyzeHeader):
         -----
         Applies freesurfer hack for large vectors described in
         https://github.com/nipy/nibabel/issues/100 and
-        http://code.google.com/p/fieldtrip/source/browse/trunk/external/freesurfer/save_nifti.m?spec=svn5022&r=5022#77
+        https://code.google.com/p/fieldtrip/source/browse/trunk/external/freesurfer/save_nifti.m?spec=svn5022&r=5022#77
         '''
         # Apply freesurfer hack for vector
         hdr = self._structarr

--- a/nibabel/nifti2.py
+++ b/nibabel/nifti2.py
@@ -10,11 +10,11 @@
 
 Format described here:
 
-    http://www.nitrc.org/forum/message.php?msg_id=3738
+    https://www.nitrc.org/forum/message.php?msg_id=3738
 
 Stuff about the CIFTI file format here:
 
-    http://www.nitrc.org/plugins/mwiki/index.php/cifti:ConnectivityMatrixFileFormats
+    https://www.nitrc.org/plugins/mwiki/index.php/cifti:ConnectivityMatrixFileFormats
 '''
 
 import numpy as np
@@ -25,7 +25,7 @@ from .spatialimages import HeaderDataError, ImageFileError
 from .nifti1 import Nifti1Header, Nifti1Pair, Nifti1Image
 
 r"""
-Header struct from : http://www.nitrc.org/forum/message.php?msg_id=3738
+Header struct from : https://www.nitrc.org/forum/message.php?msg_id=3738
 
 /*! \struct nifti_2_header
     \brief Data structure defining the fields in the nifti2 header.

--- a/nibabel/onetime.py
+++ b/nibabel/onetime.py
@@ -17,7 +17,7 @@ References
 [1] How-To Guide for Descriptors, Raymond
 Hettinger. http://users.rcn.com/python/download/Descriptor.htm
 
-[2] Python data model, http://docs.python.org/reference/datamodel.html
+[2] Python data model, https://docs.python.org/reference/datamodel.html
 """
 from __future__ import division, print_function, absolute_import
 

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -124,7 +124,7 @@ def quat2mat(q):
     References
     ----------
     Algorithm from
-    http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
+    https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
 
     Examples
     --------
@@ -180,7 +180,7 @@ def mat2quat(M):
 
     References
     ----------
-    * http://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
+    * https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
     * Bar-Itzhack, Itzhack Y. (2000), "New method for extracting the
       quaternion from a rotation matrix", AIAA Journal of Guidance,
       Control and Dynamics 23(6):1085-1087 (Engineering Note), ISSN
@@ -233,7 +233,7 @@ def mult(q1, q2):
 
     Notes
     -----
-    See : http://en.wikipedia.org/wiki/Quaternions#Hamilton_product
+    See : https://en.wikipedia.org/wiki/Quaternions#Hamilton_product
     '''
     w1, x1, y1, z1 = q1
     w2, x2, y2, z2 = q2
@@ -319,7 +319,7 @@ def rotate_vector(v, q):
 
     Notes
     -----
-    See: http://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Describing_rotations_with_quaternions
+    See: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Describing_rotations_with_quaternions
 
     '''
     varr = np.zeros((4,))
@@ -422,7 +422,7 @@ def angle_axis2mat(theta, vector, is_normalized=False):
 
     Notes
     -----
-    From: http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle
+    From: https://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle
     '''
     x, y, z = vector
     if not is_normalized:

--- a/nibabel/tests/test_helpers.py
+++ b/nibabel/tests/test_helpers.py
@@ -34,7 +34,7 @@ def bz2_mio_error():
 
     Writing an empty string can fail for bz2 objects in python 3.3:
 
-    http://bugs.python.org/issue16828
+    https://bugs.python.org/issue16828
 
     This in turn causes scipy to give this error when trying to write bz2 mat
     files.

--- a/nibabel/tests/test_utils.py
+++ b/nibabel/tests/test_utils.py
@@ -233,7 +233,7 @@ def test_array_from_file_openers():
                                              (0, 5, 10)):
             fname = 'test.bin' + ext
             with Opener(fname, 'wb') as out_buf:
-                if offset != 0: # avoid http://bugs.python.org/issue16828
+                if offset != 0: # avoid https://bugs.python.org/issue16828
                     out_buf.write(b' ' * offset)
                 out_buf.write(in_arr.tostring(order='F'))
             with Opener(fname, 'rb') as in_buf:

--- a/nibabel/trackvis.py
+++ b/nibabel/trackvis.py
@@ -21,7 +21,7 @@ except NameError:  # python 3
 
 # Definition of trackvis header structure.
 # See http://www.trackvis.org/docs/?subsect=fileformat
-# See http://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
+# See https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
 header_1_dtd = [
     ('id_string', 'S6'),
     ('dim', 'h', 3),

--- a/nisext/sexts.py
+++ b/nisext/sexts.py
@@ -238,7 +238,7 @@ class install_scripts_bat(install_scripts):
     Notes
     -----
     See discussion at
-    http://matthew-brett.github.com/pydagogue/installing_scripts.html and
+    https://matthew-brett.github.io/pydagogue/installing_scripts.html and
     example at git://github.com/matthew-brett/myscripter.git for more
     background.
     """

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -138,7 +138,7 @@ def make_link_targets(proj_name,
     if not url is None:
         lines.append('.. _%s: %s\n' % (proj_name, url))
     if not have_gh_url:
-        gh_url = 'http://github.com/%s/%s\n' % (user_name, repo_name)
+        gh_url = 'https://github.com/%s/%s\n' % (user_name, repo_name)
         lines.append('.. _`%s github`: %s\n' % (proj_name, gh_url))
     if not ml_url is None:
         lines.append('.. _`%s mailing list`: %s\n' % (proj_name, ml_url))

--- a/tools/install_python.ps1
+++ b/tools/install_python.ps1
@@ -1,8 +1,8 @@
 # Sample script to install Python and pip under Windows
 # Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner
-# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+# License: CC0 1.0 Universal: https://creativecommons.org/publicdomain/zero/1.0/
 
-$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$MINICONDA_URL = "https://repo.continuum.io/miniconda/"
 $BASE_URL = "https://www.python.org/ftp/python/"
 
 


### PR DESCRIPTION
Since `*.github.io` pages support HTTPS, pulling in content from HTTP addresses causes browsers to complain about unsafe scripts. This eliminates any warnings, on a test I ran on one of our lab web servers. Loading scripts over HTTPS from an HTTP connection shouldn't cause problems.

HTTPS might not be a priority for nibabel, so I limited this initial commit to making the nibabel site eliminate browser warnings. If it would be welcome, I can also go through other URLs throughout the documentation and upgrade them to HTTPS when they exist and have a valid certificate.