### PR TITLE
MRG: rewrite gifti docstrings; refactor init

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -14,6 +14,7 @@ from http://www.nitrc.org/projects/gifti/
 from __future__ import division, print_function, absolute_import
 
 import sys
+import warnings
 
 import numpy as np
 
@@ -407,6 +408,10 @@ class GiftiDataArray(xml.XmlSerializable):
         -------
         da : instance of our own class
         """
+        warnings.warn(
+            "Please use GiftiDataArray constructor instead of from_array "
+            "class method",
+            DeprecationWarning, stacklevel=2)
         return klass(data=darray,
                      intent=intent,
                      datatype=datatype,

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -133,7 +133,6 @@ class GiftiLabel(xml.XmlSerializable):
         the GIFTI file format, the attribute Index was used instead of Key. If
         an Index attribute is encountered, it should be processed like the Key
         attribute."
-    label : str
     red : None or float
         Optional value for red.
     green : None or float
@@ -149,10 +148,8 @@ class GiftiLabel(xml.XmlSerializable):
     because they are floats, not 4 8-bit integers.
     """
 
-    def __init__(self, key=0, label='', red=None, green=None, blue=None,
-                 alpha=None):
+    def __init__(self, key=0, red=None, green=None, blue=None, alpha=None):
         self.key = key
-        self.label = label
         self.red = red
         self.green = green
         self.blue = blue

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -6,6 +6,11 @@
 #   copyright and license terms.
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+""" Classes defining Gifti objects
+
+The Gifti specification was (at time of writing) available as a PDF download
+from http://www.nitrc.org/projects/gifti/
+"""
 from __future__ import division, print_function, absolute_import
 
 import sys
@@ -25,8 +30,8 @@ import base64
 
 
 class GiftiMetaData(xml.XmlSerializable):
-    """ A list of GiftiNVPairs in stored in
-    the list self.data """
+    """ A sequence of GiftiNVPairs containing metadata for a gifti data array
+    """
 
     def __init__(self, nvpair=None):
         self.data = []
@@ -68,9 +73,12 @@ class GiftiMetaData(xml.XmlSerializable):
 
 
 class GiftiNVPairs(object):
