### PR TITLE
RF: getArraysFromIntent => get_arrays_from_intent

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -444,13 +444,17 @@ class GiftiImage(object):
                 self.darrays.remove(dele)
                 self.numDA -= 1
 
-    def getArraysFromIntent(self, intent):
+    def get_arrays_from_intent(self, intent):
         """ Returns a a list of GiftiDataArray elements matching
         the given intent """
 
         it = intent_codes.code[intent]
 
         return [x for x in self.darrays if x.intent == it]
+
+    @np.deprecate_with_doc("Use get_arrays_from_intent instead.")
+    def getArraysFromIntent(self, intent):
+        return self.get_arrays_from_intent(intent)
 
     def print_summary(self):
         print('----start----')

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 from os.path import join as pjoin, dirname
 import sys
+import warnings
 
 import numpy as np
 
@@ -23,6 +24,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_raises)
+from ...testing import clear_and_catch_warnings
 
 
 IO_DATA_PATH = pjoin(dirname(__file__), 'data')
@@ -227,11 +229,21 @@ def test_newmetadata():
 
 def test_getbyintent():
     img = gi.read(DATA_FILE1)
-    da = img.getArraysFromIntent("NIFTI_INTENT_POINTSET")
+
+    da = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")
     assert_equal(len(da), 1)
-    da = img.getArraysFromIntent("NIFTI_INTENT_TRIANGLE")
+
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        da = img.getArraysFromIntent("NIFTI_INTENT_POINTSET")
+        assert_equal(len(da), 1)
+        assert_equal(len(w), 1)
+        assert_equal(w[0].category, DeprecationWarning)
+
+    da = img.get_arrays_from_intent("NIFTI_INTENT_TRIANGLE")
     assert_equal(len(da), 1)
-    da = img.getArraysFromIntent("NIFTI_INTENT_CORREL")
+
+    da = img.get_arrays_from_intent("NIFTI_INTENT_CORREL")
     assert_equal(len(da), 0)
     assert_equal(da, [])
 


### PR DESCRIPTION
GIFTI has a function in CamelCase, not snake_case. Deprecate that.