### PR TITLE
WIP: add GIFTI to nib.load/save (and enable non-SpatialImage classes in load/save)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ dist/
 .tox/
 .coverage
 .ropeproject/
+htmlcov/
 
 # Logs and databases #
 ######################

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -386,11 +386,15 @@ class GiftiDataArray(xml.XmlSerializable):
 
 
 class GiftiImage(FileBasedImage, xml.XmlSerializable):
+    valid_exts = ('.gii',)
     files_types = (('image', '.gii'),)
     valid_exts = ('.gii',)
 
-    def __init__(self, meta=None, labeltable=None, darrays=None,
-                 version="1.0"):
+    def __init__(self, header=None, extra=None, file_map=None, meta=None,
+                 labeltable=None, darrays=None, version="1.0"):
+        FileBasedImage.__init__(self, header=header, extra=extra,
+                                file_map=file_map)
+
         if darrays is None:
             darrays = []
         if meta is None:

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -191,6 +191,7 @@ def data_tag(dataarray, encoding, datatype, ordering):
     class DataTag(xml.XmlSerializable):
         def __init__(self, *args):
             self.args = args
+
         def _to_xml_element(self):
             return _data_tag_element(*self.args)
 
@@ -518,7 +519,6 @@ class GiftiImage(FileBasedImage, xml.XmlSerializable):
             print(da.print_summary())
         print('----end----')
 
