### PR TITLE
BF: fix bug for Windows bat-file install

### DIFF
--- a/nisext/sexts.py
+++ b/nisext/sexts.py
@@ -222,7 +222,7 @@ echo First line of %pyscript% does not start with "#!"
 exit /b 1
 :goodstart
 set py_exe=%line1:~2%
-call %py_exe% %pyscript% %*
+call "%py_exe%" %pyscript% %*
 """
 
 class install_scripts_bat(install_scripts):


### PR DESCRIPTION
Windows .bat file shadow of Python script fails for paths with spaces.

Thanks to P. Renner for the fix - see 
https://github.com/matthew-brett/myscripter/pull/2