### PR TITLE
Fix for issue 362: nibabel fails to stream gzipped files > 4GB (uncompressed) in Python 3.5

### DIFF
--- a/doc/source/devel/advanced_testing.rst
+++ b/doc/source/devel/advanced_testing.rst
@@ -1,0 +1,32 @@
+.. -*- mode: rst -*-
+.. ex: set sts=4 ts=4 sw=4 et tw=79:
+  ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
+  #
+  #   See COPYING file distributed along with the NiBabel package for the
+  #   copyright and license terms.
+  #
+  ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
+
+.. _advanced_testing:
+
+************
+Advanced Testing
+************
+
+Setup
+-----
+
+Before running advanced tests, please update all submodules of nibabel, by running ``git submodule update --init``
+
+
+Long-running tests
+------------------
+
+Long-running tests are not enabled by default, and can be resource-intensive. To run these tests:
+
+* Set environment variable ``NIPY_EXTRA_TESTS=slow``
+* Run ``nosetests``.
+
+Note that some tests may require a machine with >4GB of RAM.
+
+.. include:: ../links_names.txt

--- a/doc/source/devel/index.rst
+++ b/doc/source/devel/index.rst
@@ -14,3 +14,4 @@ Developer documentation page
     add_image_format
     devdiscuss
     make_release
+    advanced_testing

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -114,7 +114,11 @@ Just install the modules by invoking::
 If sudo is not configured (or even installed) you might have to use
 ``su`` instead.
 
-Now fire up Python and try importing the module to see if everything is fine.
+
+Validating your install
+-----------------------
+
+For a basic test of your installation, fire up Python and try importing the module to see if everything is fine.
 It should look something like this::
 
     Python 2.7.8 (v2.7.8:ee879c0ffa11, Jun 29 2014, 21:07:35)
@@ -122,5 +126,10 @@ It should look something like this::
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import nibabel
     >>>
+
+
+To run the nibabel test suite, from the terminal run ``nosetests nibabel`` or ``python -c "import nibabel; nibabel.test()``.
+
+To run an extended test suite that validates ``nibabel`` for long-running and resource-intensive cases, please see :ref:`advanced_testing`.
 
 .. include:: links_names.txt

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -13,7 +13,6 @@ import bz2
 import gzip
 import sys
 from os.path import splitext
-from distutils.version import LooseVersion
 
 
 # The largest memory chunk that gzip can use for reads

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -9,12 +9,14 @@
 ''' Utilities for testing '''
 from __future__ import division, print_function
 
+import os
 import sys
 import warnings
 from os.path import dirname, abspath, join as pjoin
 
 import numpy as np
 
+from numpy.testing.decorators import skipif
 # Allow failed import of nose if not now running tests
 try:
     from nose.tools import (assert_equal, assert_not_equal,
@@ -164,3 +166,11 @@ class catch_warn_reset(clear_and_catch_warnings):
         warnings.warn('catch_warn_reset is deprecated and will be removed in '
                       'nibabel v3.0; use nibabel.testing.clear_and_catch_warnings.',
                       FutureWarning)
+
+
+def runif_extra_has(test_str):
+    """Decorator checks to see if NIPY_EXTRA_TESTS env var contains test_str"""
+    def decorator(func):
+        skip_set = os.environ.get('NIPY_EXTRA_TESTS', '').split(',')
+        return skipif(test_str not in skip_set, "Skip slow tests.")(func)
+    return decorator

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -168,9 +168,10 @@ class catch_warn_reset(clear_and_catch_warnings):
                       FutureWarning)
 
 
+EXTRA_SET = os.environ.get('NIPY_EXTRA_TESTS', '').split(',')
+
+
 def runif_extra_has(test_str):
     """Decorator checks to see if NIPY_EXTRA_TESTS env var contains test_str"""
-    def decorator(func):
-        skip_set = os.environ.get('NIPY_EXTRA_TESTS', '').split(',')
-        return skipif(test_str not in skip_set, "Skip slow tests.")(func)
-    return decorator
+    return skipif(test_str not in EXTRA_SET,
+                  "Skip {0} tests.".format(test_str))

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1248,11 +1248,14 @@ class TestNifti1General(object):
 @runif_extra_has('slow')
 def test_large_nifti1():
     image_shape = (91, 109, 91, 1200)