-    """
-    name = str
-    value = str
+    """ Gifti name / value pairs
+
+    Attributes
+    ----------
+    name : str
+    value : str
     """
     def __init__(self, name='', value=''):
         self.name = name
@@ -78,6 +86,13 @@ class GiftiNVPairs(object):
 
 
 class GiftiLabelTable(xml.XmlSerializable):
+    """ Gifti label table: a sequence of key, label pairs
+
+    From the gifti spec dated 2011-01-14:
+        The label table is used by DataArrays whose values are an key into the
+        LabelTable's labels. A file should contain at most one LabelTable and
+        it must be located in the file prior to any DataArray elements.
+    """
 
     def __init__(self):
         self.labels = []
@@ -104,17 +119,34 @@ class GiftiLabelTable(xml.XmlSerializable):
 
 
 class GiftiLabel(xml.XmlSerializable):
-    """
-    key = int
-    label = str
-    # rgba
-    # freesurfer examples seem not to conform
-    # to datatype "NIFTI_TYPE_RGBA32" because they
-    # are floats, not unsigned 32-bit integers
-    red = float
-    green = float
-    blue = float
-    alpha = float
+    """ Gifti label: association of integer key with optional RGBA values
+
+    Quotes are from the gifti spec dated 2011-01-14.
+
+    Attributes
+    ----------
+    key : int
+        (From the spec): "This required attribute contains a non-negative
+        integer value. If a DataArray's Intent is NIFTI_INTENT_LABEL and a
+        value in the DataArray is 'X', its corresponding label is the label
+        with the Key attribute containing the value 'X'. In early versions of
+        the GIFTI file format, the attribute Index was used instead of Key. If
+        an Index attribute is encountered, it should be processed like the Key
+        attribute."
+    label : str
+    red : None or float
+        Optional value for red.
+    green : None or float
+        Optional value for green.
+    blue : None or float
+        Optional value for blue.
+    alpha : None or float
+        Optional value for alpha.
+
+    Notes
+    -----
+    freesurfer examples seem not to conform to datatype "NIFTI_TYPE_RGBA32"
+    because they are floats, not 4 8-bit integers.
     """
 
     def __init__(self, key=0, label='', red=None, green=None, blue=None,
@@ -137,12 +169,12 @@ class GiftiLabel(xml.XmlSerializable):
 
     @rgba.setter
     def rgba(self, rgba):
-        """ Set RGBA via tuple
+        """ Set RGBA via sequence
 
         Parameters
         ----------
-        rgba : tuple (red, green, blue, alpha)
-
+        rgba : length 4 sequence
+            Sequence containing values for red, green, blue, alpha.
         """
         if len(rgba) != 4:
             raise ValueError('rgba must be length 4.')
@@ -159,10 +191,38 @@ def _arr2txt(arr, elem_fmt):
 
 
 class GiftiCoordSystem(xml.XmlSerializable):
-    """
-    dataspace = int
-    xformspace = int
-    xform = np.ndarray  # 4x4 numpy array
+    """ Gifti coordinate system transform matrix
+
+    Quotes are from the gifti spec dated 2011-01-14.
+
+        "For a DataArray with an Intent NIFTI_INTENT_POINTSET, this element
+        describes the stereotaxic space of the data before and after the
+        application of a transformation matrix. The most common stereotaxic
+        space is the Talairach Space that places the origin at the anterior
+        commissure and the negative X, Y, and Z axes correspond to left,
+        posterior, and inferior respectively.  At least one
+        CoordinateSystemTransformMatrix is required in a DataArray with an
+        intent of NIFTI_INTENT_POINTSET. Multiple
+        CoordinateSystemTransformMatrix elements may be used to describe the
+        transformation to multiple spaces."
+
+    Attributes
+    ----------
+    dataspace : int
+        From the spec: "Contains the stereotaxic space of a DataArray's data
+        prior to application of the transformation matrix. The stereotaxic
+        space should be one of:
+            NIFTI_XFORM_UNKNOWN
+            NIFTI_XFORM_SCANNER_ANAT
+            NIFTI_XFORM_ALIGNED_ANAT
+            NIFTI_XFORM_TALAIRACH
+            NIFTI_XFORM_MNI_152"
+    xformspace : int
+        Spec: "Contains the stereotaxic space of a DataArray's data after
+        application of the transformation matrix. See the DataSpace element for
+        a list of stereotaxic spaces."
+    xform : array-like shape (4, 4)
+        Affine transformation matrix
     """
 
     def __init__(self, dataspace=0, xformspace=0, xform=None):
@@ -205,8 +265,8 @@ def data_tag(dataarray, encoding, datatype, ordering):
 
 
 def _data_tag_element(dataarray, encoding, datatype, ordering):
-    """ Creates the data tag depending on the required encoding,
-    returns as XML element"""
+    """ Creates data tag with given `encoding`, returns as XML element
+    """
     import zlib
     ord = array_index_order_codes.npcode[ordering]
     enclabel = gifti_encoding_codes.label[encoding]
@@ -228,42 +288,84 @@ def _data_tag_element(dataarray, encoding, datatype, ordering):
 
 
 class GiftiDataArray(xml.XmlSerializable):
-    """
-    # These are for documentation only; we don't use these class variables
-    intent = int
-    datatype = int
-    ind_ord = int
-    dims = list
-    encoding = int
-    endian = int
-    ext_fname = str
-    ext_offset = str
-    data = np.ndarray
-    coordsys = GiftiCoordSystem
-    meta = GiftiMetaData
+    """ Container for Gifti numerical data array and associated metadata
+
+    Quotes are from the gifti spec dated 2011-01-14.
+
+    Description of DataArray in spec:
+        "This element contains the numeric data and its related metadata. The
+        CoordinateSystemTransformMatrix child is only used when the DataArray's
+        Intent is NIFTI_INTENT_POINTSET.  FileName and FileOffset are required
+        if the data is stored in an external file."
+
+    Attributes
+    ----------
+    darray : None or ndarray
+        Data array
+    intent : int
+        NIFTI intent code, see nifti1.intent_codes
+    datatype : int
+        NIFTI data type codes, see nifti1.data_type_codes.  From the spec:
+        "This required attribute describes the numeric type of the data
+        contained in a Data Array and are limited to the types displayed in the
+        table:
+
+        NIFTI_TYPE_UINT8 : Unsigned, 8-bit bytes.
+        NIFTI_TYPE_INT32 : Signed, 32-bit integers.
+        NIFTI_TYPE_FLOAT32 : 32-bit single precision floating point."
+
+        At the moment, we do not enforce that the datatype is one of these
+        three.
+    encoding : string
+        Encoding of the data, see util.gifti_encoding_codes; default is
+        GIFTI_ENCODING_B64GZ.
+    endian : string
+        The Endianness to store the data array.  Should correspond to the
+        machine endianness.  Default is system byteorder.
+    coordsys : :class:`GiftiCoordSystem` instance
+        Input and output coordinate system with tranformation matrix between
+        the two.
+    ind_ord : int
+        The ordering of the array. see util.array_index_order_codes.  Default
+        is RowMajorOrder - C ordering
+    meta : :class:`GiftiMetaData` instance
+        An instance equivalent to a dictionary for metadata information.
+    ext_fname : str
+        Filename in which data is stored, or empty string if no corresponding
+        filename.
+    ext_offset : int
+        Position in bytes within `ext_fname` at which to start reading data.
     """
 
-    def __init__(self, data=None,
+    def __init__(self,
+                 data=None,
+                 intent='NIFTI_INTENT_NONE',
+                 datatype=None,
                  encoding="GIFTI_ENCODING_B64GZ",
                  endian=sys.byteorder,
                  coordsys=None,
                  ordering="C",
-                 meta=None):
+                 meta=None,
+                 ext_fname='',
+                 ext_offset=0):
         """
         Returns a shell object that cannot be saved.
         """
-        self.data = data
-        self.dims = []
-        self.meta = meta or GiftiMetaData()
+        self.data = None if data is None else np.asarray(data)
+        self.intent = intent_codes.code[intent]
+        if datatype is None:
+            datatype = 'none' if self.data is None else self.data.dtype
+        self.datatype = data_type_codes.code[datatype]
+        self.encoding = gifti_encoding_codes.code[encoding]
+        self.endian = gifti_endian_codes.code[endian]
         self.coordsys = coordsys or GiftiCoordSystem()
-        self.ext_fname = ''
-        self.ext_offset = ''
-        self.intent = 0  # required attribute, NIFTI_INTENT_NONE
-        self.datatype = 0  # required attribute, void/none
-        # python/numpy default: column major order
         self.ind_ord = array_index_order_codes.code[ordering]
-        self.encoding = encoding
-        self.endian = endian
+        self.meta = (GiftiMetaData() if meta is None else
+                     meta if isinstance(meta, GiftiMetaData) else
+                     GiftiMetaData.from_dict(meta))
+        self.ext_fname = ext_fname
+        self.ext_offset = ext_offset
+        self.dims = [] if self.data is None else list(self.data.shape)
 
     @property
     def num_dim(self):
@@ -308,22 +410,14 @@ class GiftiDataArray(xml.XmlSerializable):
         -------
         da : instance of our own class
         """
-        if meta is None:
-            meta = {}
-        cda = klass(darray)
-        cda.dims = list(darray.shape)
-        if datatype is None:
-            cda.datatype = data_type_codes.code[darray.dtype]
-        else:
-            cda.datatype = data_type_codes.code[datatype]
-        cda.intent = intent_codes.code[intent]
-        cda.encoding = gifti_encoding_codes.code[encoding]
-        cda.endian = gifti_endian_codes.code[endian]
-        if coordsys is not None:
-            cda.coordsys = coordsys
-        cda.ind_ord = array_index_order_codes.code[ordering]
-        cda.meta = GiftiMetaData.from_dict(meta)
-        return cda
+        return klass(data=darray,
+                     intent=intent,
+                     datatype=datatype,
+                     encoding=encoding,
+                     endian=endian,
+                     coordsys=coordsys,
+                     ordering=ordering,
+                     meta=meta)
 
     def _to_xml_element(self):
         # fix endianness to machine endianness
@@ -364,7 +458,7 @@ class GiftiDataArray(xml.XmlSerializable):
 %s\tEncoding="%s"
 \tEndian="%s"
 \tExternalFileName="%s"
-\tExternalFileOffset="%s">\n"""
+\tExternalFileOffset="%d">\n"""
         di = ""
         for i, n in enumerate(self.dims):
             di = di + '\tDim%s=\"%s\"\n' % (str(i), str(n))
@@ -475,8 +569,7 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
 
         Parameters
         ----------
-        labeltable : GiftiLabelTable
-
+        labeltable : :class:`GiftiLabelTable` instance
         """
         if not isinstance(labeltable, GiftiLabelTable):
             raise TypeError("Not a valid GiftiLabelTable instance")
@@ -500,11 +593,7 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
 
         Parameters
         ----------
-        meta : GiftiMetaData
-
-        Returns
-        -------
-        None
+        meta : :class:`GiftiMetaData` instance
         """
         if not isinstance(meta, GiftiMetaData):
             raise TypeError("Not a valid GiftiMetaData instance")
@@ -523,7 +612,7 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
 
         Parameters
         ----------
-        dataarr : GiftiDataArray
+        dataarr : :class:`GiftiDataArray` instance
         """
         if not isinstance(dataarr, GiftiDataArray):
             raise TypeError("Not a valid GiftiDataArray instance")
@@ -541,11 +630,9 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
                 self.darrays.remove(dele)
 
     def get_arrays_from_intent(self, intent):
-        """ Returns a a list of GiftiDataArray elements matching
-        the given intent """
-
+        """ Return list of GiftiDataArray elements matching given intent
+        """
         it = intent_codes.code[intent]
-
         return [x for x in self.darrays if x.intent == it]
 
     @np.deprecate_with_doc("Use get_arrays_from_intent instead.")
@@ -594,7 +681,9 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
 
         Parameters
         ----------
-        file_map : string
+        file_map : dict
+            Dictionary with single key ``image`` with associated value which is
+            a :class:`FileHolder` instance pointing to the image file.
 
         Returns
         -------
@@ -610,17 +699,18 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         """ Load a Gifti image from a file_map
 
         Parameters
-        file_map : string
+        ----------
+        file_map : dict
+            Dictionary with single key ``image`` with associated value which is
+            a :class:`FileHolder` instance pointing to the image file.
 
         Returns
         -------
         img : GiftiImage
-            Returns a GiftiImage
-         """
+        """
         parser = klass.parser(buffer_size=buffer_size)
         parser.parse(fptr=file_map['image'].get_prepare_fileobj('rb'))
-        img = parser.img
-        return img
+        return parser.img
 
     @classmethod
     def from_filename(klass, filename, buffer_size=35000000):

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -13,6 +13,7 @@ import sys
 import warnings
 import zlib
 from ..externals.six import StringIO
+from xml.parsers.expat import ExpatError
 
 import numpy as np
 
@@ -23,6 +24,10 @@ from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes)
 from ..nifti1 import data_type_codes, xform_codes, intent_codes
 from ..xmlutils import XmlParser
