### PR TITLE
MRG: fix for Freesurfer mmap bug

### DIFF
--- a/nibabel/fileholders.py
+++ b/nibabel/fileholders.py
@@ -90,6 +90,12 @@ class FileHolder(object):
         return ((self.filename == other.filename) and
                 (self.fileobj == other.fileobj))
 
+    @property
+    def file_like(self):
+        """ Return ``self.fileobj`` if not None, otherwise ``self.filename``
+        """
+        return self.fileobj if self.fileobj is not None else self.filename
+
 
 def copy_file_map(file_map):
     ''' Copy mapping of fileholders given by `file_map`

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -496,11 +496,13 @@ class MGHImage(SpatialImage):
         '''
         if not mmap in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
-        mghf = file_map['image'].get_prepare_fileobj('rb')
+        img_fh = file_map['image']
+        mghf = img_fh.get_prepare_fileobj('rb')
         header = klass.header_class.from_fileobj(mghf)
         affine = header.get_affine()
         hdr_copy = header.copy()
-        data = klass.ImageArrayProxy(mghf, hdr_copy, mmap=mmap)
+        # Pass original image fileobj / filename to array proxy
+        data = klass.ImageArrayProxy(img_fh.file_like, hdr_copy, mmap=mmap)
         img = klass(data, affine, header, file_map=file_map)
         img._load_cache = {'header': hdr_copy,
                            'affine': affine.copy(),

--- a/nibabel/tests/test_fileholders.py
+++ b/nibabel/tests/test_fileholders.py
@@ -50,4 +50,12 @@ def test_same_file_as():
     assert_true(fh3.same_file_as(fh4_again))
 
 
-
+def test_file_like():
+    # Test returning file object or filename
+    fh = FileHolder('a_fname')
+    assert_equal(fh.file_like, 'a_fname')
+    bio = BytesIO()
+    fh = FileHolder(fileobj=bio)
+    assert_true(fh.file_like is bio)
+    fh = FileHolder('a_fname', fileobj=bio)
+    assert_true(fh.file_like is bio)


### PR DESCRIPTION
We were accidentally passing an ImageOpener instance as the file object to the array proxy, and Pyton 3.5 pointed this out by failing:

http://nipy.bic.berkeley.edu/builders/nibabel-bdist32-35/builds/9/steps/shell_6/logs/stdio

This branch fixes the Python 3.5 tests:

http://nipy.bic.berkeley.edu/builders/nibabel-bdist32-35/builds/11/steps/shell_6/logs/stdio