-    img = Nifti1Image(np.zeros(image_shape, dtype=np.float32),
+    img = Nifti1Image(np.ones(image_shape, dtype=np.float32),
                       affine=np.eye(4))
+    # Dump and load the large image.
     with InTemporaryDirectory():
         img.to_filename('test.nii.gz')
         del img
         data = load('test.nii.gz').get_data()
-    assert_array_equal(np.asarray(image_shape), data.shape)
-    assert_true(np.all(data == 0.))
+    # Check that te data are all ones
+    assert_equal(image_shape, data.shape)
+    n_ones = np.sum((data == 1.))
+    assert_equal(np.prod(image_shape), n_ones)

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1242,3 +1242,13 @@ class TestNifti1General(object):
                 # Hokey use of max_miss as a std estimate
                 bias_thresh = np.max([max_miss / np.sqrt(count), eps])
                 assert_true(np.abs(bias) < bias_thresh)
+
+
+def test_large_nifti():
+    img = Nifti1Image(np.zeros((91, 109, 91, 1200), dtype=np.float32),
+                      affine=np.eye(4))
+    with InTemporaryDirectory():
+        img.to_filename('test.nii.gz')
+        del img
+        # Expect to fail on Python 3.5
+        load('test.nii.gz').get_data()

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1244,11 +1244,13 @@ class TestNifti1General(object):
                 assert_true(np.abs(bias) < bias_thresh)
 
 
-def test_large_nifti():
-    img = Nifti1Image(np.zeros((91, 109, 91, 1200), dtype=np.float32),
+def test_large_nifti1():
+    image_shape = (91, 109, 91, 1200)
+    img = Nifti1Image(np.zeros(image_shape, dtype=np.float32),
                       affine=np.eye(4))
     with InTemporaryDirectory():
         img.to_filename('test.nii.gz')
         del img
-        # Expect to fail on Python 3.5
-        load('test.nii.gz').get_data()
+        data = load('test.nii.gz').get_data()
+    assert_equal(np.asarray(image_shape), data.shape)
+    assert_true(np.all(data == 0.))

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -13,17 +13,18 @@ import warnings
 
 import numpy as np
 
-from ..externals.six import BytesIO
-from ..casting import type_info, have_binary128
-from ..tmpdirs import InTemporaryDirectory
-from ..spatialimages import HeaderDataError
-from ..eulerangles import euler2mat
-from ..affines import from_matvec
-from .. import nifti1 as nifti1
-from ..nifti1 import (load, Nifti1Header, Nifti1PairHeader, Nifti1Image,
-                      Nifti1Pair, Nifti1Extension, Nifti1Extensions,
-                      data_type_codes, extension_codes, slice_order_codes)
-
+from nibabel import nifti1 as nifti1
+from nibabel.affines import from_matvec
+from nibabel.casting import type_info, have_binary128
+from nibabel.eulerangles import euler2mat
+from nibabel.externals.six import BytesIO
+from nibabel.nifti1 import (load, Nifti1Header, Nifti1PairHeader, Nifti1Image,
+                            Nifti1Pair, Nifti1Extension, Nifti1Extensions,
+                            data_type_codes, extension_codes,
+                            slice_order_codes)
+from nibabel.openers import ImageOpener
+from nibabel.spatialimages import HeaderDataError
+from nibabel.tmpdirs import InTemporaryDirectory
 from ..freesurfer import load as mghload
 
 from .test_arraywriters import rt_err_estimate, IUINT_TYPES
@@ -35,7 +36,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_raises)
 
-from ..testing import data_path, suppress_warnings
+from ..testing import data_path, suppress_warnings, runif_extra_has
 
 from . import test_analyze as tana
 from . import test_spm99analyze as tspm
@@ -1244,6 +1245,7 @@ class TestNifti1General(object):
                 assert_true(np.abs(bias) < bias_thresh)
 
 
+@runif_extra_has('slow')
 def test_large_nifti1():
     image_shape = (91, 109, 91, 1200)
     img = Nifti1Image(np.zeros(image_shape, dtype=np.float32),
@@ -1252,5 +1254,5 @@ def test_large_nifti1():
         img.to_filename('test.nii.gz')
         del img
         data = load('test.nii.gz').get_data()
-    assert_equal(np.asarray(image_shape), data.shape)
+    assert_array_equal(np.asarray(image_shape), data.shape)
     assert_true(np.all(data == 0.))

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1255,7 +1255,7 @@ def test_large_nifti1():
         img.to_filename('test.nii.gz')
         del img
         data = load('test.nii.gz').get_data()
-    # Check that te data are all ones
+    # Check that the data are all ones
     assert_equal(image_shape, data.shape)
     n_ones = np.sum((data == 1.))
     assert_equal(np.prod(image_shape), n_ones)


### PR DESCRIPTION
This not a `nibabel` bug, but works around a Python bug (https://bugs.python.org/issue25626).

The workaround is: we wrap `gzip.GzipFile` with buffering, so that files > 4GB require multiple calls to `GzipFile.readinto`.

I've also added test functionality: if `NIPY_EXTRA_TESTS` contains `'slow'`, slowly running tests can be run. I've used this to include a test for creation of a large file.