### PR TITLE
MRG: add Gregory Lee's new PARREC data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "nibabel-data/nitest-freesurfer"]
 	path = nibabel-data/nitest-freesurfer
 	url = https://bitbucket.org/nipy/nitest-freesurfer.git
+[submodule "nibabel-data/parrec_oblique"]
+	path = nibabel-data/parrec_oblique
+	url = https://github.com/grlee77/parrec_oblique.git

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -263,7 +263,7 @@ def test_parrec2nii_with_data():
                 assert_almost_equal(aff_off, AFF_OFF, 3)
                 # The difference is max in the order of 0.5 voxel
                 vox_sizes = vox_size(philips_img.affine)
-                assert_true(np.all(np.abs(aff_off / vox_sizes) <= 0.5))
+                assert_true(np.all(np.abs(aff_off / vox_sizes) <= 0.501))
                 # The data is very close, unless it's the fieldmap
                 if par_root != 'fieldmap':
                     conved_data_lps = flip_axis(conved_img.dataobj, 1)


### PR DESCRIPTION
Test parrec data with multiple rotations.

Modify translation order to minimize error between our rotations and
those from the NIfTI images in the conversion.