-
     def _to_xml_element(self):
         GIFTI = xml.Element('GIFTI', attrib={
             'Version': self.version,
@@ -550,7 +550,8 @@ class GiftiImage(FileBasedImage, xml.XmlSerializable):
             Returns a GiftiImage
          """
         from .parse_gifti_fast import parse_gifti_file
-        return parse_gifti_file(fptr=file_map['image'].get_prepare_fileobj('rb'))
+        return parse_gifti_file(
+            fptr=file_map['image'].get_prepare_fileobj('rb'))
 
     def to_file_map(self, file_map=None):
         """ Save the current image to the specified file_map
@@ -565,8 +566,8 @@ class GiftiImage(FileBasedImage, xml.XmlSerializable):
 
         Notes
         -----
-        We write all files with utf-8 encoding, and specify this at the top of the
-        XML file with the ``encoding`` attribute.
+        We write all files with utf-8 encoding, and specify this at the top of
+        the XML file with the ``encoding`` attribute.
 
         The Gifti spec suggests using the following suffixes to your
         filename when saving each specific type of data:

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -389,7 +389,6 @@ class GiftiDataArray(xml.XmlSerializable):
 class GiftiImage(FileBasedImage, xml.XmlSerializable):
     valid_exts = ('.gii',)
     files_types = (('image', '.gii'),)
-    valid_exts = ('.gii',)
 
     def __init__(self, header=None, extra=None, file_map=None, meta=None,
                  labeltable=None, darrays=None, version="1.0"):

--- a/nibabel/gifti/giftiio.py
+++ b/nibabel/gifti/giftiio.py
@@ -10,12 +10,7 @@
 # Stephan Gerhard, Oktober 2010
 ##############
 
-import warnings
-
 import numpy as np
-
-
-warnings.warn('Please use nibabel.load/save.', DeprecationWarning)
 
 
 @np.deprecate_with_doc("Use nibabel.load() instead.")
@@ -84,4 +79,3 @@ def write(image, filename):
     """
     from ..loadsave import save
     return save(image, filename)
-

--- a/nibabel/gifti/giftiio.py
+++ b/nibabel/gifti/giftiio.py
@@ -10,12 +10,15 @@
 # Stephan Gerhard, Oktober 2010
 ##############
 
-import os
-import codecs
+import warnings
 
-from .parse_gifti_fast import parse_gifti_file
+import numpy as np
 
 
+warnings.warn('Please use nibabel.load/save.', DeprecationWarning)
+
+
+@np.deprecate_with_doc("Use nibabel.load() instead.")
 def read(filename):
     """ Load a Gifti image from a file
 
@@ -29,11 +32,11 @@ def read(filename):
     img : GiftiImage
         Returns a GiftiImage
      """
-    if not os.path.isfile(filename):
-        raise IOError("No such file or directory: '%s'" % filename)
-    return parse_gifti_file(filename)
+    from ..loadsave import load
+    return load(filename)
 
 
+@np.deprecate_with_doc("Use nibabel.save() instead.")
 def write(image, filename):
     """ Save the current image to a new file
 
@@ -79,6 +82,6 @@ def write(image, filename):
 
     The Gifti file is stored in endian convention of the current machine.
     """
-    # Our giftis are always utf-8 encoded - see GiftiImage.to_xml
-    with open(filename, 'wb') as f:
-        f.write(image.to_xml())
+    from ..loadsave import save
+    return save(image, filename)
+

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -4,9 +4,10 @@ import warnings
 
 import numpy as np
 
+import nibabel as nib
 from nibabel.externals.six import string_types
 from nibabel.gifti import (GiftiImage, GiftiDataArray, GiftiLabel,
-                           GiftiLabelTable, GiftiMetaData, giftiio)
+                           GiftiLabelTable, GiftiMetaData)
 from nibabel.gifti.gifti import data_tag
 from nibabel.nifti1 import data_type_codes, intent_codes
 
@@ -14,8 +15,8 @@ from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 from nibabel.testing import clear_and_catch_warnings
-from .test_giftiio import (DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
-                           DATA_FILE5, DATA_FILE6)
+from .test_parse_gifti_fast import (DATA_FILE1, DATA_FILE2, DATA_FILE3,
+                                    DATA_FILE4, DATA_FILE5, DATA_FILE6)
 
 
 def test_gifti_image():
@@ -142,7 +143,7 @@ def test_gifti_label_rgba():
 def test_print_summary():
     for fil in [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4,
                             DATA_FILE5, DATA_FILE6]:
-        gimg = giftiio.read(fil)
+        gimg = nib.load(fil)
         gimg.print_summary()
 
 

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -1,0 +1,35 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the NiBabel package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import warnings
+
+from nose.tools import (assert_true, assert_false, assert_equal,
+                        assert_raises)
+from ...testing import clear_and_catch_warnings
+
+
+from .test_parse_gifti_fast import (DATA_FILE1, DATA_FILE2, DATA_FILE3,
+                                    DATA_FILE4, DATA_FILE5, DATA_FILE6)
+
+
+class TestGiftiIO(object):
+    def setUp(self):
+        with clear_and_catch_warnings() as w:
+            warnings.simplefilter('always', DeprecationWarning)
+            import nibabel.gifti.giftiio
+            assert_equal(len(w), 1)
+
+
+def test_read_deprecated():
+    with clear_and_catch_warnings() as w:
+        warnings.simplefilter('always', DeprecationWarning)
+        from nibabel.gifti.giftiio import read
+
+        img = read(DATA_FILE1)
+        assert_equal(len(w), 1)

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -15,6 +15,8 @@ import warnings
 import numpy as np
 
 from ... import gifti as gi
+from ...loadsave import load, save
+
 from ..util import gifti_endian_codes
 from ...nifti1 import xform_codes
 
@@ -102,23 +104,23 @@ def test_read_ordering():
     # DATA_FILE1 has an expected darray[0].data shape of (3,3).  However if we
     # read another image first (DATA_FILE2) then the shape is wrong
     # Read an image
-    img2 = gi.read(DATA_FILE2)
+    img2 = load(DATA_FILE2)
     assert_equal(img2.darrays[0].data.shape, (143479, 1))
     # Read image for which we know output shape
-    img = gi.read(DATA_FILE1)
+    img = load(DATA_FILE1)
     assert_equal(img.darrays[0].data.shape, (3,3))
 
 
 def test_load_metadata():
     for i, dat in enumerate(datafiles):
-        img = gi.read(dat)
+        img = load(dat)
         me = img.meta
         assert_equal(numDA[i], img.numDA)
         assert_equal(img.version,'1.0')
 
 
 def test_metadata_deprecations():
-    img = gi.read(datafiles[0])
+    img = load(datafiles[0])
     me = img.meta
 
     # Test deprecation
@@ -133,12 +135,11 @@ def test_metadata_deprecations():
 
 
 def test_load_dataarray1():
-    img1 = gi.read(DATA_FILE1)
-
+    img1 = load(DATA_FILE1)
     # Round trip
     with InTemporaryDirectory():
-        gi.write(img1, 'test.gii')
-        bimg = gi.read('test.gii')
+        save(img1, 'test.gii')
+        bimg = load('test.gii')
     for img in (img1, bimg):
         assert_array_almost_equal(img.darrays[0].data, DATA_FILE1_darr1)
         assert_array_almost_equal(img.darrays[1].data, DATA_FILE1_darr2)
@@ -152,40 +153,36 @@ def test_load_dataarray1():
 
 
 def test_load_dataarray2():
-    img2 = gi.read(DATA_FILE2)
-
+    img2 = load(DATA_FILE2)
     # Round trip
     with InTemporaryDirectory():
-        gi.write(img2, 'test.gii')
-        bimg = gi.read('test.gii')
+        save(img2, 'test.gii')
+        bimg = load('test.gii')
     for img in (img2, bimg):
         assert_array_almost_equal(img.darrays[0].data[:10], DATA_FILE2_darr1)
 
 
 def test_load_dataarray3():
-    img3 = gi.read(DATA_FILE3)
-
+    img3 = load(DATA_FILE3)
     with InTemporaryDirectory():
-        gi.write(img3, 'test.gii')
-        bimg = gi.read('test.gii')
+        save(img3, 'test.gii')
+        bimg = load('test.gii')
     for img in (img3, bimg):
         assert_array_almost_equal(img.darrays[0].data[30:50], DATA_FILE3_darr1)
 
 
 def test_load_dataarray4():
-    img4 = gi.read(DATA_FILE4)
-
+    img4 = load(DATA_FILE4)
     # Round trip
     with InTemporaryDirectory():
-        gi.write(img4, 'test.gii')
-        bimg = gi.read('test.gii')
+        save(img4, 'test.gii')
+        bimg = load('test.gii')
     for img in (img4, bimg):
         assert_array_almost_equal(img.darrays[0].data[:10], DATA_FILE4_darr1)
 
 
 def test_dataarray5():
-    img5 = gi.read(DATA_FILE5)
-
+    img5 = load(DATA_FILE5)
     for da in img5.darrays:
         assert_equal(gifti_endian_codes.byteorder[da.endian], 'little')
     assert_array_almost_equal(img5.darrays[0].data, DATA_FILE5_darr1)
@@ -204,8 +201,8 @@ def test_base64_written():
         assert_false(b'Base64Binary' in contents)
         assert_false(b'LittleEndian' in contents)
         # Round trip
-        img5 = gi.read(DATA_FILE5)
-        gi.write(img5, 'fixed.gii')
+        img5 = load(DATA_FILE5)
+        save(img5, 'fixed.gii')
         with open('fixed.gii', 'rb') as fobj:
             contents = fobj.read()
         # The bad codes have gone, replaced by the good ones
@@ -216,17 +213,17 @@ def test_base64_written():
             assert_true(b'LittleEndian' in contents)
         else:
             assert_true(b'BigEndian' in contents)
-        img5_fixed = gi.read('fixed.gii')
+        img5_fixed = load('fixed.gii')
         darrays = img5_fixed.darrays
         assert_array_almost_equal(darrays[0].data, DATA_FILE5_darr1)
         assert_array_almost_equal(darrays[1].data, DATA_FILE5_darr2)
 
 
 def test_readwritedata():
-    img = gi.read(DATA_FILE2)
+    img = load(DATA_FILE2)
     with InTemporaryDirectory():
-        gi.write(img, 'test.gii')
-        img2 = gi.read('test.gii')
+        save(img, 'test.gii')
+        img2 = load('test.gii')
         assert_equal(img.numDA,img2.numDA)
         assert_array_almost_equal(img.darrays[0].data,
                                   img2.darrays[0].data)
@@ -247,8 +244,7 @@ def test_write_newmetadata():
 
 
 def test_load_getbyintent():
-    img = gi.read(DATA_FILE1)
-
+    img = load(DATA_FILE1)
     da = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")
     assert_equal(len(da), 1)
 
@@ -268,12 +264,11 @@ def test_load_getbyintent():
 
 
 def test_load_labeltable():
-    img6 = gi.read(DATA_FILE6)
-
+    img6 = load(DATA_FILE6)
     # Round trip
     with InTemporaryDirectory():
-        gi.write(img6, 'test.gii')
-        bimg = gi.read('test.gii')
+        save(img6, 'test.gii')
+        bimg = load('test.gii')
     for img in (img6, bimg):
         assert_array_almost_equal(img.darrays[0].data[:3], DATA_FILE6_darr1)
         assert_equal(len(img.labeltable.labels), 36)
@@ -288,7 +283,7 @@ def test_load_labeltable():
 
 
 def test_labeltable_deprecations():
-    img = gi.read(DATA_FILE6)
+    img = load(DATA_FILE6)
     lt = img.labeltable
 
     # Test deprecation
@@ -307,7 +302,7 @@ def test_parse_dataarrays():
     img = gi.GiftiImage()
 
     with InTemporaryDirectory():
-        gi.write(img, fn)
+        save(img, fn)
         with open(fn, 'r') as fp:
             txt = fp.read()
         # Make a bad gifti.
@@ -317,6 +312,6 @@ def test_parse_dataarrays():
 
         with clear_and_catch_warnings() as w:
             warnings.filterwarnings('once', category=UserWarning)
-            gi.read(fn)
+            load(fn)
             assert_equal(len(w), 1)
             assert_equal(img.numDA, 0)

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -14,13 +14,11 @@ import warnings
 
 import numpy as np
 
-from ... import gifti as gi
-from ...loadsave import load, save
-
-from ..util import gifti_endian_codes
-from ...nifti1 import xform_codes
-
-from ...tmpdirs import InTemporaryDirectory
+import nibabel.gifti as gi
+from nibabel.gifti.util import gifti_endian_codes
+from nibabel.loadsave import load, save
+from nibabel.nifti1 import xform_codes
+from nibabel.tmpdirs import InTemporaryDirectory
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -10,15 +10,17 @@
 import warnings
 
 from .analyze import AnalyzeImage
-from .spm99analyze import Spm99AnalyzeImage
-from .spm2analyze import Spm2AnalyzeImage
-from .nifti1 import Nifti1Pair, Nifti1Image
-from .nifti2 import Nifti2Pair, Nifti2Image
+from .freesurfer import MGHImage
+from .gifti import GiftiImage
 from .minc1 import Minc1Image
 from .minc2 import Minc2Image
-from .freesurfer import MGHImage
+from .nifti1 import Nifti1Pair, Nifti1Image
+from .nifti2 import Nifti2Pair, Nifti2Image
 from .parrec import PARRECImage
+from .spm99analyze import Spm99AnalyzeImage
+from .spm2analyze import Spm2AnalyzeImage
 from .volumeutils import Recoder
+
 from .optpkg import optional_package
 _, have_scipy, _ = optional_package('scipy')
 
@@ -27,7 +29,7 @@ _, have_scipy, _ = optional_package('scipy')
 all_image_classes = [Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
                      Spm2AnalyzeImage, Spm99AnalyzeImage, AnalyzeImage,
                      Minc1Image, Minc2Image, MGHImage,
-                     PARRECImage]
+                     PARRECImage, GiftiImage]
 
 
 # DEPRECATED: mapping of names to classes and class functionality

--- a/nibabel/tests/test_files_interface.py
+++ b/nibabel/tests/test_files_interface.py
@@ -15,17 +15,20 @@ import numpy as np
 from .. import Nifti1Image, Nifti1Pair, MGHImage, all_image_classes
 from ..externals.six import BytesIO
 from ..fileholders import FileHolderError
+from ..spatialimages import SpatialImage
 
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 
-def test_files_images():
+def test_files_spatialimages():
     # test files creation in image classes
     arr = np.zeros((2,3,4))
     aff = np.eye(4)
-    for klass in all_image_classes:
+    klasses = [klass for klass in all_image_classes
+               if klass.rw and issubclass(klass, SpatialImage)]
+    for klass in klasses:
         file_map = klass.make_file_map()
         for key, value in file_map.items():
             assert_equal(value.filename, None)
@@ -81,11 +84,12 @@ def test_files_interface():
     assert_array_equal(img2.get_data(), img.get_data())
 
 
-def test_round_trip():
+def test_round_trip_spatialimages():
     # write an image to files
     data = np.arange(24, dtype='i4').reshape((2, 3, 4))
     aff = np.eye(4)
-    klasses = filter(lambda klass: klass.rw, all_image_classes)
+    klasses = [klass for klass in all_image_classes
+               if klass.rw and issubclass(klass, SpatialImage)]
     for klass in klasses:
         file_map = klass.make_file_map()
         for key in file_map:

--- a/nibabel/tests/test_image_load_save.py
+++ b/nibabel/tests/test_image_load_save.py
@@ -27,6 +27,7 @@ from .. import (Nifti1Image, Nifti1Header, Nifti1Pair, Nifti2Image, Nifti2Pair,
 from ..tmpdirs import InTemporaryDirectory
 from ..volumeutils import native_code, swapped_code
 from ..optpkg import optional_package
+from ..spatialimages import SpatialImage
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal
@@ -45,17 +46,19 @@ def round_trip(img):
     return img2
 
 
-def test_conversion():
+def test_conversion_spatialimages():
     shape = (2, 4, 6)
     affine = np.diag([1, 2, 3, 1])
+    klasses = [klass for klass in all_image_classes
+               if klass.rw and issubclass(klass, SpatialImage)]
     for npt in np.float32, np.int16:
         data = np.arange(np.prod(shape), dtype=npt).reshape(shape)
-        for r_class in all_image_classes:
+        for r_class in klasses:
             if not r_class.makeable:
                 continue
             img = r_class(data, affine)
             img.set_data_dtype(npt)
-            for w_class in all_image_classes:
+            for w_class in klasses:
                 if not w_class.makeable:
                     continue
                 img2 = w_class.from_image(img)


### PR DESCRIPTION
This is for #316. All the recent work has been to get us here :D Thanks @matthew-brett and @effigies !

**Issue:**
The final issue blocking streamlined GIFTI/CIFTI in nibabel is: image file I/O functions are tied directly to the `SpatialImage` class; non-volumetric images (GIFTI/CIFTI) can't extend `SpatialImage` and so can't easily get in the `load`/`save` patheway.

**Proposed Solution:**
The good news is, the file I/O code actually is quite general. We can easily abstract the file I/O into a higher-level class (which I've called `FileBasedHeader`/`FileBasedImage`, as the more generic `Header` was already taken) that `SpatialImage` and `GiftiImage` inherit from.

**Caveats:**
One danger in doing this is that *not all image classes (`nibabel.imageclasses.all_image_classes`) will be of type `SpatialImage`*. Some tests assume this, and I'm not sure if there's other code out there that might.

**To do:**
- [X] Move file I/O from `SpatialImage` into `FileBasedHeader`/`FileBasedImage` 
- [X] Update tests that assume all image types are of type `SpatialImage`
- [X] Extend `GiftiImage` from `FileBasedImage`
- [x] Deprecate public access to `nibabel.gifti.read` and `nibabel.gifti.write`
- [x] Clean up code (a bit messy from merge/unmerge/refactor/rebase, plus my own fiddling)

**Notes:**
* Given the above design, I believe this is mostly done. Rather than fine-tuning the code now, I'd rather get ideas about the overall design first. @matthew-brett and @effigies , your input is most welcome when you have the time!
* Whatever we decide here, I'll be using to push forward CIFTI support, in #249 .