+
+
+class GiftiParseError(ExpatError):
+    """ Gifti-specific parsing error """
 
 
 def read_data_block(encoding, endian, ordering, datatype, shape, data):
@@ -130,12 +135,12 @@ class GiftiImageParser(XmlParser):
 
         elif name == 'Name':
             if self.nvpair is None:
-                raise ExpatError
+                raise GiftiParseError
             self.write_to = 'Name'
 
         elif name == 'Value':
             if self.nvpair is None:
-                raise ExpatError
+                raise GiftiParseError
             self.write_to = 'Value'
 
         elif name == 'LabelTable':
@@ -193,17 +198,17 @@ class GiftiImageParser(XmlParser):
 
         elif name == 'DataSpace':
             if self.coordsys is None:
-                raise ExpatError
+                raise GiftiParseError
             self.write_to = 'DataSpace'
 
         elif name == 'TransformedSpace':
             if self.coordsys is None:
-                raise ExpatError
+                raise GiftiParseError
             self.write_to = 'TransformedSpace'
 
         elif name == 'MatrixData':
             if self.coordsys is None:
-                raise ExpatError
+                raise GiftiParseError
             self.write_to = 'MatrixData'
 
         elif name == 'Data':

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -40,7 +40,7 @@ def test_gifti_image():
 
     # Test from numpy numeric array
     data = np.random.random((5,))
