### PR TITLE
TST: Add GIFTI tests

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -155,6 +155,7 @@ class GiftiLabel(object):
             raise ValueError('rgba must be length 4.')
         self.red, self.green, self.blue, self.alpha = rgba
 
+
 def _arr2txt(arr, elem_fmt):
     arr = np.asarray(arr)
     assert arr.dtype.names is None
@@ -404,7 +405,7 @@ class GiftiImage(object):
 
         """
         if not isinstance(labeltable, GiftiLabelTable):
-            raise ValueError("Not a valid GiftiLabelTable instance")
+            raise TypeError("Not a valid GiftiLabelTable instance")
         self._labeltable = labeltable
 
     @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
@@ -432,7 +433,7 @@ class GiftiImage(object):
         None
         """
         if not isinstance(meta, GiftiMetaData):
-            raise ValueError("Not a valid GiftiMetaData instance")
+            raise TypeError("Not a valid GiftiMetaData instance")
         self._meta = meta
 
     @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
@@ -450,10 +451,9 @@ class GiftiImage(object):
         ----------
         dataarr : GiftiDataArray
         """
-        if isinstance(dataarr, GiftiDataArray):
-            self.darrays.append(dataarr)
-        else:
-            raise ValueError("dataarr paramater must be of type GiftiDataArray")
+        if not isinstance(dataarr, GiftiDataArray):
+            raise TypeError("dataarr paramater must be of type GiftiDataArray")
+        self.darrays.append(dataarr)
 
     def remove_gifti_data_array(self, ith):
         """ Removes the ith data array element from the GiftiImage """

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -453,7 +453,7 @@ class GiftiImage(object):
         if isinstance(dataarr, GiftiDataArray):
             self.darrays.append(dataarr)
         else:
-            print("dataarr paramater must be of tzpe GiftiDataArray")
+            raise ValueError("dataarr paramater must be of type GiftiDataArray")
 
     def remove_gifti_data_array(self, ith):
         """ Removes the ith data array element from the GiftiImage """

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -452,7 +452,7 @@ class GiftiImage(object):
         dataarr : GiftiDataArray
         """
         if not isinstance(dataarr, GiftiDataArray):
-            raise TypeError("dataarr paramater must be of type GiftiDataArray")
+            raise TypeError("Not a valid GiftiDataArray instance")
         self.darrays.append(dataarr)
 
     def remove_gifti_data_array(self, ith):

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -83,7 +83,7 @@ def test_labeltable():
     # Try to set to non-table
     def assign_labeltable(val):
         img.labeltable = val
-    assert_raises(ValueError, assign_labeltable, 'not-a-table')
+    assert_raises(TypeError, assign_labeltable, 'not-a-table')
 
 
 def test_metadata():
@@ -156,4 +156,4 @@ def test_gifti_image():
     assert_true(img.meta is not None)
     assert_true(img.labeltable is not None)
 
-    assert_raises(ValueError, img.add_gifti_data_array, 'not-a-data-array')
+    assert_raises(TypeError, img.add_gifti_data_array, 'not-a-data-array')

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -4,14 +4,17 @@ import warnings
 
 import numpy as np
 
+from nibabel.gifti import giftiio
+
+from .test_giftiio import (DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
+                           DATA_FILE5, DATA_FILE6)
 from ..gifti import (GiftiImage, GiftiDataArray, GiftiLabel, GiftiLabelTable,
                      GiftiMetaData)
 from ...nifti1 import data_type_codes, intent_codes
-
+from ...testing import clear_and_catch_warnings
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
-from ...testing import clear_and_catch_warnings
 
 
 def test_gifti_image():
@@ -127,3 +130,30 @@ def test_gifti_label_rgba():
     gl4 = GiftiLabel()
     assert_equal(len(gl4.rgba), 4)
     assert_true(np.all([elem is None for elem in gl4.rgba]))
+
+
+def test_print_summary():
+    for fil in [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
+                            DATA_FILE5, DATA_FILE6]:
+        gimg = giftiio.read(fil)
+        gimg.print_summary()
+
+
+def test_gifti_coord():
+    from ..gifti import GiftiCoordSystem
+    gcs = GiftiCoordSystem()
+    assert_true(gcs.xform is not None)
+
+    # Smoke test
+    gcs.xform = None
+    gcs.print_summary()
+    gcs.to_xml()
+
+
+def test_gifti_image():
+    img = GiftiImage()
+    assert_true(img.darrays is not None)
+    assert_true(img.meta is not None)
+    assert_true(img.labeltable is not None)
+
+    assert_raises(ValueError, img.add_gifti_data_array, 'not-a-data-array')

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -80,11 +80,6 @@ def test_labeltable():
     img.labeltable = new_table
     assert_equal(len(img.labeltable.labels), 2)
 
-    # Try to set to non-table
-    def assign_labeltable(val):
-        img.labeltable = val
-    assert_raises(TypeError, assign_labeltable, 'not-a-table')
-
 
 def test_metadata():
     # Test deprecation
@@ -156,4 +151,15 @@ def test_gifti_image():
     assert_true(img.meta is not None)
     assert_true(img.labeltable is not None)
 
+    # Try to set a non-data-array
     assert_raises(TypeError, img.add_gifti_data_array, 'not-a-data-array')
+
+    # Try to set to non-table
+    def assign_labeltable(val):
+        img.labeltable = val
+    assert_raises(TypeError, assign_labeltable, 'not-a-table')
+
+    # Try to set to non-table
+    def assign_metadata(val):
+        img.meta = val
+    assert_raises(TypeError, assign_metadata, 'not-a-meta')


### PR DESCRIPTION
This isn't complete, but add some basic smoke tests (at least `print_summary` shouldn't raise an error), that explicit errors are hit, and that non-`None` defaults are set by objects.