### PR TITLE
BF: Make sure xml is encoded as utf-8

### DIFF
--- a/nibabel/gifti/__init__.py
+++ b/nibabel/gifti/__init__.py
@@ -19,4 +19,4 @@
 
 from .giftiio import read, write
 from .gifti import (GiftiMetaData, GiftiNVPairs, GiftiLabelTable, GiftiLabel,
-                    GiftiCoordSystem, data_tag, GiftiDataArray, GiftiImage)
+                    GiftiCoordSystem, GiftiDataArray, GiftiImage)

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -185,6 +185,17 @@ class GiftiCoordSystem(xml.XmlSerializable):
         print('Affine Transformation Matrix: \n', self.xform)
 
 
+@np.deprecate_with_doc("This is an internal API that will be discontinued.")
+def data_tag(dataarray, encoding, datatype, ordering):
+    class DataTag(xml.XmlSerializable):
+        def __init__(self, *args):
+            self.args = args
+        def _to_xml_element(self):
+            return _data_tag_element(*self.args)
+
+    return DataTag(dataarray, encoding, datatype, ordering).to_xml()
+
+
 def _data_tag_element(dataarray, encoding, datatype, ordering):
     """ Creates the data tag depending on the required encoding,
     returns as XML element"""

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -9,10 +9,10 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-import xml.etree.ElementTree as xml
 
 import numpy as np
 
+from .. import xmlutils as xml
 from ..nifti1 import data_type_codes, xform_codes, intent_codes
 from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes, KIND2FMT)