-    da = GiftiDataArray.from_array(data)
+    da = GiftiDataArray(data)
     gi.add_gifti_data_array(da)
     assert_equal(gi.numDA, 1)
     assert_array_equal(gi.darrays[0].data, data)
@@ -56,7 +56,7 @@ def test_gifti_image():
 
     # Remove one
     gi = GiftiImage()
-    da = GiftiDataArray.from_array(np.zeros((5,)), intent=0)
+    da = GiftiDataArray(np.zeros((5,)), intent=0)
     gi.add_gifti_data_array(da)
 
     gi.remove_gifti_data_array_by_intent(3)
@@ -153,19 +153,25 @@ def test_dataarray_init():
 
 
 def test_dataarray_from_array():
-    for dt_code in data_type_codes.value_set():
-        data_type = data_type_codes.type[dt_code]
-        if data_type is np.void:  # not supported
-            continue
-        arr = np.zeros((10, 3), dtype=data_type)
-        da = GiftiDataArray.from_array(arr, 'triangle')
-        assert_equal(da.datatype, data_type_codes[arr.dtype])
-        bs_arr = arr.byteswap().newbyteorder()
-        da = GiftiDataArray.from_array(bs_arr, 'triangle')
-        assert_equal(da.datatype, data_type_codes[arr.dtype])
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+        da = GiftiDataArray.from_array(np.ones((3, 4)))
+        assert_equal(len(w), 1)
+        for dt_code in data_type_codes.value_set():
+            data_type = data_type_codes.type[dt_code]
+            if data_type is np.void:  # not supported
+                continue
+            arr = np.zeros((10, 3), dtype=data_type)
+            da = GiftiDataArray.from_array(arr, 'triangle')
+            assert_equal(da.datatype, data_type_codes[arr.dtype])
+            bs_arr = arr.byteswap().newbyteorder()
+            da = GiftiDataArray.from_array(bs_arr, 'triangle')
+            assert_equal(da.datatype, data_type_codes[arr.dtype])
 
