### PR TITLE
MRG: delay set of gifti parser for circular import

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -419,14 +419,15 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
     valid_exts = ('.gii',)
     files_types = (('image', '.gii'),)
 
+    # The parser will in due course be a GiftiImageParser, but we can't set
+    # that now, because it would result in a circular import.  We set it after
+    # the class has been defined, at the end of the class definition.
+    parser = None
+
     def __init__(self, header=None, extra=None, file_map=None, meta=None,
                  labeltable=None, darrays=None, version="1.0"):
         super(GiftiImage, self).__init__(header=header, extra=extra,
                                          file_map=file_map)
-        # placed here temporarily for git diff purposes
-        from .parse_gifti_fast import GiftiImageParser
-        GiftiImage.parser = GiftiImageParser
-
         if darrays is None:
             darrays = []
         if meta is None:
@@ -606,3 +607,8 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         file_map = klass.filespec_to_file_map(filename)
         img = klass.from_file_map(file_map, buffer_size=buffer_size)
         return img
+
+
+# Now GiftiImage is defined, we can import the parser module and set the parser
+from .parse_gifti_fast import GiftiImageParser
+GiftiImage.parser = GiftiImageParser

--- a/nibabel/gifti/tests/test_1.py
+++ b/nibabel/gifti/tests/test_1.py
@@ -1,0 +1,18 @@
+""" Testing loading of gifti file
+
+The file is ``test_1`` because we are testing a bug where, if we try to load a
+file before instantiating some Gifti objects, loading fails with an
+AttributeError (see: https://github.com/nipy/nibabel/issues/392).
+
+Thus, we have to run this test before the other gifti tests to catch the gifti
+code unprepared.
+"""
+
+from nibabel import load
+
+from .test_parse_gifti_fast import DATA_FILE3
+
+
+def test_load_gifti():
+    # This expression should not raise an error
+    load(DATA_FILE3)


### PR DESCRIPTION
The GiftiImage class sets GiftiImageParser as a class attribute, but the GiftiImageParser needs to import and use the GiftiImage class.  So, delay the setting of the parser class attribute until GiftiImage is fully defined, and therefore usable from `parse_fast_gifti.py`, which defines GiftiImageParser.