### PR TITLE
ENH: reading PAR headers from NIfTI extensions

### DIFF
--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -504,14 +504,14 @@ def _data_from_rec(rec_fileobj, in_shape, dtype, slice_indices, out_shape,
     return rec_data
 
 
-def exts2pars(img_or_hdr):
-    """Parse, return any PAR headers in NIfTI extensions for `img_or_hdr`
+def exts2pars(exts_source):
+    """Parse, return any PAR headers from NIfTI extensions in `exts_source`
 
     Parameters
     ----------
-    img_or_hdr : `Nifti1Image` or `Nifti1Header` instance
-        An image or header that may have PAR headers in the contained NIfTI
-        extensions.
+    exts_source : sequence or `Nifti1Image`, `Nifti1Header` instance
+        A sequence of extensions, or header containing NIfTI extensions, or an
+        image containing a header with NIfTI extensions.
 
     Returns
     -------
@@ -520,11 +520,11 @@ def exts2pars(img_or_hdr):
         element contains a PARRECHeader read from the contained extensions.
     """
     headers = []
-    try:  # Allow images or headers as input
-        hdr = img_or_hdr.header
-    except AttributeError:
-        hdr = img_or_hdr
-    for extension in hdr.extensions:
+    exts_source = (exts_source.header if hasattr(exts_source, 'header')
+                   else exts_source)
+    exts_source = (exts_source.extensions if hasattr(exts_source, 'extensions')
+                   else exts_source)
+    for extension in exts_source:
         content = extension.get_content()
         content = content.decode(getpreferredencoding(False))
         if not content.startswith('# === DATA DESCRIPTION FILE ==='):

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -4,7 +4,6 @@
 from os.path import join as pjoin, dirname, basename
 from glob import glob
 from warnings import simplefilter
-import shutil
 
 import numpy as np
 from numpy import array as npa
@@ -22,7 +21,7 @@ from numpy.testing import (assert_almost_equal,
                            assert_array_equal)
 
 from nose.tools import (assert_true, assert_false, assert_raises,
-                        assert_equal, assert_not_equal)
+                        assert_equal)
 
 from ..testing import catch_warn_reset, suppress_warnings
 
@@ -609,6 +608,8 @@ def test_exts2par():
     nii_img = Nifti1Image.from_image(par_img)
     assert_equal(exts2pars(nii_img), [])
     assert_equal(exts2pars(nii_img.header), [])
+    assert_equal(exts2pars(nii_img.header.extensions), [])
+    assert_equal(exts2pars([]), [])
     # Add a header extension
     with open(EG_PAR, 'rb') as fobj:
         hdr_dump = fobj.read()
@@ -626,5 +627,10 @@ def test_exts2par():
     assert_equal(hdrs[1].get_slice_orientation(), 'transverse')
     # Add null extension, ignored
     nii_img.header.extensions.append(Nifti1Extension('comment', b''))
-    hdrs = exts2pars(nii_img)
-    assert_equal(len(hdrs), 2)
+    # Check all valid inputs
+    for source in (nii_img,
+                   nii_img.header,
+                   nii_img.header.extensions,
+                   list(nii_img.header.extensions)):
+        hdrs = exts2pars(source)
+        assert_equal(len(hdrs), 2)

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -10,9 +10,10 @@ import numpy as np
 from numpy import array as npa
 
 from .. import load as top_load
+from ..nifti1 import Nifti1Image, Nifti1Extension
 from .. import parrec
 from ..parrec import (parse_PAR_header, PARRECHeader, PARRECError, vol_numbers,
-                      vol_is_full, PARRECImage, PARRECArrayProxy)
+                      vol_is_full, PARRECImage, PARRECArrayProxy, exts2pars)
 from ..openers import Opener
 from ..fileholders import FileHolder
 from ..volumeutils import array_from_file
@@ -600,3 +601,30 @@ def test_anonymized():
     assert_almost_equal(img_defs['window center'][-1], 236.385836385836, 6)
     assert_almost_equal(img_defs['window width'][0], 767.277167277167, 6)
     assert_almost_equal(img_defs['window width'][-1], 236.385836385836, 6)
+
+
+def test_exts2par():
+    # Test we can load PAR headers from NIfTI extensions
+    par_img = PARRECImage.from_filename(EG_PAR)
+    nii_img = Nifti1Image.from_image(par_img)
+    assert_equal(exts2pars(nii_img), [])
+    assert_equal(exts2pars(nii_img.header), [])
+    # Add a header extension
+    with open(EG_PAR, 'rb') as fobj:
+        hdr_dump = fobj.read()
+        dump_ext = Nifti1Extension('comment', hdr_dump)
+    nii_img.header.extensions.append(dump_ext)
+    hdrs = exts2pars(nii_img)
+    assert_equal(len(hdrs), 1)
+    # Test attribute from PARRECHeader
+    assert_equal(hdrs[0].get_slice_orientation(), 'transverse')
+    # Add another PAR extension
+    nii_img.header.extensions.append(Nifti1Extension('comment', hdr_dump))
+    hdrs = exts2pars(nii_img)
+    assert_equal(len(hdrs), 2)
+    # Test attribute from PARRECHeader
+    assert_equal(hdrs[1].get_slice_orientation(), 'transverse')
+    # Add null extension, ignored
+    nii_img.header.extensions.append(Nifti1Extension('comment', b''))
+    hdrs = exts2pars(nii_img)
+    assert_equal(len(hdrs), 2)


### PR DESCRIPTION
A small function to fetch PARHeader object from PAR headers recorded in NIfTI
comment extensions.