+
+def test_to_xml_open_close_deprecations():
     # Smoke test on deprecated functions
-    da = GiftiDataArray.from_array(np.ones((1,)), 'triangle')
+    da = GiftiDataArray(np.ones((1,)), 'triangle')
     with clear_and_catch_warnings() as w:
         warnings.filterwarnings('always', category=DeprecationWarning)
         assert_true(isinstance(da.to_xml_open(), string_types))

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -1,13 +1,15 @@
 """ Testing gifti objects
 """
 import warnings
+import sys
 
 import numpy as np
 
 import nibabel as nib
 from nibabel.externals.six import string_types
 from nibabel.gifti import (GiftiImage, GiftiDataArray, GiftiLabel,
-                           GiftiLabelTable, GiftiMetaData, GiftiNVPairs)
+                           GiftiLabelTable, GiftiMetaData, GiftiNVPairs,
+                           GiftiCoordSystem)
 from nibabel.gifti.gifti import data_tag
 from nibabel.nifti1 import data_type_codes
 
@@ -24,6 +26,8 @@ def test_gifti_image():
     # arguments.
     gi = GiftiImage()
     assert_equal(gi.darrays, [])
+    assert_equal(gi.meta.metadata, {})
+    assert_equal(gi.labeltable.labels, [])
     arr = np.zeros((2, 3))
     gi.darrays.append(arr)
     # Now check we didn't overwrite the default arg
