### PR TITLE
RF: Use python properties, rather than set/get methods

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -133,9 +133,30 @@ class GiftiLabel(object):
         self.blue = blue
         self.alpha = alpha
 
+    @np.deprecate_with_doc("Use the rgba property instead.")
     def get_rgba(self):
+        return self.rgba
+
+    @property
+    def rgba(self):
         """ Returns RGBA as tuple """
         return (self.red, self.green, self.blue, self.alpha)
+
+    @rgba.setter
+    def rgba(self, rgba):
+        """ Set RGBA via tuple
+
+        Parameters
+        ----------
+        rgba : tuple (red, green, blue, alpha)
+
+        """
+        if len(rgba) != 4:
+            raise ValueError('rgba must be length 4.')
+        self.red = rgba[0]
+        self.green = rgba[1]
+        self.blue = rgba[2]
+        self.alpha = rgba[3]
 
 
 def _arr2txt(arr, elem_fmt):

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -380,6 +380,14 @@ class GiftiImage(object):
             raise ValueError("Not a valid GiftiLabelTable instance")
         self._labeltable = labeltable
 
+    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    def set_labeltable(self, labeltable):
+        self.labeltable = labeltable
+
+    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    def get_labeltable(self):
+        return self.labeltable
+
     @property
     def meta(self):
         return self._meta
@@ -400,6 +408,14 @@ class GiftiImage(object):
             raise ValueError("Not a valid GiftiMetaData instance")
         self._meta = meta
  
+    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    def set_metadata(self, meta):
+        self.meta = meta
+
+    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    def get_meta(self):
+        return self.meta
+
     def add_gifti_data_array(self, dataarr):
         """ Adds a data array to the GiftiImage
 

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -153,11 +153,7 @@ class GiftiLabel(object):
         """
         if len(rgba) != 4:
             raise ValueError('rgba must be length 4.')
-        self.red = rgba[0]
-        self.green = rgba[1]
-        self.blue = rgba[2]
-        self.alpha = rgba[3]
-
+        self.red, self.green, self.blue, self.alpha = rgba
 
 def _arr2txt(arr, elem_fmt):
     arr = np.asarray(arr)
@@ -438,7 +434,7 @@ class GiftiImage(object):
         if not isinstance(meta, GiftiMetaData):
             raise ValueError("Not a valid GiftiMetaData instance")
         self._meta = meta
- 
+
     @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
     def set_metadata(self, meta):
         self.meta = meta

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -344,47 +344,31 @@ class GiftiDataArray(object):
 
 
 class GiftiImage(object):
-
-    numDA = int
-    version = str
-    filename = str
-
     def __init__(self, meta=None, labeltable=None, darrays=None,
                  version="1.0"):
         if darrays is None:
             darrays = []
-        self.darrays = darrays
         if meta is None:
-            self.meta = GiftiMetaData()
-        else:
-            self.meta = meta
+            meta = GiftiMetaData()
         if labeltable is None:
-            self.labeltable = GiftiLabelTable()
-        else:
-            self.labeltable = labeltable
-        self.numDA = len(self.darrays)
+            labeltable = GiftiLabelTable()
+
+        self._labeltable = labeltable
+        self._meta = meta
+
+        self.darrays = darrays
         self.version = version
 
-#    @classmethod
-#    def from_array(cls):
-#        pass
-#def GiftiImage_fromarray(data, intent = GiftiIntentCode.NIFTI_INTENT_NONE, encoding=GiftiEncoding.GIFTI_ENCODING_B64GZ, endian = GiftiEndian.GIFTI_ENDIAN_LITTLE):
-#    """ Returns a GiftiImage from a Numpy array with a given intent code and
-#    encoding """
+    @property
+    def numDA(self):
+        return len(self.darrays)
 
