### PR TITLE
BF: Load gifti parser iff parsing gifti files

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -423,10 +423,6 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
                  labeltable=None, darrays=None, version="1.0"):
         super(GiftiImage, self).__init__(header=header, extra=extra,
                                          file_map=file_map)
-        # placed here temporarily for git diff purposes
-        from .parse_gifti_fast import GiftiImageParser
-        GiftiImage.parser = GiftiImageParser
-
         if darrays is None:
             darrays = []
         if meta is None:
@@ -596,7 +592,8 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         img : GiftiImage
             Returns a GiftiImage
          """
-        parser = klass.parser(buffer_size=buffer_size)
+        from .parse_gifti_fast import GiftiImageParser
+        parser = GiftiImageParser(buffer_size=buffer_size)
         parser.parse(fptr=file_map['image'].get_prepare_fileobj('rb'))
         img = parser.img
         return img

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -592,6 +592,12 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         img : GiftiImage
             Returns a GiftiImage
          """
+        # Note for refactorers: We were aiming to make ``parser`` a class
+        # attribute such that klass.parser().parse(...) would return an
+        # instance of klass.
+        #
+        # In the current setup of parse_gifti_fast.GiftiImageParser, this
+        # results in a circular dependency, so using a local import only.
         from .parse_gifti_fast import GiftiImageParser
         parser = GiftiImageParser(buffer_size=buffer_size)
         parser.parse(fptr=file_map['image'].get_prepare_fileobj('rb'))


### PR DESCRIPTION
Setting `parser` as a class attribute turns out not to be very necessary. Avoid the circular reference by calling the parser directly when needed.

Fixes #392.