@@ -45,13 +49,6 @@ def test_gifti_image():
     gi.remove_gifti_data_array(0)
     assert_equal(gi.numDA, 0)
 
-    # Test from string
-    da = GiftiDataArray.from_array('zzzzz')
-    gi.add_gifti_data_array(da)
-    assert_equal(gi.numDA, 1)
-    assert_array_equal(gi.darrays[0].data, data)
-
-
     # Remove from empty
     gi = GiftiImage()
     gi.remove_gifti_data_array_by_intent(0)
@@ -69,7 +66,93 @@ def test_gifti_image():
     assert_equal(gi.numDA, 0)
 
 
-def test_dataarray():
+def test_gifti_image_bad_inputs():
+    img = GiftiImage()
+    # Try to set a non-data-array
+    assert_raises(TypeError, img.add_gifti_data_array, 'not-a-data-array')
+
+    # Try to set to non-table
+    def assign_labeltable(val):
+        img.labeltable = val
+    assert_raises(TypeError, assign_labeltable, 'not-a-table')
+
+    # Try to set to non-table
+    def assign_metadata(val):
+        img.meta = val
+    assert_raises(TypeError, assign_metadata, 'not-a-meta')
+
+
+def test_dataarray_empty():
+    # Test default initialization of DataArray
+    null_da = GiftiDataArray()
+    assert_equal(null_da.data, None)
+    assert_equal(null_da.intent, 0)
+    assert_equal(null_da.datatype, 0)
+    assert_equal(null_da.encoding, 3)
+    assert_equal(null_da.endian, 2 if sys.byteorder == 'little' else 1)
+    assert_equal(null_da.coordsys.dataspace, 0)
+    assert_equal(null_da.coordsys.xformspace, 0)
+    assert_array_equal(null_da.coordsys.xform, np.eye(4))
+    assert_equal(null_da.ind_ord, 1)
+    assert_equal(null_da.meta.metadata, {})
+    assert_equal(null_da.ext_fname, '')
+    assert_equal(null_da.ext_offset, 0)
+
+
+def test_dataarray_init():
+    # Test non-default dataarray initialization
+    gda = GiftiDataArray  # shortcut
+    assert_equal(gda(None).data, None)
+    arr = np.arange(12, dtype=np.float32).reshape((3, 4))
+    assert_array_equal(gda(arr).data, arr)
+    # Intents
+    assert_raises(KeyError, gda, intent=1)  # Invalid code
+    assert_raises(KeyError, gda, intent='not an intent')  # Invalid string
+    assert_equal(gda(intent=2).intent, 2)
+    assert_equal(gda(intent='correlation').intent, 2)
+    assert_equal(gda(intent='NIFTI_INTENT_CORREL').intent, 2)
+    # Datatype
+    assert_equal(gda(datatype=2).datatype, 2)
+    assert_equal(gda(datatype='uint8').datatype, 2)
+    assert_raises(KeyError, gda, datatype='not_datatype')
+    # Float32 datatype comes from array if datatype not set
+    assert_equal(gda(arr).datatype, 16)
+    # Can be overriden by init
+    assert_equal(gda(arr, datatype='uint8').datatype, 2)
+    # Encoding
+    assert_equal(gda(encoding=1).encoding, 1)
+    assert_equal(gda(encoding='ASCII').encoding, 1)
+    assert_equal(gda(encoding='GIFTI_ENCODING_ASCII').encoding, 1)
+    assert_raises(KeyError, gda, encoding='not an encoding')
+    # Endian
+    assert_equal(gda(endian=1).endian, 1)
+    assert_equal(gda(endian='big').endian, 1)
+    assert_equal(gda(endian='GIFTI_ENDIAN_BIG').endian, 1)
+    assert_raises(KeyError, gda, endian='not endian code')
+    # CoordSys
+    aff = np.diag([2, 3, 4, 1])
+    cs = GiftiCoordSystem(1, 2, aff)
+    da = gda(coordsys=cs)
+    assert_equal(da.coordsys.dataspace, 1)
+    assert_equal(da.coordsys.xformspace, 2)
+    assert_array_equal(da.coordsys.xform, aff)
+    # Ordering
+    assert_equal(gda(ordering=2).ind_ord, 2)
+    assert_equal(gda(ordering='F').ind_ord, 2)
+    assert_equal(gda(ordering='ColumnMajorOrder').ind_ord, 2)
+    assert_raises(KeyError, gda, ordering='not an ordering')
+    # metadata
+    meta_dict=dict(one=1, two=2)
+    assert_equal(gda(meta=GiftiMetaData.from_dict(meta_dict)).meta.metadata,
+                 meta_dict)
+    assert_equal(gda(meta=meta_dict).meta.metadata, meta_dict)
+    assert_equal(gda(meta=None).meta.metadata, {})
+    # ext_fname and ext_offset
+    assert_equal(gda(ext_fname='foo').ext_fname, 'foo')
+    assert_equal(gda(ext_offset=12).ext_offset, 12)
+
+
+def test_dataarray_from_array():
     for dt_code in data_type_codes.value_set():
         data_type = data_type_codes.type[dt_code]
         if data_type is np.void:  # not supported