-#    @classmethod
-#    def from_vertices_and_triangles(cls):
-#        pass
-#    def from_vertices_and_triangles(cls, vertices, triangles, coordsys = None, \
-#                                    encoding = GiftiEncoding.GIFTI_ENCODING_B64GZ,\
-#                                    endian = GiftiEndian.GIFTI_ENDIAN_LITTLE):
-#    """ Returns a GiftiImage from two numpy arrays representing the vertices
-#    and the triangles. Additionally defining the coordinate system and encoding """
+    @property
+    def labeltable(self):
+        return self._labeltable
 
-    def get_labeltable(self):
-        return self.labeltable
-
-    def set_labeltable(self, labeltable):
+    @labeltable.setter
+    def labeltable(self, labeltable):
         """ Set the labeltable for this GiftiImage
 
         Parameters
@@ -392,15 +376,16 @@ class GiftiImage(object):
         labeltable : GiftiLabelTable
 
         """
-        if isinstance(labeltable, GiftiLabelTable):
-            self.labeltable = labeltable
-        else:
-            print("Not a valid GiftiLabelTable instance")
+        if not isinstance(labeltable, GiftiLabelTable):
+            raise ValueError("Not a valid GiftiLabelTable instance")
+        self._labeltable = labeltable
 
-    def get_metadata(self):
-        return self.meta
+    @property
+    def meta(self):
+        return self._meta
 
-    def set_metadata(self, meta):
+    @meta.setter
+    def meta(self, meta):
         """ Set the metadata for this GiftiImage
 
         Parameters
@@ -411,13 +396,10 @@ class GiftiImage(object):
         -------
         None
         """
-        if isinstance(meta, GiftiMetaData):
-            self.meta = meta
-            print("New Metadata set. Be aware of changing "
-                  "coordinate transformation!")
-        else:
-            print("Not a valid GiftiMetaData instance")
-
+        if not isinstance(meta, GiftiMetaData):
+            raise ValueError("Not a valid GiftiMetaData instance")
+        self._meta = meta
+ 
     def add_gifti_data_array(self, dataarr):
         """ Adds a data array to the GiftiImage
 
@@ -427,14 +409,12 @@ class GiftiImage(object):
         """
         if isinstance(dataarr, GiftiDataArray):
             self.darrays.append(dataarr)
-            self.numDA += 1
         else:
             print("dataarr paramater must be of tzpe GiftiDataArray")
 
     def remove_gifti_data_array(self, ith):
         """ Removes the ith data array element from the GiftiImage """
         self.darrays.pop(ith)
-        self.numDA -= 1
 
     def remove_gifti_data_array_by_intent(self, intent):
         """ Removes all the data arrays with the given intent type """
@@ -442,7 +422,6 @@ class GiftiImage(object):
         for dele in self.darrays:
             if dele.intent == intent2remove:
                 self.darrays.remove(dele)
