### PR TITLE
Use "optional_package" for scipy checks

### DIFF
--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -16,7 +16,7 @@ from .freesurfer import MGHImage
 from .parrec import PARRECImage
 from .volumeutils import Recoder
 from .optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 
 
 # mapping of names to classes and class functionality

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -15,14 +15,9 @@ from .minc1 import Minc1Image
 from .freesurfer import MGHImage
 from .parrec import PARRECImage
 from .volumeutils import Recoder
+from .optpkg import optional_package
+have_scipy = optional_package('scipy')[1]
 
-# If we don't have scipy, then we cannot write SPM format files
-try:
-    import scipy.io
-except ImportError:
-    have_scipy = False
-else:
-    have_scipy = True
 
 # mapping of names to classes and class functionality
 

--- a/nibabel/tests/data/check_parrec_reslice.py
+++ b/nibabel/tests/data/check_parrec_reslice.py
@@ -33,7 +33,6 @@ _, have_scipy, _ = optional_package('scipy')
 
 
 def resample_img2img(img_to, img_from, order=1, out_class=nib.Nifti1Image):
-    global have_scipy
     if not have_scipy:
         raise Exception('Scipy must be installed to run resample_img2img.')
 

--- a/nibabel/tests/data/check_parrec_reslice.py
+++ b/nibabel/tests/data/check_parrec_reslice.py
@@ -24,15 +24,20 @@ of the field of view.
 import glob
 import numpy as np
 import numpy.linalg as npl
-np.set_printoptions(suppress=True, precision=4)
 
 import nibabel as nib
 from nibabel import parrec
 from nibabel.affines import to_matvec
+from nibabel.optpkg import optional_package
+have_scipy = optional_package('scipy')[1]
 
-from scipy import ndimage as spnd
 
 def resample_img2img(img_to, img_from, order=1, out_class=nib.Nifti1Image):
