### PR TITLE
BF: fix dependency on numpy >= 1.8 in viewer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     - python: 2.7
       env:
         - DEPENDS=numpy==1.5.1 PYDICOM=0
+    # Absolute minimum dependencies plus oldest MPL
+    - python: 2.7
+      env:
+        - DEPENDS=numpy==1.5.1 matplotlib==1.3.1 PYDICOM=0
     # Minimum pydicom dependency
     - python: 2.7
       env:

--- a/nibabel/viewers.py
+++ b/nibabel/viewers.py
@@ -382,8 +382,8 @@ class OrthoSlicer3D(object):
             # sagittal: get to S/A
             # coronal: get to S/L
             # axial: get to A/L
-            data = np.take(self._current_vol_data, self._data_idx[ii],
-                           axis=self._order[ii])
+            data = np.rollaxis(self._current_vol_data,
+                               axis=self._order[ii])[self._data_idx[ii]]
             xax = [1, 0, 0][ii]
             yax = [2, 2, 1][ii]
             if self._order[xax] < self._order[yax]:


### PR DESCRIPTION
Viewer was using `np.take` with integer argument for `indices`, only
allowed in numpy 1.8 or greater.

See:
http://nipy.bic.berkeley.edu/builders/nibabel-py2.6-32/builds/352/steps/shell_5/logs/stdio

Instead, use rollaxis and slicing to get the slice that we need.  This
should also be faster, because we always get a view rather than a copy.