### PR TITLE
MRG: testing on numpy 1.12 plus fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
-
 addons:
   apt:
     packages:
       - libhdf5-serial-dev
-
+      # For numpy --pre wheels
+      - libatlas-base-dev
 env:
     global:
         - DEPENDS="numpy scipy matplotlib h5py"
@@ -45,6 +45,10 @@ matrix:
     - python: 2.7
       env:
         - PYDICOM="v1.0"
+    # test against pre-release builds
+    - python: 2.7
+      env:
+        - EXTRA_PIP_FLAGS="--pre"
     # Documentation doctests
     - python: 2.7
       env:
@@ -71,7 +75,7 @@ before_install:
     - python --version # just to check
     - pip install -U pip wheel  # upgrade to latest pip find 3.5 wheels; wheel to avoid errors
     - retry pip install nose flake8  # always
-    - wheelhouse_pip_install $DEPENDS
+    - wheelhouse_pip_install $EXTRA_PIP_FLAGS $DEPENDS
     # pydicom <= 0.9.8 doesn't install on python 3
     - if [ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]; then
         if [ "$PYDICOM" == "1" ]; then
@@ -92,13 +96,13 @@ install:
       elif [ "$INSTALL_TYPE" == "sdist" ]; then
           python setup_egg.py egg_info  # check egg_info while we're here
           python setup_egg.py sdist
-          wheelhouse_pip_install dist/*.tar.gz
+          wheelhouse_pip_install $EXTRA_PIP_FLAGS dist/*.tar.gz
       elif [ "$INSTALL_TYPE" == "wheel" ]; then
           pip install wheel
           python setup_egg.py bdist_wheel
-          wheelhouse_pip_install dist/*.whl
+          wheelhouse_pip_install $EXTRA_PIP_FLAGS dist/*.whl
       elif [ "$INSTALL_TYPE" == "requirements" ]; then
-          wheelhouse_pip_install -r requirements.txt
+          wheelhouse_pip_install $EXTRA_PIP_FLAGS -r requirements.txt
           python setup.py install
       fi
     # Point to nibabel data directory

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -11,6 +11,7 @@ than an AttributeError - breaking the 'properties manifesto'.   So, any
 processing that needs to raise an error, should be in a method, rather
 than in a property, or property-like thing.
 """
+from __future__ import division
 
 import operator
 
@@ -724,7 +725,7 @@ class MosaicWrapper(SiemensWrapper):
     Adds attributes:
 
     * n_mosaic : int
-    * mosaic_size : float
+    * mosaic_size : int
     """
     is_mosaic = True
 
@@ -758,7 +759,7 @@ class MosaicWrapper(SiemensWrapper):
                                    'header; is this really '
                                    'Siemens mosiac data?')
         self.n_mosaic = n_mosaic
-        self.mosaic_size = np.ceil(np.sqrt(n_mosaic))
+        self.mosaic_size = int(np.ceil(np.sqrt(n_mosaic)))
 
     @one_time
     def image_shape(self):

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -220,7 +220,8 @@ def inv_ornt_aff(ornt, shape):
     # ornt indicates the transpose that has occurred to get the current
     # ordering, relative to canonical, so we just use that.
     # undo_reorder is a row permutatation matrix
-    undo_reorder = np.eye(p + 1)[list(ornt[:, 0]) + [p], :]
+    axis_transpose = [int(v) for v in ornt[:, 0]]
+    undo_reorder = np.eye(p + 1)[axis_transpose + [p], :]
     undo_flip = np.diag(list(ornt[:, 1]) + [1.0])
     center_trans = -(shape - 1) / 2.0
     undo_flip[:p, p] = (ornt[:, 1] * center_trans) - center_trans

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -7,8 +7,12 @@ PY2 = sys.version_info[0] < 3
 from io import BytesIO
 from itertools import product
 from functools import partial
+from distutils.version import LooseVersion
 
 import numpy as np
+
+# np > 1.11 makes double ellipsis illegal in indices
+HAVE_NP_GT_1p11 = LooseVersion(np.__version__) > '1.11'
 
 from ..fileslice import (is_fancy, canonical_slicers, fileslice,
                          predict_shape, read_segments, _positive_slice,
@@ -41,7 +45,11 @@ def test_is_fancy():
     for slice0 in slices:
         _check_slice(slice0)
         _check_slice((slice0,))  # tuple is same
+        # Double ellipsis illegal in np 1.12dev - set up check for that case
+        maybe_bad = HAVE_NP_GT_1p11 and slice0 is Ellipsis
         for slice1 in slices:
+            if maybe_bad and slice1 is Ellipsis:
+                continue
             _check_slice((slice0, slice1))
     assert_false(is_fancy((None,)))
     assert_false(is_fancy((None, 1)))

--- a/tools/travis_tools.sh
+++ b/tools/travis_tools.sh
@@ -1,6 +1,12 @@
 # Tools for working with travis-ci
-export WHEELHOST="travis-wheels.scikit-image.org"
-export WHEELHOUSE="http://${WHEELHOST}/"
+WHEELHOSTS="travis-wheels.scikit-image.org travis-dev-wheels.scipy.org"
+
+PIP_FLAGS="--timeout=60 --no-index"
+
+for host in $WHEELHOSTS; do
+   PIP_FLAGS="${PIP_FLAGS} --trusted-host ${host} --find-links=http://${host}"
+done
+
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804
@@ -22,5 +28,5 @@ retry () {
 
 wheelhouse_pip_install() {
     # Install pip requirements via travis wheelhouse
-    retry pip install --timeout=60 --no-index --trusted-host $WHEELHOST --find-links $WHEELHOUSE $@
+    retry pip install $PIP_FLAGS $@
 }


### PR DESCRIPTION
Numpy 1.12 (not yet released) breaks some stuff; have travis test against daily
numpy builds and fix problems.