### PR TITLE
ENH: Add write_morph_data to freesurfer.io

### DIFF
--- a/nibabel/freesurfer/__init__.py
+++ b/nibabel/freesurfer/__init__.py
@@ -1,6 +1,6 @@
 """Reading functions for freesurfer files
 """
 
-from .io import read_geometry, read_morph_data, \
+from .io import read_geometry, read_morph_data, write_morph_data, \
     read_annot, read_label, write_geometry, write_annot
 from .mghformat import load, save, MGHImage

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -6,6 +6,7 @@ import time
 
 
 from .. externals.six.moves import xrange
+from ..openers import Opener
 
 
 def _fread3(fobj):
@@ -160,8 +161,8 @@ def read_morph_data(filepath):
     return curv
 
 
-def write_morph_data(filepath, values, fnum=0):
-    """Write Freesurfer morphometry data `values` to file `filepath`
+def write_morph_data(file_like, values, fnum=0):
+    """Write Freesurfer morphometry data `values` to file-like `file_like`
 
     Equivalent to FreeSurfer's `write_curv.m`_
 
@@ -173,8 +174,9 @@ def write_morph_data(filepath, values, fnum=0):
 
     Parameters
     ----------
-    filepath : str
-        Path to annotation file to be written
+    file_like : file-like
+        String containing path of file to be written, or file-like object, open
+        in binary write (`'wb'` mode, implementing the `write` method)
     values : array-like
         Surface morphometry values
     fnum : int, optional
@@ -193,13 +195,13 @@ def write_morph_data(filepath, values, fnum=0):
     if len(array.shape) > 1:
         raise ValueError("Multi-dimensional values not supported")
 
-    with open(filepath, 'wb') as fobj:
-        magic_bytes.tofile(fobj)
+    with Opener(file_like, 'wb') as fobj:
+        fobj.write(magic_bytes)
 
         # vertex count, face count (unused), vals per vertex (only 1 supported)
-        np.array([len(values), fnum, 1], dtype='>i4').tofile(fobj)
+        fobj.write(np.array([len(values), fnum, 1], dtype='>i4'))
 
-        array.tofile(fobj)
+        fobj.write(array)
 
 
 def read_annot(filepath, orig_ids=False):

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -160,23 +160,27 @@ def read_morph_data(filepath):
     return curv
 
 
-def write_morph_data(filename, values):
-    '''
-    '''
-    with open(filename, 'wb') as f:
+def write_morph_data(filepath, values):
+    """Write out a Freesurfer morphometry data file.
 
-      # magic number
-      np.array([255], dtype='>u1').tofile(f)
-      np.array([255], dtype='>u1').tofile(f)
-      np.array([255], dtype='>u1').tofile(f)
+    See:
+    http://www.grahamwideman.com/gw/brain/fs/surfacefileformats.htm#CurvNew
 
-      # vertices number and two un-used int4
-      np.array([len(values)], dtype='>i4').tofile(f)
-      np.array([0], dtype='>i4').tofile(f)
-      np.array([1], dtype='>i4').tofile(f)
+    Parameters
+    ----------
+    filepath : str
+        Path to annotation file to be written
+    values : ndarray, shape (n_vertices,)
+        Surface morphometry values
+    """
+    magic_bytes = np.array([255, 255, 255], dtype=np.uint8)
+    with open(filepath, 'wb') as fobj:
+        magic_bytes.tofile(fobj)
 
-      # now the data
-      np.array(values, dtype='>f4').tofile(f)
+        # vertex count, face count (unused), vals per vertex (only 1 supported)
+        np.array([len(values), 0, 1], dtype='>i4').tofile(fobj)
+
+        np.array(values, dtype='>f4').tofile(fobj)
 
 
 def read_annot(filepath, orig_ids=False):

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -160,6 +160,25 @@ def read_morph_data(filepath):
     return curv
 
 
