### PR TITLE
BF+TST: Skip over missing CSA header elem instead of raising.

### DIFF
--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -66,6 +66,7 @@ def get_csa_header(dcm_data, csa_type='image'):
     try:
         tag = dcm_data[(0x29, element_no)]
     except KeyError:
+        # The element could be missing due to anonymization
         return None
     return read(tag.value)
 

--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -63,8 +63,10 @@ def get_csa_header(dcm_data, csa_type='image'):
     if section_start is None:
         return None
     element_no = section_start + element_offset
-    # Assume tag exists
-    tag = dcm_data[(0x29, element_no)]
+    try:
+        tag = dcm_data[(0x29, element_no)]
+    except KeyError:
+        return None
     return read(tag.value)
 
 

--- a/nibabel/nicom/tests/test_csareader.py
+++ b/nibabel/nicom/tests/test_csareader.py
@@ -1,6 +1,7 @@
 """ Testing Siemens CSA header reader
 """
 from os.path import join as pjoin
+from copy import deepcopy
 import gzip
 
 import numpy as np
@@ -13,6 +14,8 @@ from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 from .test_dicomwrappers import (have_dicom, dicom_test,
                                  IO_DATA_PATH, DATA, DATA_FILE)
+if have_dicom:
+    from .test_dicomwrappers import pydicom
 
 CSA2_B0 = open(pjoin(IO_DATA_PATH, 'csa2_b0.bin'), 'rb').read()
 CSA2_B1000 = open(pjoin(IO_DATA_PATH, 'csa2_b1000.bin'), 'rb').read()
@@ -128,3 +131,15 @@ def test_ice_dims():
         assert_equal(csa.get_ice_dims(csa_info),
                      ex_dims)
     assert_equal(csa.get_ice_dims({}), None)
+
+
+@dicom_test
+def test_missing_csa_elem():
+    # Test that we get None instead of raising an Exception when the file has
+    # the PrivateCreator element for the CSA dict but not the element with the
+    # actual CSA header (perhaps due to anonymization)
+    dcm = deepcopy(DATA)
+    csa_tag = pydicom.tag.Tag(0x29, 0x1010)
+    del dcm[csa_tag]
+    hdr = csa.get_csa_header(dcm, 'image')
+    assert_equal(hdr, None)

--- a/nibabel/nicom/tests/test_csareader.py
+++ b/nibabel/nicom/tests/test_csareader.py
@@ -14,8 +14,6 @@ from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 from .test_dicomwrappers import (have_dicom, dicom_test,
                                  IO_DATA_PATH, DATA, DATA_FILE)
-if have_dicom:
-    from .test_dicomwrappers import pydicom
 
 CSA2_B0 = open(pjoin(IO_DATA_PATH, 'csa2_b0.bin'), 'rb').read()
 CSA2_B1000 = open(pjoin(IO_DATA_PATH, 'csa2_b1000.bin'), 'rb').read()
@@ -138,8 +136,12 @@ def test_missing_csa_elem():
     # Test that we get None instead of raising an Exception when the file has
     # the PrivateCreator element for the CSA dict but not the element with the
     # actual CSA header (perhaps due to anonymization)
+    try:
+        from dicom.tag import Tag
+    except ImportError:
+        from pydicom.tag import Tag
     dcm = deepcopy(DATA)
-    csa_tag = pydicom.tag.Tag(0x29, 0x1010)
+    csa_tag = Tag(0x29, 0x1010)
     del dcm[csa_tag]
     hdr = csa.get_csa_header(dcm, 'image')
     assert_equal(hdr, None)


### PR DESCRIPTION
Allows us to load data where the PrivateCreator is present but
the element containing the header info is not. Ran into this with
anonymized data.