@@ -104,24 +187,15 @@ def test_labeltable():
 
 
 def test_metadata():
+    nvpair = GiftiNVPairs('key', 'value')
+    da = GiftiMetaData(nvpair=nvpair)
+    assert_equal(da.data[0].name, 'key')
+    assert_equal(da.data[0].value, 'value')
     # Test deprecation
     with clear_and_catch_warnings() as w:
         warnings.filterwarnings('always', category=DeprecationWarning)
         assert_equal(len(GiftiDataArray().get_metadata()), 0)
         assert_equal(len(w), 1)
-
-    # Test deprecation
-    with clear_and_catch_warnings() as w:
-        warnings.filterwarnings('once', category=DeprecationWarning)
-        assert_equal(len(GiftiMetaData().get_metadata()), 0)
-        assert_equal(len(w), 1)
-
-
-def test_metadata():
-    nvpair = GiftiNVPairs('key', 'value')
-    da = GiftiMetaData(nvpair=nvpair)
-    assert_equal(da.data[0].name, 'key')
-    assert_equal(da.data[0].value, 'value')
 
 
 def test_gifti_label_rgba():
@@ -175,26 +249,6 @@ def test_gifti_coord():
     gcs.xform = None
     gcs.print_summary()
     gcs.to_xml()
-
-
-def test_gifti_image():
-    img = GiftiImage()
-    assert_true(img.darrays is not None)
-    assert_true(img.meta is not None)
-    assert_true(img.labeltable is not None)
-
-    # Try to set a non-data-array
-    assert_raises(TypeError, img.add_gifti_data_array, 'not-a-data-array')
-
-    # Try to set to non-table
-    def assign_labeltable(val):
-        img.labeltable = val
-    assert_raises(TypeError, assign_labeltable, 'not-a-table')
-
-    # Try to set to non-table
-    def assign_metadata(val):
-        img.meta = val
-    assert_raises(TypeError, assign_metadata, 'not-a-meta')
 
 
 def test_data_tag_deprecated():


### PR DESCRIPTION
Responding to comments on Ben's previous PR #403.

Expand and fix docstrings and gifti attribute descriptions from gifti
spec.

Rewrite GiftiDataArray init to allow full initialization of object, that
can be used from GiftiDataArray.from_array.  Add tests.

Fix up the tests - there were some duplicate test names so some tests were not being run.

Remove unused `label` attribute of `GiftiLabel` object.