@@ -23,19 +23,7 @@ from .util import (array_index_order_codes, gifti_encoding_codes,
 import base64
 
 
-class XmlSerializable(object):
-    """ Basic interface for serializing an object to xml"""
-    def _to_xml_element(self):
-        """ Output should be a xml.etree.ElementTree.Element"""
-        raise NotImplementedError()
-
-    def to_xml(self, enc='utf-8'):
-        """ Output should be an xml string with the given encoding.
-        (default: utf-8)"""
-        return xml.tostring(self._to_xml_element(), enc)
-
-
-class GiftiMetaData(XmlSerializable):
+class GiftiMetaData(xml.XmlSerializable):
     """ A list of GiftiNVPairs in stored in
     the list self.data """
     def __init__(self, nvpair=None):
@@ -87,7 +75,7 @@ class GiftiNVPairs(object):
         self.value = value
 
 
-class GiftiLabelTable(XmlSerializable):
+class GiftiLabelTable(xml.XmlSerializable):
 
     def __init__(self):
         self.labels = []
@@ -113,7 +101,7 @@ class GiftiLabelTable(XmlSerializable):
         print(self.get_labels_as_dict())
 
 
-class GiftiLabel(XmlSerializable):
+class GiftiLabel(xml.XmlSerializable):
     key = int
     label = str
     # rgba
@@ -166,7 +154,7 @@ def _arr2txt(arr, elem_fmt):
     return '\n'.join(fmt % tuple(row) for row in arr)
 
 
-class GiftiCoordSystem(XmlSerializable):
+class GiftiCoordSystem(xml.XmlSerializable):
     dataspace = int
     xformspace = int
     xform = np.ndarray  # 4x4 numpy array
@@ -199,7 +187,7 @@ class GiftiCoordSystem(XmlSerializable):
 
 def _data_tag_element(dataarray, encoding, datatype, ordering):
     """ Creates the data tag depending on the required encoding,
-    returns as bytes"""
+    returns as XML element"""
     import zlib
     ord = array_index_order_codes.npcode[ordering]
     enclabel = gifti_encoding_codes.label[encoding]
@@ -225,7 +213,7 @@ def data_tag(dataarray, encoding, datatype, ordering):
     return xml.tostring(data, 'utf-8')
 
 
-class GiftiDataArray(XmlSerializable):
+class GiftiDataArray(xml.XmlSerializable):
 
     # These are for documentation only; we don't use these class variables
     intent = int
@@ -362,7 +350,7 @@ class GiftiDataArray(XmlSerializable):
         return self.meta.metadata
 
 
-class GiftiImage(XmlSerializable):
+class GiftiImage(xml.XmlSerializable):
 
     def __init__(self, meta=None, labeltable=None, darrays=None,
                  version="1.0"):
@@ -506,4 +494,4 @@ class GiftiImage(XmlSerializable):
         """ Return XML corresponding to image content """
         return b"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE GIFTI SYSTEM "http://www.nitrc.org/frs/download.php/115/gifti.dtd">
-""" + XmlSerializable.to_xml(self, enc)
+""" + xml.XmlSerializable.to_xml(self, enc)

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -208,11 +208,6 @@ def _data_tag_element(dataarray, encoding, datatype, ordering):
     return data
 
 
-def data_tag(dataarray, encoding, datatype, ordering):
-    data = _data_tag_element(dataarray, encoding, datatype, ordering)
-    return xml.tostring(data, 'utf-8')
-
-
 class GiftiDataArray(xml.XmlSerializable):
 
     # These are for documentation only; we don't use these class variables

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -330,6 +330,34 @@ class GiftiDataArray(xml.XmlSerializable):
 
         return data_array
 
+    @np.deprecate_with_doc("Use the to_xml() function instead.")
+    def to_xml_open(self):
+        out = """<DataArray Intent="%s"
+\tDataType="%s"
+\tArrayIndexingOrder="%s"
+\tDimensionality="%s"
+%s\tEncoding="%s"
+\tEndian="%s"
+\tExternalFileName="%s"
+\tExternalFileOffset="%s">\n"""
+        di = ""
+        for i, n in enumerate(self.dims):
+            di = di + '\tDim%s=\"%s\"\n' % (str(i), str(n))
+        return out % (intent_codes.niistring[self.intent],
+                      data_type_codes.niistring[self.datatype],
+                      array_index_order_codes.label[self.ind_ord],
+                      str(self.num_dim),
+                      str(di),
+                      gifti_encoding_codes.specs[self.encoding],
+                      gifti_endian_codes.specs[self.endian],
+                      self.ext_fname,
+                      self.ext_offset,
+                      )
+
+    @np.deprecate_with_doc("Use the to_xml() function instead.")
+    def to_xml_close(self):
+        return "</DataArray>\n"
+
     def print_summary(self):
         print('Intent: ', intent_codes.niistring[self.intent])
         print('DataType: ', data_type_codes.niistring[self.datatype])

--- a/nibabel/gifti/giftiio.py
+++ b/nibabel/gifti/giftiio.py
@@ -80,5 +80,5 @@ def write(image, filename):
     The Gifti file is stored in endian convention of the current machine.
     """
     # Our giftis are always utf-8 encoded - see GiftiImage.to_xml
-    with codecs.open(filename, 'wb', encoding='utf-8') as f:
+    with open(filename, 'wb') as f:
         f.write(image.to_xml())

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -4,17 +4,17 @@ import warnings
 
 import numpy as np
 
-from nibabel.gifti import giftiio
+from nibabel.gifti import (GiftiImage, GiftiDataArray, GiftiLabel,
+                           GiftiLabelTable, GiftiMetaData, giftiio)
+from nibabel.gifti.gifti import data_tag
+from nibabel.nifti1 import data_type_codes, intent_codes
 
-from .test_giftiio import (DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
-                           DATA_FILE5, DATA_FILE6)
-from ..gifti import (GiftiImage, GiftiDataArray, GiftiLabel, GiftiLabelTable,
-                     GiftiMetaData)
-from ...nifti1 import data_type_codes, intent_codes
-from ...testing import clear_and_catch_warnings
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
+from nibabel.testing import clear_and_catch_warnings
+from .test_giftiio import (DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
+                           DATA_FILE5, DATA_FILE6)
 
 
 def test_gifti_image():
@@ -163,3 +163,11 @@ def test_gifti_image():
     def assign_metadata(val):
         img.meta = val
     assert_raises(TypeError, assign_metadata, 'not-a-meta')
+
+
+def test_data_tag_deprecated():
+    img = GiftiImage()
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        data_tag(np.array([]), 'ASCII', '%i', 1)
+        assert_equal(len(w), 1)

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 
+from nibabel.externals.six import string_types
 from nibabel.gifti import (GiftiImage, GiftiDataArray, GiftiLabel,
                            GiftiLabelTable, GiftiMetaData, giftiio)
 from nibabel.gifti.gifti import data_tag
@@ -69,6 +70,17 @@ def test_dataarray():
         bs_arr = arr.byteswap().newbyteorder()
         da = GiftiDataArray.from_array(bs_arr, 'triangle')
         assert_equal(da.datatype, data_type_codes[arr.dtype])
+
+    # Smoke test on deprecated functions
+    da = GiftiDataArray.from_array(np.ones((1,)), 'triangle')
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+        assert_true(isinstance(da.to_xml_open(), string_types))
+        assert_equal(len(w), 1)
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
+        assert_true(isinstance(da.to_xml_close(), string_types))
+        assert_equal(len(w), 1)
 
 
 def test_labeltable():

--- a/nibabel/xmlutils.py
+++ b/nibabel/xmlutils.py
@@ -1,0 +1,25 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the NiBabel package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+Thin layer around xml.etree.ElementTree, to abstract nibabel xml support.
+"""
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+
+class XmlSerializable(object):
+    """ Basic interface for serializing an object to xml"""
+
+    def _to_xml_element(self):
+        """ Output should be a xml.etree.ElementTree.Element"""
+        raise NotImplementedError()
+
+    def to_xml(self, enc='utf-8'):
+        """ Output should be an xml string with the given encoding.
+        (default: utf-8)"""
+        return tostring(self._to_xml_element(), enc)


### PR DESCRIPTION
Valid XML has to be utf-8--in bytes. Current code doesn't explicitly encode or decode, and so different versions of Python return bytes (Python 2) or Unicode (Python 3). 

This caused test errors in the `cifti` PR (and was fixed there); a similar issue needs to be fixed for GIFTI.