-                self.numDA -= 1
 
     def get_arrays_from_intent(self, intent):
         """ Returns a a list of GiftiDataArray elements matching

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -38,7 +38,12 @@ class GiftiMetaData(object):
             meda.data.append(nv)
         return meda
 
+    @np.deprecate_with_doc("Use the metadata property instead.")
     def get_metadata(self):
+        return self.metadata
+
+    @property
+    def metadata(self):
         """ Returns metadata as dictionary """
         self.data_as_dict = {}
         for ele in self.data:
@@ -59,7 +64,7 @@ class GiftiMetaData(object):
         return res
 
     def print_summary(self):
-        print(self.get_metadata())
+        print(self.metadata)
 
 
 class GiftiNVPairs(object):
@@ -338,9 +343,14 @@ class GiftiDataArray(object):
             print('Coordinate System:')
             print(self.coordsys.print_summary())
 
+    @np.deprecate_with_doc("Use the metadata property instead.")
     def get_metadata(self):
+        return self.meta.metadata
+
+    @property
+    def metadata(self):
         """ Returns metadata as dictionary """
-        return self.meta.get_metadata()
+        return self.meta.metadata
 
 
 class GiftiImage(object):

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 import base64
 import sys
+import warnings
 import zlib
 from ..externals.six import StringIO
 from xml.parsers.expat import ParserCreate, ExpatError
@@ -108,6 +109,8 @@ class Outputter(object):
             self.img = GiftiImage()
             if 'Version' in attrs:
                 self.img.version = attrs['Version']
+            if 'NumberOfDataArrays' in attrs:
+                self.expected_numDA = int(attrs['NumberOfDataArrays'])
 
             self.fsm_state.append('GIFTI')
         elif name == 'MetaData':
@@ -204,6 +207,10 @@ class Outputter(object):
         if DEBUG_PRINT:
             print('End element:\n\t', repr(name))
         if name == 'GIFTI':
+            if hasattr(self, 'expected_numDA') and self.expected_numDA != self.img.numDA:
+                warnings.warn("Actual # of data arrays does not match "
+                              "# expected: %d != %d." % (self.expected_numDA,
+                                                         self.img.numDA))
             # remove last element of the list
             self.fsm_state.pop()
             # assert len(self.fsm_state) == 0

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -108,9 +108,6 @@ class Outputter(object):
             self.img = GiftiImage()
             if 'Version' in attrs:
                 self.img.version = attrs['Version']
-            if 'NumberOfDataArrays' in attrs:
-                self.img.numDA = int(attrs['NumberOfDataArrays'])
-                self.count_da = False
 
             self.fsm_state.append('GIFTI')
         elif name == 'MetaData':
@@ -234,8 +231,6 @@ class Outputter(object):
             self.img.labeltable = self.lata
             self.lata = None
         elif name == 'DataArray':
-            if self.count_da:
-                self.img.numDA += 1
             self.fsm_state.pop()
         elif name == 'CoordinateSystemTransformMatrix':
             self.fsm_state.pop()

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -79,8 +79,9 @@ def test_labeltable():
     assert_equal(len(img.labeltable.labels), 2)
 
     # Try to set to non-table
-    with assert_raises(ValueError):
-        img.labeltable = 'not-a-table'
+    def assign_labeltable(val):
+        img.labeltable = val
+    assert_raises(ValueError, assign_labeltable, 'not-a-table')
 
 
 def test_metadata():
@@ -112,10 +113,10 @@ def test_gifti_label_rgba():
     assert_equal(kwargs['blue'], gl.rgba[2])
     assert_equal(kwargs['alpha'], gl.rgba[3])
 
-    with assert_raises(ValueError):
-        gl.rgba = rgba[:2]
-    with assert_raises(ValueError):
-        gl.rgba = rgba.tolist() + rgba.tolist()
+    def assign_rgba(val):
+        gl.rgba = val
+    assert_raises(ValueError, assign_rgba, rgba[:2])
+    assert_raises(ValueError, assign_rgba, rgba.tolist() + rgba.tolist())
 
     # Test deprecation
     with clear_and_catch_warnings() as w:

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -1,16 +1,18 @@
 """ Testing gifti objects
 """
+import warnings
 
 import numpy as np
 
+from .. import giftiio as gi
+from ..gifti import (GiftiImage, GiftiDataArray, GiftiLabel, GiftiLabelTable,
+                     GiftiMetaData)
 from ...nifti1 import data_type_codes, intent_codes
-
-from ..gifti import GiftiImage, GiftiDataArray, GiftiLabelTable
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
-
 from nose.tools import assert_true, assert_equal, assert_raises
+from ...testing import clear_and_catch_warnings
 
 
 def test_gifti_image():
@@ -47,3 +49,18 @@ def test_labeltable():
     img.labeltable = new_table
     assert_equal(len(img.labeltable.labels), 2)
 
+    # Try to set to non-table
+    with assert_raises(ValueError):
+        img.labeltable = 'not-a-table'
+
+
+def test_metadata():
+    # Test deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_equal(len(GiftiDataArray().get_metadata()), 0)
+
+    # Test deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_equal(len(GiftiMetaData().get_metadata()), 0)

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -64,3 +64,31 @@ def test_metadata():
     with clear_and_catch_warnings() as w:
         warnings.filterwarnings('once', category=DeprecationWarning)
         assert_equal(len(GiftiMetaData().get_metadata()), 0)
+
+
+def test_gifti_label_rgba():
+    rgba = np.random.rand(4)
+    kwargs = dict(zip(['red', 'green', 'blue', 'alpha'], rgba))
+
+    gl = GiftiLabel(**kwargs)
+    assert_equal(kwargs['red'], gl.rgba[0])
+    assert_equal(kwargs['green'], gl.rgba[1])
+    assert_equal(kwargs['blue'], gl.rgba[2])
+    assert_equal(kwargs['alpha'], gl.rgba[3])
+
+    gl = GiftiLabel()
+    gl.rgba = rgba
+    assert_equal(kwargs['red'], gl.rgba[0])
+    assert_equal(kwargs['green'], gl.rgba[1])
+    assert_equal(kwargs['blue'], gl.rgba[2])
+    assert_equal(kwargs['alpha'], gl.rgba[3])
+
+    with assert_raises(ValueError):
+        gl.rgba = rgba[:2]
+    with assert_raises(ValueError):
+        gl.rgba = rgba.tolist() + rgba.tolist()
+
+    # Test deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_equal(kwargs['red'], gl.get_rgba()[0])

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ...nifti1 import data_type_codes, intent_codes
 
-from ..gifti import GiftiImage, GiftiDataArray
+from ..gifti import GiftiImage, GiftiDataArray, GiftiLabelTable
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
@@ -36,3 +36,14 @@ def test_dataarray():
         bs_arr = arr.byteswap().newbyteorder()
         da = GiftiDataArray.from_array(bs_arr, 'triangle')
         assert_equal(da.datatype, data_type_codes[arr.dtype])
+
+
+def test_labeltable():
+    img = GiftiImage()
+    assert_equal(len(img.labeltable.labels), 0)
+
+    new_table = GiftiLabelTable()
+    new_table.labels += ['test', 'me']
+    img.labeltable = new_table
+    assert_equal(len(img.labeltable.labels), 2)
+

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -26,6 +26,35 @@ def test_gifti_image():
     gi = GiftiImage()
     assert_equal(gi.darrays, [])
 
+    # Test darrays / numDA
+    gi = GiftiImage()
+    assert_equal(gi.numDA, 0)
+
+    da = GiftiDataArray(data='data')
+    gi.add_gifti_data_array(da)
+    assert_equal(gi.numDA, 1)
+    assert_equal(gi.darrays[0].data, 'data')
+
+    gi.remove_gifti_data_array(0)
+    assert_equal(gi.numDA, 0)
+
+    # Remove from empty
+    gi = GiftiImage()
+    gi.remove_gifti_data_array_by_intent(0)
+    assert_equal(gi.numDA, 0)
+
+    # Remove one
+    gi = GiftiImage()
+    da = GiftiDataArray(data='data')
+    gi.add_gifti_data_array(da)
+
+    gi.remove_gifti_data_array_by_intent(0)
+    assert_equal(gi.numDA, 1)
+
+    gi.darrays[0].intent = 0
+    gi.remove_gifti_data_array_by_intent(0)
+    assert_equal(gi.numDA, 0)
+
 
 def test_dataarray():
     for dt_code in data_type_codes.value_set():

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -300,3 +300,23 @@ def test_labeltable_deprecations():
         warnings.filterwarnings('once', category=DeprecationWarning)
         img.set_labeltable(lt)
     assert_equal(lt, img.labeltable)
+
+
+def test_parse_dataarrays():
+    fn = 'bad_daa.gii'
+    img = gi.GiftiImage()
+
+    with InTemporaryDirectory():
+        gi.write(img, fn)
+        with open(fn, 'r') as fp:
+            txt = fp.read()
+        # Make a bad gifti.
+        txt = txt.replace('NumberOfDataArrays="0"', 'NumberOfDataArrays ="1"')
+        with open(fn, 'w') as fp:
+            fp.write(txt)
+
+        with clear_and_catch_warnings() as w:
+            warnings.filterwarnings('once', category=UserWarning)
+            gi.read(fn)
+            assert_equal(len(w), 1)
+            assert_equal(img.numDA, 0)

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -117,6 +117,21 @@ def test_load_metadata():
         assert_equal(img.version,'1.0')
 
 
+def test_metadata_deprecations():
+    img = gi.read(datafiles[0])
+    me = img.meta
+
+    # Test deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_equal(me, img.get_meta())
+
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        img.set_metadata(me)
+    assert_equal(me, img.meta)
+
+
 def test_load_dataarray1():
     img1 = gi.read(DATA_FILE1)
 
@@ -270,3 +285,18 @@ def test_load_labeltable():
         assert_equal(img.labeltable.labels[1].green, 0.392157)
         assert_equal(img.labeltable.labels[1].blue, 0.156863)
         assert_equal(img.labeltable.labels[1].alpha, 1)
+
+
+def test_labeltable_deprecations():
+    img = gi.read(DATA_FILE6)
+    lt = img.labeltable
+
+    # Test deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_equal(lt, img.get_labeltable())
+
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        img.set_labeltable(lt)
+    assert_equal(lt, img.labeltable)

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -41,8 +41,8 @@ DATA_FILE5 = pjoin(IO_DATA_PATH, 'base64bin.gii')
 DATA_FILE6 = pjoin(IO_DATA_PATH, 'rh.aparc.annot.gii')
 
 datafiles = [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4, DATA_FILE5, DATA_FILE6]
-numda = [2, 1, 1, 1, 2, 1]
- 
+numDA = [2, 1, 1, 1, 2, 1]
+
 DATA_FILE1_darr1 = np.array(
        [[-16.07201 , -66.187515,  21.266994],
        [-16.705893, -66.054337,  21.232786],
@@ -113,7 +113,7 @@ def test_load_metadata():
     for i, dat in enumerate(datafiles):
         img = gi.read(dat)
         me = img.meta
-        assert_equal(numda[i], img.numDA)
+        assert_equal(numDA[i], img.numDA)
         assert_equal(img.version,'1.0')
 
 

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -112,8 +112,7 @@ def test_read_ordering():
 def test_metadata():
     for i, dat in enumerate(datafiles):
         img = gi.read(dat)
-        me = img.get_metadata()
-        medat = me.get_metadata()
+        me = img.meta
         assert_equal(numda[i], img.numDA)
         assert_equal(img.version,'1.0')
 
@@ -217,11 +216,11 @@ def test_newmetadata():
     img = gi.GiftiImage()
     attr = gi.GiftiNVPairs(name = 'mykey', value = 'val1')
     newmeta = gi.GiftiMetaData(attr)
-    img.set_metadata(newmeta)
+    img.meta = newmeta
     myme = img.meta.get_metadata()
     assert_true('mykey' in myme)
     newmeta = gi.GiftiMetaData.from_dict( {'mykey1' : 'val2'} )
-    img.set_metadata(newmeta)
+    img.meta = newmeta
     myme = img.meta.get_metadata()
     assert_true('mykey1' in myme)
     assert_false('mykey' in myme)

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -142,7 +142,7 @@ def test_load_dataarray1():
     for img in (img1, bimg):
         assert_array_almost_equal(img.darrays[0].data, DATA_FILE1_darr1)
         assert_array_almost_equal(img.darrays[1].data, DATA_FILE1_darr2)
-        me=img.darrays[0].meta.get_metadata()
+        me=img.darrays[0].meta.metadata
         assert_true('AnatomicalStructurePrimary' in me)
         assert_true('AnatomicalStructureSecondary' in me)
         assert_equal(me['AnatomicalStructurePrimary'], 'CortexLeft')
@@ -237,11 +237,11 @@ def test_write_newmetadata():
     attr = gi.GiftiNVPairs(name = 'mykey', value = 'val1')
     newmeta = gi.GiftiMetaData(attr)
     img.meta = newmeta
-    myme = img.meta.get_metadata()
+    myme = img.meta.metadata
     assert_true('mykey' in myme)
     newmeta = gi.GiftiMetaData.from_dict( {'mykey1' : 'val2'} )
     img.meta = newmeta
-    myme = img.meta.get_metadata()
+    myme = img.meta.metadata
     assert_true('mykey1' in myme)
     assert_false('mykey' in myme)
 

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -109,7 +109,7 @@ def test_read_ordering():
     assert_equal(img.darrays[0].data.shape, (3,3))
 
 
-def test_metadata():
+def test_load_metadata():
     for i, dat in enumerate(datafiles):
         img = gi.read(dat)
         me = img.meta
@@ -117,8 +117,9 @@ def test_metadata():
         assert_equal(img.version,'1.0')
 
 
-def test_dataarray1():
+def test_load_dataarray1():
     img1 = gi.read(DATA_FILE1)
+
     # Round trip
     with InTemporaryDirectory():
         gi.write(img1, 'test.gii')
@@ -135,8 +136,9 @@ def test_dataarray1():
         assert_equal(xform_codes.niistring[img.darrays[0].coordsys.xformspace],'NIFTI_XFORM_TALAIRACH')
 
 
-def test_dataarray2():
+def test_load_dataarray2():
     img2 = gi.read(DATA_FILE2)
+
     # Round trip
     with InTemporaryDirectory():
         gi.write(img2, 'test.gii')
@@ -145,8 +147,9 @@ def test_dataarray2():
         assert_array_almost_equal(img.darrays[0].data[:10], DATA_FILE2_darr1)
 
 
-def test_dataarray3():
+def test_load_dataarray3():
     img3 = gi.read(DATA_FILE3)
+
     with InTemporaryDirectory():
         gi.write(img3, 'test.gii')
         bimg = gi.read('test.gii')
@@ -154,8 +157,9 @@ def test_dataarray3():
         assert_array_almost_equal(img.darrays[0].data[30:50], DATA_FILE3_darr1)
 
 
-def test_dataarray4():
+def test_load_dataarray4():
     img4 = gi.read(DATA_FILE4)
+
     # Round trip
     with InTemporaryDirectory():
         gi.write(img4, 'test.gii')
@@ -166,6 +170,7 @@ def test_dataarray4():
 
 def test_dataarray5():
     img5 = gi.read(DATA_FILE5)
+
     for da in img5.darrays:
         assert_equal(gifti_endian_codes.byteorder[da.endian], 'little')
     assert_array_almost_equal(img5.darrays[0].data, DATA_FILE5_darr1)
@@ -212,7 +217,7 @@ def test_readwritedata():
                                   img2.darrays[0].data)
 
 
-def test_newmetadata():
+def test_write_newmetadata():
     img = gi.GiftiImage()
     attr = gi.GiftiNVPairs(name = 'mykey', value = 'val1')
     newmeta = gi.GiftiMetaData(attr)
@@ -226,7 +231,7 @@ def test_newmetadata():
     assert_false('mykey' in myme)
 
 
-def test_getbyintent():
+def test_load_getbyintent():
     img = gi.read(DATA_FILE1)
 
     da = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")
@@ -247,8 +252,9 @@ def test_getbyintent():
     assert_equal(da, [])
 
 
-def test_labeltable():
+def test_load_labeltable():
     img6 = gi.read(DATA_FILE6)
+
     # Round trip
     with InTemporaryDirectory():
         gi.write(img6, 'test.gii')


### PR DESCRIPTION
`numDA`, `version`, and `filename` properties on GIFTI have `set_` and `get_` methods. Seems cleaner (and more pythonic) to use Python properties instead.

Question: is GIFTI support officially published? I.e. do I need to add deprecation warnings for the old methods, and deprecation tests?

Also renamed tests to be clear that they're testing the loading of these properties, not necessarily of their setting or saving.