+    global have_scipy
+    if not have_scipy:
+        raise Exception('Scipy must be installed to run resample_img2img.')
+
+    from scipy import ndimage as spnd
     vox2vox = npl.inv(img_from.affine).dot(img_to.affine)
     rzs, trans = to_matvec(vox2vox)
     data = spnd.affine_transform(img_from.get_data(),
@@ -49,22 +54,24 @@ def gmean_norm(data):
     return data / gmean
 
 
-normal_fname = "Phantom_EPI_3mm_tra_SENSE_6_1.PAR"
-normal_img = parrec.load(normal_fname)
-normal_data = normal_img.get_data()
-normal_normed = gmean_norm(normal_data)
+if __name__ == '__main__':
+    np.set_printoptions(suppress=True, precision=4)
+    normal_fname = "Phantom_EPI_3mm_tra_SENSE_6_1.PAR"
+    normal_img = parrec.load(normal_fname)
+    normal_data = normal_img.get_data()
+    normal_normed = gmean_norm(normal_data)
 
-print("RMS of standard image {:<44}: {}".format(
-    normal_fname,
-    np.sqrt(np.sum(normal_normed ** 2))))
+    print("RMS of standard image {:<44}: {}".format(
+        normal_fname,
+        np.sqrt(np.sum(normal_normed ** 2))))
 
-for parfile in glob.glob("*.PAR"):
-    if parfile == normal_fname:
-        continue
-    funny_img = parrec.load(parfile)
-    fixed_img = resample_img2img(normal_img, funny_img)
-    fixed_data = fixed_img.get_data()
-    difference_data = normal_normed - gmean_norm(fixed_data)
-    print('RMS resliced {:<52} : {}'.format(
-        parfile,
-        np.sqrt(np.sum(difference_data ** 2))))
+    for parfile in glob.glob("*.PAR"):
+        if parfile == normal_fname:
+            continue
+        funny_img = parrec.load(parfile)
+        fixed_img = resample_img2img(normal_img, funny_img)
+        fixed_data = fixed_img.get_data()
+        difference_data = normal_normed - gmean_norm(fixed_data)
+        print('RMS resliced {:<52} : {}'.format(
+            parfile,
+            np.sqrt(np.sum(difference_data ** 2))))

--- a/nibabel/tests/data/check_parrec_reslice.py
+++ b/nibabel/tests/data/check_parrec_reslice.py
@@ -29,7 +29,7 @@ import nibabel as nib
 from nibabel import parrec
 from nibabel.affines import to_matvec
 from nibabel.optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 
 
 def resample_img2img(img_to, img_from, order=1, out_class=nib.Nifti1Image):

--- a/nibabel/tests/test_helpers.py
+++ b/nibabel/tests/test_helpers.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_equal
 from ..openers import Opener
 from ..optpkg import optional_package
 from ..tmpdirs import InTemporaryDirectory
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 
 
 def bytesio_filemap(klass):

--- a/nibabel/tests/test_helpers.py
+++ b/nibabel/tests/test_helpers.py
@@ -3,13 +3,14 @@
 from io import BytesIO
 
 import numpy as np
-from nose.tools import assert_true
-from numpy.testing import assert_array_equal
 
 from ..openers import Opener
-from ..optpkg import optional_package
 from ..tmpdirs import InTemporaryDirectory
-_, have_scipy, _ = optional_package('scipy')
+from ..optpkg import optional_package
+_, have_scipy, _ = optional_package('scipy.io')
+
+from nose.tools import assert_true
+from numpy.testing import assert_array_equal
 
 
 def bytesio_filemap(klass):
@@ -45,14 +46,16 @@ def bz2_mio_error():
     """
     if not have_scipy:
         return True
+    import scipy.io
+
     with InTemporaryDirectory():
         with Opener('test.mat.bz2', 'wb') as fobj:
             try:
-                import scipy.io
                 scipy.io.savemat(fobj, {'a': 1}, format='4')
             except ValueError:
                 return True
-    return False
+            else:
+                return False
 
 
 def assert_data_similar(arr, params):

--- a/nibabel/tests/test_helpers.py
+++ b/nibabel/tests/test_helpers.py
@@ -1,14 +1,15 @@
 """ Helper functions for tests
 """
+from io import BytesIO
 
 import numpy as np
-
-from io import BytesIO
-from ..openers import Opener
-from ..tmpdirs import InTemporaryDirectory
-
 from nose.tools import assert_true
 from numpy.testing import assert_array_equal
+
+from ..openers import Opener
+from ..optpkg import optional_package
+from ..tmpdirs import InTemporaryDirectory
+have_scipy = optional_package('scipy')[1]
 
 
 def bytesio_filemap(klass):
@@ -42,13 +43,12 @@ def bz2_mio_error():
     This won't cause a problem for scipy releases after Jan 24 2014 because of
     commit 98ef522d99 (in scipy)
     """
-    try:
-        import scipy.io
-    except ImportError:
+    if not have_scipy:
         return True
     with InTemporaryDirectory():
         with Opener('test.mat.bz2', 'wb') as fobj:
             try:
+                import scipy.io
                 scipy.io.savemat(fobj, {'a': 1}, format='4')
             except ValueError:
                 return True

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -28,8 +28,8 @@ from functools import partial
 import numpy as np
 
 from ..optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
-have_h5py = optional_package('h5py')[1]
+_, have_scipy, _ = optional_package('scipy')
+_, have_h5py, _ = optional_package('h5py')
 
 from .. import (AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage,
                 Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -28,8 +28,8 @@ from functools import partial
 import numpy as np
 
 from ..optpkg import optional_package
-_, have_scipy, _ = optional_package('scipy')
-_, have_h5py, _ = optional_package('h5py')
+have_scipy = optional_package('scipy')[1]
+have_h5py = optional_package('h5py')[1]
 
 from .. import (AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage,
                 Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,

--- a/nibabel/tests/test_image_load_save.py
+++ b/nibabel/tests/test_image_load_save.py
@@ -17,7 +17,7 @@ import numpy as np
 
 # If we don't have scipy, then we cannot write SPM format files
 from ..optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 
 from .. import analyze as ana
 from .. import spm99analyze as spm99

--- a/nibabel/tests/test_image_load_save.py
+++ b/nibabel/tests/test_image_load_save.py
@@ -16,13 +16,8 @@ from ..externals.six import BytesIO
 import numpy as np
 
 # If we don't have scipy, then we cannot write SPM format files
-try:
-    import scipy.io
-except ImportError:
-    have_scipy = False
-else:
-    have_scipy = True
-
+from ..optpkg import optional_package
+have_scipy = optional_package('scipy')[1]
 
 from .. import analyze as ana
 from .. import spm99analyze as spm99

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -14,7 +14,8 @@ from ..loadsave import load, read_img_data
 from ..spatialimages import ImageFileError
 from ..tmpdirs import InTemporaryDirectory, TemporaryDirectory
 
-from .test_spm99analyze import have_scipy
+from ..optpkg import optional_package
+have_scipy = optional_package('scipy')[1]
 
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal)

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -15,7 +15,7 @@ from ..spatialimages import ImageFileError
 from ..tmpdirs import InTemporaryDirectory, TemporaryDirectory
 
 from ..optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal)

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -16,12 +16,8 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal, dec
 
 # Decorator to skip tests requiring save / load if scipy not available for mat
 # files
-try:
-    import scipy
-except ImportError:
-    have_scipy = False
-else:
-    have_scipy = True
+from ..optpkg import optional_package
+have_scipy = optional_package('scipy')[1]
 scipy_skip = dec.skipif(not have_scipy, 'scipy not available')
 
 from ..spm99analyze import (Spm99AnalyzeHeader, Spm99AnalyzeImage,

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -17,7 +17,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal, dec
 # Decorator to skip tests requiring save / load if scipy not available for mat
 # files
 from ..optpkg import optional_package
-have_scipy = optional_package('scipy')[1]
+_, have_scipy, _ = optional_package('scipy')
 scipy_skip = dec.skipif(not have_scipy, 'scipy not available')
 
 from ..spm99analyze import (Spm99AnalyzeHeader, Spm99AnalyzeImage,


### PR DESCRIPTION
In a few places, scipy was still checked for in `try.. catch` blocks, rather than a call to `optional_package`. Switch those over.

Made another related changes as well, just because I was there:
* Turn `nibabel/tests/data/check_parrec_reslice.py` into an importable module, and fail more gracefully if `scipy` is not installed.