+def write_morph_data(filename, values):
+    '''
+    '''
+    with open(filename, 'wb') as f:
+
+      # magic number
+      np.array([255], dtype='>u1').tofile(f)
+      np.array([255], dtype='>u1').tofile(f)
+      np.array([255], dtype='>u1').tofile(f)
+
+      # vertices number and two un-used int4
+      np.array([len(values)], dtype='>i4').tofile(f)
+      np.array([0], dtype='>i4').tofile(f)
+      np.array([1], dtype='>i4').tofile(f)
+
+      # now the data
+      np.array(values, dtype='>f4').tofile(f)
+
+
 def read_annot(filepath, orig_ids=False):
     """Read in a Freesurfer annotation from a .annot file.
 

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -184,22 +184,22 @@ def write_morph_data(file_like, values, fnum=0):
     """
     magic_bytes = np.array([255, 255, 255], dtype=np.uint8)
 
+    array = np.asarray(values).astype('>f4').squeeze()
+    if len(array.shape) > 1:
+        raise ValueError("Multi-dimensional values not supported")
+
     i4info = np.iinfo('i4')
-    if len(values) > i4info.max:
+    if len(array) > i4info.max:
         raise ValueError("Too many values for morphometry file")
     if not i4info.min <= fnum <= i4info.max:
         raise ValueError("Argument fnum must be between {0} and {1}".format(
                          i4info.min, i4info.max))
 
-    array = np.asarray(values).astype('>f4')
-    if len(array.shape) > 1:
-        raise ValueError("Multi-dimensional values not supported")
-
     with Opener(file_like, 'wb') as fobj:
         fobj.write(magic_bytes)
 
         # vertex count, face count (unused), vals per vertex (only 1 supported)
-        fobj.write(np.array([len(values), fnum, 1], dtype='>i4'))
+        fobj.write(np.array([len(array), fnum, 1], dtype='>i4'))
 
         fobj.write(array)
 

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.testing import assert_equal, dec
 
 from .. import (read_geometry, read_morph_data, read_annot, read_label,
-                write_geometry, write_annot)
+                write_geometry, write_morph_data, write_annot)
 
 from ...tests.nibabel_data import get_nibabel_data
 
@@ -92,6 +92,11 @@ def test_morph_data():
     curv = read_morph_data(curv_path)
     assert_true(-1.0 < curv.min() < 0)
     assert_true(0 < curv.max() < 1.0)
+    with InTemporaryDirectory():
+        new_path = 'test'
+        write_morph_data(new_path, curv)
+        curv2 = read_morph_data(new_path)
+        assert_equal(curv2, curv)
 
 
 @freesurfer_test

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -113,8 +113,10 @@ def test_write_morph_data():
             assert_equal(values, read_morph_data('test.curv'))
         assert_raises(ValueError, write_morph_data, 'test.curv',
                       np.zeros(shape), big_num)
-        assert_raises(ValueError, write_morph_data, 'test.curv',
-                      strided_scalar((big_num,)))
+        # Windows 32-bit overflows Python int
+        if np.dtype(np.int) != np.dtype(np.int32):
+            assert_raises(ValueError, write_morph_data, 'test.curv',
+                          strided_scalar((big_num,)))
         for shape in bad_shapes:
             assert_raises(ValueError, write_morph_data, 'test.curv',
                           values.reshape(shape))

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -104,7 +104,7 @@ def test_write_morph_data():
     """Test write_morph_data edge cases"""
     values = np.arange(20, dtype='>f4')
     okay_shapes = [(20,), (20, 1), (20, 1, 1), (1, 20)]
-    bad_shape = (10, 2)
+    bad_shapes = [(10, 2), (1, 1, 20, 1, 1)]
     big_num = np.iinfo('i4').max + 1
     with InTemporaryDirectory():
         for shape in okay_shapes:
@@ -114,9 +114,10 @@ def test_write_morph_data():
         assert_raises(ValueError, write_morph_data, 'test.curv',
                       np.zeros(shape), big_num)
         assert_raises(ValueError, write_morph_data, 'test.curv',
-                      values.reshape(bad_shape))
-        assert_raises(ValueError, write_morph_data, 'test.curv',
                       strided_scalar((big_num,)))
+        for shape in bad_shapes:
+            assert_raises(ValueError, write_morph_data, 'test.curv',
+                          values.reshape(shape))
 
 
 @freesurfer_test


### PR DESCRIPTION
The first commit was in the midst of #249 and causing PEP8 warnings. Not otherwise relevant to Cifti, so  I'm submitting as its own PR. Fixed the style and brought a little more in line with `freesurfer.io` functions.