### PR TITLE
MRG: 5 small documentation changes

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -209,3 +209,32 @@ the PDDL version 1.0 available at http://opendatacommons.org/licenses/pddl/1.0/
 
 is courtesy of the University of Massachusetts Medical School, also released
 under the PDDL.
+
+
+Six
+--------------------
+
+In ``nibabel/externals/six.py``
+
+Copied from: https://pypi.python.org/packages/source/s/six/six-1.3.0.tar.gz#md5=ec47fe6070a8a64c802363d2c2b1e2ee
+
+    Copyright (c) 2010-2013 Benjamin Peterson
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/COPYING
+++ b/COPYING
@@ -128,27 +128,29 @@ In ``nibabel/externals/ordereddict.py``
 
 Copied from: https://pypi.python.org/packages/source/o/ordereddict/ordereddict-1.1.tar.gz#md5=a0ed854ee442051b249bfad0f638bbec
 
-Copyright (c) 2009 Raymond Hettinger
+::
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software,
-and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+  Copyright (c) 2009 Raymond Hettinger
 
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation files
+  (the "Software"), to deal in the Software without restriction,
+  including without limitation the rights to use, copy, modify, merge,
+  publish, distribute, sublicense, and/or sell copies of the Software,
+  and to permit persons to whom the Software is furnished to do so,
+  subject to the following conditions:
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+      OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+      NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+      HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+      OTHER DEALINGS IN THE SOFTWARE.
 
 mni_icbm152_t1_tal_nlin_asym_09a
 --------------------------------
@@ -157,6 +159,8 @@ The file ``doc/source/someone.nii.gz`` is a subsampled version of the file
 ``mni_icbm152_t1_tal_nlin_asym_09a.nii`` from the MNI non-linear templates
 archive ``mni_icbm152_t1_tal_nlin_asym_09a``.  The original image has the
 following license (where 'softwware' refers to the image):
+
+::
 
     Copyright (C) 1993-2004 Louis Collins, McConnell Brain Imaging Centre,
     Montreal Neurological Institute, McGill University.
@@ -217,6 +221,8 @@ Six
 In ``nibabel/externals/six.py``
 
 Copied from: https://pypi.python.org/packages/source/s/six/six-1.3.0.tar.gz#md5=ec47fe6070a8a64c802363d2c2b1e2ee
+
+::
 
     Copyright (c) 2010-2013 Benjamin Peterson
 

--- a/doc/source/_static/nibabel.css
+++ b/doc/source/_static/nibabel.css
@@ -31,3 +31,8 @@ div.footer {
 div.body {
     background-color: white;
 }
+
+.sphinxsidebarwrapper {
+    /* don't let anything exceed sidebar boundaries */
+    overflow: hidden;
+}

--- a/doc/source/_templates/indexsidebar.html
+++ b/doc/source/_templates/indexsidebar.html
@@ -6,7 +6,7 @@
     <li><a href="https://mail.python.org/pipermail/neuroimaging">Mailing list archive</a></li>
 </ul>
 
-<script type="text/javascript" src="https://www.ohloh.net/projects/480908/widgets/project_partner_badge"></script>
+<script type='text/javascript' src='https://www.openhub.net/p/nibabel/widgets/project_thin_badge?format=js'></script>
 
 <h3>Search mailing list archive</h3>
 <script type="text/javascript">

--- a/doc/source/devel/devguide.rst
+++ b/doc/source/devel/devguide.rst
@@ -28,7 +28,7 @@ Code Documentation
 
 All documentation should be written using Numpy documentation conventions:
 
-  http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines#docstring-standard
+  https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard
 
 
 Git Repository


### PR DESCRIPTION
1. Add 3rd party copyright notice for `six`  (#375)
2. Fix openhub.net badge (#378); see issue for images.
3. Update URL to numpy's docstrings (partial #376 fix).
4. Prevent content from overflowing sidebar (discovered solving #378)
5. Make all copyright notices enclosed in greyed boxes (see image below)

Currently, some copyright notices are contained in greyed boxes, others were plain text (white background, no border). Changed all to be in greyed boxes:
![image](https://cloud.githubusercontent.com/assets/4072455/11001512/5697a9be-845c-11e5-84bb-caed0513a6b7.png)
