### PR TITLE
[WIP] BF: Check for attribute existence before value

### DIFF
--- a/nisext/codegen.py
+++ b/nisext/codegen.py
@@ -174,14 +174,14 @@ class SourceGenerator(NodeVisitor):
                 paren_or_comma()
                 self.write(keyword.arg + '=')
                 self.visit(keyword.value)
-            if node.starargs is not None:
-                paren_or_comma()
-                self.write('*')
-                self.visit(node.starargs)
-            if node.kwargs is not None:
-                paren_or_comma()
-                self.write('**')
-                self.visit(node.kwargs)
+        if hasattr(node, 'starargs') and node.starargs is not None:
+            paren_or_comma()
+            self.write('*')
+            self.visit(node.starargs)
+        if hasattr(node, 'kwargs') and node.kwargs is not None:
+            paren_or_comma()
+            self.write('**')
+            self.visit(node.kwargs)
         self.write(have_args and '):' or ':')
         self.body(node.body)
 

--- a/nisext/codegen.py
+++ b/nisext/codegen.py
@@ -339,11 +339,11 @@ class SourceGenerator(NodeVisitor):
             write_comma()
             self.write(keyword.arg + '=')
             self.visit(keyword.value)
-        if node.starargs is not None:
+        if hasattr(node, 'starargs') and node.starargs is not None:
             write_comma()
             self.write('*')
             self.visit(node.starargs)
-        if node.kwargs is not None:
+        if hasattr(node, 'kwargs') and node.kwargs is not None:
             write_comma()
             self.write('**')
             self.visit(node.kwargs)


### PR DESCRIPTION
Indentation seemed to be erroneous, as the presence of keyword arguments should not be prerequisite for `*args` and `**kwargs`.

Closes #366.