### PR TITLE
MRG: Prepare for pydicom 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
     - python: 2.7
       env:
         - DEPENDS="numpy==1.5.1 pydicom==0.9.7"
+    # pydicom 1.0 (currently unreleased)
+    - python: 2.7
+      env:
+        - PYDICOM="v1.0"
     # Documentation doctests
     - python: 2.7
       env:
@@ -56,6 +60,8 @@ before_install:
     - if [ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]; then
         if [ "$PYDICOM" == "1" ]; then
             pip install pydicom;
+        elif [ "$PYDICOM" == "v1.0" ]; then
+            pip install git+https://github.com/darcymason/pydicom.git@43f278444d5cb2e4648135d3edcd430c363c6975;
         fi
       fi
     - if [ "${COVERAGE}" == "1" ]; then

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -49,10 +49,13 @@ def wrapper_from_file(file_like, *args, **kwargs):
     dcm_w : ``dicomwrappers.Wrapper`` or subclass
        DICOM wrapper corresponding to DICOM data type
     """
-    import dicom
+    try:
+        from dicom import read_file
+    except ImportError:
+        from pydicom.dicomio import read_file
 
     with ImageOpener(file_like) as fobj:
-        dcm_data = dicom.read_file(fobj, *args, **kwargs)
+        dcm_data = read_file(fobj, *args, **kwargs)
     return wrapper_from_data(dcm_data)
 
 

--- a/nibabel/nicom/tests/test_csareader.py
+++ b/nibabel/nicom/tests/test_csareader.py
@@ -31,7 +31,10 @@ def test_csa_header_read():
     assert_true(csa.is_mosaic(hdr))
     # Get a shallow copy of the data, lacking the CSA marker
     # Need to do it this way because del appears broken in pydicom 0.9.7
-    from dicom.dataset import Dataset
+    try:
+        from dicom.dataset import Dataset
+    except ImportError:
+        from pydicom.dataset import Dataset
     data2 = Dataset()
     for element in DATA:
         if (element.tag.group, element.tag.elem) != (0x29, 0x10):

--- a/nibabel/nicom/tests/test_dicomreaders.py
+++ b/nibabel/nicom/tests/test_dicomreaders.py
@@ -40,7 +40,10 @@ def test_passing_kwds():
     # Check that we correctly pass keywords to dicom
     dwi_glob = 'siemens_dwi_*.dcm.gz'
     csa_glob = 'csa*.bin'
-    import dicom
+    try:
+        from dicom.filereader import InvalidDicomError
+    except ImportError:
+        from pydicom.filereader import InvalidDicomError
     for func in (didr.read_mosaic_dwi_dir, didr.read_mosaic_dir):
         data, aff, bs, gs = func(IO_DATA_PATH, dwi_glob)
         # This should not raise an error
@@ -49,14 +52,14 @@ def test_passing_kwds():
             dwi_glob,
             dicom_kwargs=dict(force=True))
         assert_array_equal(data, data2)
-        # This should raise an error in dicom.read_file
+        # This should raise an error in pydicom.dicomio.read_file
         assert_raises(TypeError,
                       func,
                       IO_DATA_PATH,
                       dwi_glob,
                       dicom_kwargs=dict(not_a_parameter=True))
         # These are invalid dicoms, so will raise an error unless force=True
-        assert_raises(dicom.filereader.InvalidDicomError,
+        assert_raises(InvalidDicomError,
                       func,
                       IO_DATA_PATH,
                       csa_glob)

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -9,12 +9,17 @@ from copy import copy
 
 import numpy as np
 
+have_dicom = True
 try:
-    import dicom
+    import dicom as pydicom
+    read_file = pydicom.read_file
 except ImportError:
-    have_dicom = False
-else:
-    have_dicom = True
+    try:
+        import pydicom
+    except ImportError:
+        have_dicom = False
+    else:
+        from pydicom.dicomio import read_file
 dicom_test = np.testing.dec.skipif(not have_dicom,
                                    'could not import pydicom')
 
@@ -32,8 +37,8 @@ IO_DATA_PATH = pjoin(dirname(__file__), 'data')
 DATA_FILE = pjoin(IO_DATA_PATH, 'siemens_dwi_1000.dcm.gz')
 DATA_FILE_PHILIPS = pjoin(IO_DATA_PATH, 'philips_mprage.dcm.gz')
 if have_dicom:
-    DATA = dicom.read_file(gzip.open(DATA_FILE))
-    DATA_PHILIPS = dicom.read_file(gzip.open(DATA_FILE_PHILIPS))
+    DATA = read_file(gzip.open(DATA_FILE))
+    DATA_PHILIPS = read_file(gzip.open(DATA_FILE_PHILIPS))
 else:
     DATA = None
     DATA_PHILIPS = None
@@ -166,7 +171,7 @@ def test_wrapper_from_data():
 
 @dicom_test
 def test_wrapper_args_kwds():
-    # Test we can pass args, kwargs to dicom.read_file
+    # Test we can pass args, kwargs to read_file
     dcm = didw.wrapper_from_file(DATA_FILE)
     data = dcm.get_data()
     # Passing in non-default arg for defer_size
@@ -177,7 +182,7 @@ def test_wrapper_args_kwds():
     assert_array_equal(data, dcm2.get_data())
     # Trying to read non-dicom file raises pydicom error, usually
     csa_fname = pjoin(IO_DATA_PATH, 'csa2_b0.bin')
-    assert_raises(dicom.filereader.InvalidDicomError,
+    assert_raises(pydicom.filereader.InvalidDicomError,
                   didw.wrapper_from_file,
                   csa_fname)
     # We can force the read, in which case rubbish returns

--- a/nibabel/nicom/tests/test_utils.py
+++ b/nibabel/nicom/tests/test_utils.py
@@ -28,7 +28,10 @@ def test_find_private_section_real():
     assert_equal(find_private_section(DATA_PHILIPS, 0x29, 'SIEMENS CSA HEADER'),
                  None)
     # Make fake datasets
-    from dicom.dataset import Dataset
+    try:
+        from dicom.dataset import Dataset
+    except ImportError:
+        from pydicom.dataset import Dataset
     ds = Dataset({})
     ds.add_new((0x11, 0x10), 'LO', b'some section')
     assert_equal(find_private_section(ds, 0x11, 'some section'), 0x1000)


### PR DESCRIPTION
pydicom 1.0 will change the import name from `dicom` to `pydicom`, and move `dicom.read_file` to `pydicom.dicomio.read_file`. Adjust imports accordingly, and rename `dicom` to `pydicom`, when imported directly.

Closes #351