### PR TITLE
NF: -H for nib-ls to list desired header fields

### DIFF
--- a/bin/nib-ls
+++ b/bin/nib-ls
@@ -13,7 +13,7 @@ Output a summary table for neuroimaging files (resolution, dimensionality, etc.)
 from __future__ import division, print_function, absolute_import
 
 __author__ = 'Yaroslav Halchenko'
-__copyright__ = 'Copyright (c) 2011-2012 Yaroslav Halchenko ' \
+__copyright__ = 'Copyright (c) 2011-2015 Yaroslav Halchenko ' \
                 'and NiBabel contributors'
 __license__ = 'MIT'
 
@@ -141,6 +141,10 @@ def get_opt_parser():
                dest="verbose", default=0,
                help="Make more noise.  Could be specified multiple times"),
 
+        Option("-H", "--header-fields",
+               dest="header_fields", default='',
+               help="Header fields (comma separated) to be printed as well (if present)"),
+
         Option("-s", "--stats",
                action="store_true", dest='stats', default=False,
                help="Output basic data statistics"),
@@ -179,6 +183,22 @@ def proc_file(f, opts):
         row += ['@l#exts: %d' % len(h.extensions)]
     else:
         row += [ '' ]
+
+    if opts.header_fields:
+        # signals "all fields"
+        if opts.header_fields == '*':
+            # TODO: might vary across file types, thus prior sensing would be needed
+            header_fields = h.keys()
+        else:
+            header_fields = opts.header_fields.split(',')
+
+        for f in header_fields:
+            if not f: # skip empty
+                continue
+            try:
+                row += [str(h[f])]
+            except (KeyError, ValueError):
+                row += [ '' ]
 
     try:
         if (hasattr(h, 'get_qform') and hasattr(h, 'get_sform')

--- a/bin/nib-ls
+++ b/bin/nib-ls
@@ -186,7 +186,7 @@ def proc_file(f, opts):
 
     if opts.header_fields:
         # signals "all fields"
-        if opts.header_fields == '*':
+        if opts.header_fields == 'all':
             # TODO: might vary across file types, thus prior sensing would be needed
             header_fields = h.keys()
         else:

--- a/bin/nib-ls
+++ b/bin/nib-ls
@@ -198,7 +198,7 @@ def proc_file(f, opts):
             try:
                 row += [str(h[f])]
             except (KeyError, ValueError):
-                row += [ '' ]
+                row += [ 'error' ]
 
     try:
         if (hasattr(h, 'get_qform') and hasattr(h, 'get_sform')

--- a/bin/nib-ls
+++ b/bin/nib-ls
@@ -187,7 +187,8 @@ def proc_file(f, opts):
     if opts.header_fields:
         # signals "all fields"
         if opts.header_fields == 'all':
-            # TODO: might vary across file types, thus prior sensing would be needed
+            # TODO: might vary across file types, thus prior sensing
+            # would be needed
             header_fields = h.keys()
         else:
             header_fields = opts.header_fields.split(',')

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -9,6 +9,7 @@
 ''' Utilities for testing '''
 from __future__ import division, print_function
 
+import re
 import os
 import sys
 import warnings
@@ -57,6 +58,17 @@ def assert_allclose_safely(a, b, match_nans=True):
     if b.dtype.kind in 'ui':
         b = b.astype(float)
     assert_true(np.allclose(a, b))
+
+
+def assert_re_in(regex, c, flags=0):
+    """Assert that container (list, str, etc) contains entry matching the regex
+    """
+    if not isinstance(c, (list, tuple)):
+        c = [c]
+    for e in c:
+        if re.match(regex, e, flags=flags):
+            return
+    raise AssertionError("Not a single entry matched %r in %r" % (regex, c))
 
 
 def get_fresh_mod(mod_name=__name__):

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -82,7 +82,9 @@ def test_nib_ls_multiple():
     assert_equal(len(stdout_lines), 4)
     # they should be indented correctly.  Since all files are int type -
     ln = max(len(f) for f in fnames)
-    assert_equal([l[ln:ln+2] for l in stdout_lines], [' i']*4)
+    assert_equal([l[ln:ln+2] for l in stdout_lines], [' i']*4,
+                 msg="Type sub-string didn't start with 'i'. "
+                     "Full output was: %s" % stdout_lines)
     # and if disregard type indicator which might vary
     assert_equal(
         [l[l.index('['):] for l in stdout_lines],

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -20,6 +20,7 @@ from ..orientations import flip_axis, aff2axcodes, inv_ornt_aff
 
 from nose.tools import (assert_true, assert_false, assert_not_equal,
                         assert_equal)
+from nose import SkipTest
 
 from numpy.testing import assert_almost_equal, assert_array_equal
 
@@ -81,6 +82,11 @@ def test_nib_ls_multiple():
     code, stdout, stderr = run_command(['nib-ls'] + fnames)
     stdout_lines = stdout.split('\n')
     assert_equal(len(stdout_lines), 4)
+    try:
+        load(pjoin(DATA_PATH, 'small.mnc'))
+    except:
+        raise SkipTest("For the other tests should be able to load MINC files")
+
     # they should be indented correctly.  Since all files are int type -
     ln = max(len(f) for f in fnames)
     assert_equal([l[ln:ln+2] for l in stdout_lines], [' i']*4,

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -53,8 +53,7 @@ script_test.__test__ = False # It's not a test
 DATA_PATH = abspath(pjoin(dirname(__file__), 'data'))
 
 
-@script_test
-def _test_nib_ls_example4d(opts=[], hdrs_str=""):
+def check_nib_ls_example4d(opts=[], hdrs_str=""):
     # test nib-ls script
     fname = pjoin(DATA_PATH, 'example4d.nii.gz')
     expected_re = (" (int16|[<>]i2) \[128,  96,  24,   2\] "
@@ -67,15 +66,17 @@ def _test_nib_ls_example4d(opts=[], hdrs_str=""):
 
 @script_test
 def test_nib_ls():
-    yield _test_nib_ls_example4d
-    yield _test_nib_ls_example4d, ['-H', 'dim,bitpix'], " \[  4 128  96  24   2   1   1   1\] 16"
+    yield check_nib_ls_example4d
+    yield check_nib_ls_example4d, \
+          ['-H', 'dim,bitpix'], " \[  4 128  96  24   2   1   1   1\] 16"
 
 @script_test
 def test_nib_ls_multiple():
     # verify that correctly lists/formats for multiple files
     fnames = [
         pjoin(DATA_PATH, f)
-        for f in ('example4d.nii.gz', 'example_nifti2.nii.gz', 'small.mnc', 'nifti2.hdr')
+        for f in ('example4d.nii.gz', 'example_nifti2.nii.gz',
+                  'small.mnc', 'nifti2.hdr')
     ]
     code, stdout, stderr = run_command(['nib-ls'] + fnames)
     stdout_lines = stdout.split('\n')

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -148,7 +148,7 @@ def test_assert_re_in():
     assert_re_in(".*", "")
     assert_re_in(".*", ["any"])
 
-    # should do match not search
+    # Should do match not search
     assert_re_in("ab", "abc")
     assert_raises(AssertionError, assert_re_in, "ab", "cab")
     assert_raises(AssertionError, assert_re_in, "ab$", "abc")
@@ -161,5 +161,5 @@ def test_assert_re_in():
     assert_re_in("ab", ("", "abc", "laskdjf"))
     assert_raises(AssertionError, assert_re_in, "ab$", ("ddd", ""))
 
-    # shouldn't "match" the emty list
+    # Shouldn't "match" the empty list
     assert_raises(AssertionError, assert_re_in, "", [])

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -10,7 +10,7 @@ import numpy as np
 from nose.tools import assert_true, assert_equal, assert_raises
 from ..testing import (error_warnings, suppress_warnings,
                        clear_and_catch_warnings, assert_allclose_safely,
-                       get_fresh_mod)
+                       get_fresh_mod, assert_re_in)
 
 
 def assert_warn_len_equal(mod, n_in_context):
@@ -142,3 +142,24 @@ def test_warn_ignore():
         with suppress_warnings():
             raise ValueError('An error')
     assert_raises(ValueError, f)
+
+
+def test_assert_re_in():
+    assert_re_in(".*", "")
+    assert_re_in(".*", ["any"])
+
+    # should do match not search
+    assert_re_in("ab", "abc")
+    assert_raises(AssertionError, assert_re_in, "ab", "cab")
+    assert_raises(AssertionError, assert_re_in, "ab$", "abc")
+
+    # Sufficient to have one entry matching
+    assert_re_in("ab", ["", "abc", "laskdjf"])
+    assert_raises(AssertionError, assert_re_in, "ab$", ["ddd", ""])
+
+    # Tuples should be ok too
+    assert_re_in("ab", ("", "abc", "laskdjf"))
+    assert_raises(AssertionError, assert_re_in, "ab$", ("ddd", ""))
+
+    # shouldn't "match" the emty list
+    assert_raises(AssertionError, assert_re_in, "", [])


### PR DESCRIPTION
saw https://neurostars.org/p/3361/ which triggered to do this tiny hack (time for tests for the beast will come!)

Now it should be possible to specify some header fields desired to be output, which will get listed as well, e.g.:

```
$> $PWD/bin/nib-ls -H dim,bitpix /usr/share/data/fsl-mni152-templates/MNI152*brain.nii.gz
/usr/share/data/fsl-mni152-templates/MNI152lin_T1_1mm_brain.nii.gz uint8 [182, 218, 182] 1.00x1.00x1.00   [  3 182 218 182   1   1   1   1]  8
/usr/share/data/fsl-mni152-templates/MNI152lin_T1_2mm_brain.nii.gz uint8 [ 91, 109,  91] 2.00x2.00x2.00   [  3  91 109  91   1   1   1   1]  8
/usr/share/data/fsl-mni152-templates/MNI152_T1_1mm_brain.nii.gz    int16 [182, 218, 182] 1.00x1.00x1.00   [  3 182 218 182   1   1   1   1] 16
/usr/share/data/fsl-mni152-templates/MNI152_T1_2mm_brain.nii.gz    int16 [ 91, 109,  91] 2.00x2.00x2.00   [  3  91 109  91   1   1   1   1] 16
```

using '*' as argument would spit out all the header fields