### PR TITLE
RF: Move extension_codes to within Nifti1Extensions.

### DIFF
--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -20,8 +20,7 @@ from nibabel.eulerangles import euler2mat
 from nibabel.externals.six import BytesIO
 from nibabel.nifti1 import (load, Nifti1Header, Nifti1PairHeader, Nifti1Image,
                             Nifti1Pair, Nifti1Extension, Nifti1Extensions,
-                            data_type_codes, extension_codes,
-                            slice_order_codes)
+                            data_type_codes, slice_order_codes)
 from nibabel.openers import ImageOpener
 from nibabel.spatialimages import HeaderDataError
 from nibabel.tmpdirs import InTemporaryDirectory
@@ -35,11 +34,13 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_almost_equal)
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_raises)
-
 from ..testing import data_path, suppress_warnings, runif_extra_has
 
 from . import test_analyze as tana
 from . import test_spm99analyze as tspm
+from .nibabel_data import get_nibabel_data, needs_nibabel_data
+from .test_arraywriters import rt_err_estimate, IUINT_TYPES
+from .test_helpers import bytesio_filemap, bytesio_round_trip
 
 header_file = os.path.join(data_path, 'nifti1.hdr')
 image_file = os.path.join(data_path, 'example4d.nii.gz')
@@ -1034,9 +1035,8 @@ def test_ext_eq():
 
 
 def test_extension_codes():
-    for k in extension_codes.keys():
+    for k in Nifti1Extensions.extension_codes.keys():
         Nifti1Extension(k, 'somevalue')
-
 
 def test_extension_list():
     ext_c0 = Nifti1Extensions()


### PR DESCRIPTION
Note: this is taken from https://github.com/satra/nibabel/pull/2 ; an implementation extending `extension_codes` for `CIFTI` can be found there.

`nifti1.extension_codes` is fixed (for the `Nifti1Image1` format, the list is fixed) and extensible (new `Nifti1Extension`s can be declared for image formats that extend `Nifti1Image`).

To support extensibility via encapsulation, I am suggesting `extension_codes` be a property of the `*Extensions` object. That way, `Nifti1Extensions.extension_codes` can remain fixed, while new image formats can extend this (e.g. `CiftiExtensions.extension_codes` extends `Nifti1Extensions` and adds extension codes). 

This should avoid potential side-effects of adding new `extension_codes` for new image formats.

***Notes:***

I found the implementation of `Nifti1Extension` and `Nifti1Extensions` to be a bit challenging to work with. `Nifti1Extension` seems like it should stand alone, as each extension is independent. But it doesn't; it refers to `extension_codes`--the entire list of `Nifti1Extension`s. `Nifti1Extensions` is a wrapper around that list of codes, and where those `extension_codes` logically belong. 

Since both objects use the list, they now depend on each other circularly, so both objects must point to the list. It's definitely unhappy, but I didn't see another way to go (without changing `Nifti1Extension` drastically, to avoid the need to refer to `extension_codes`).