### PR TITLE
ENH: add a function to retrieve .PAR data labels for the 4th dimension

### DIFF
--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -9,6 +9,7 @@ import numpy.linalg as npl
 import sys
 import os
 import json
+from copy import deepcopy
 import nibabel
 import nibabel.parrec as pr
 from nibabel.parrec import one_line
@@ -132,6 +133,24 @@ def verbose(msg, indent=0):
 def error(msg, exit_code):
     sys.stderr.write(msg + '\n')
     sys.exit(exit_code)
+
+
+def sort_info_to_lists(sort_info):
+    sort_info = deepcopy(sort_info)
+    # convert from elements from numpy array to lists for easy JSON export
+    for key in sort_info:
+        ndim = sort_info[key].ndim
+        if ndim == 1:
+            sort_info[key] = list(sort_info[key])
+        elif ndim == 2:
+            k = sort_info[key]
+            k_list = []
+            for row in range(k.shape[0]):
+                k_list.append(list(k[row]))
+            sort_info[key] = k_list
+        else:
+            raise ValueError("only 1D and 2D arrays supported")
+    return sort_info
 
 
 def proc_file(infile, opts):
@@ -265,15 +284,15 @@ def proc_file(infile, opts):
 
     opts.dim_info = True  # TODO: remove hard-coded value
     if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
-        if len(list(pr_img.dataobj._dim_4_labels.keys())) > 0:
-            with open(basefilename + '.ordering.json', 'w') as fid:
-                json.dump(pr_img.dataobj._dim_4_labels, fid, sort_keys=True,
-                          indent=4)
+        labels = pr_img.dataobj._dim_4_labels
     elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
-        if len(list(pr_img.dataobj._dim_3_4_labels.keys())) > 0:
-            with open(basefilename + '.ordering.json', 'w') as fid:
-                json.dump(pr_img.dataobj._dim_3_4_labels, fid, sort_keys=True,
-                          indent=4)
+        labels = pr_img.dataobj._dim_3_4_labels
+    else:
+        labels = None
+    if labels is not None and len(labels) > 0:
+        sort_info = sort_info_to_lists(labels)
+        with open(basefilename + '.ordering.json', 'w') as fid:
+            json.dump(sort_info, fid, sort_keys=True, indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -77,8 +77,8 @@ def get_opt_parser():
                    JSON format with a filename matching the input .PAR, but
                    with the extension .ordering.json.  Only labels that vary
                    along the 4th dimension are exported.  (e.g. for a single
-                   a single volume structural scan there are no dynamic labels
-                   and no output file will be created)""")))
+                   volume structural scan there are no dynamic labels and no
+                   output file will be created)""")))
     p.add_option(
         Option("--origin", action="store", dest="origin", default="scanner",
                help=one_line(

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.linalg as npl
 import sys
 import os
+import json
 import nibabel
 import nibabel.parrec as pr
 from nibabel.parrec import one_line
@@ -261,6 +262,18 @@ def proc_file(infile, opts):
                     for val in row:
                         fid.write('%s ' % val)
                     fid.write('\n')
+
+    opts.dim_info = True  # TODO: remove hard-coded value
+    if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
+        if len(list(pr_img.dataobj._dim_4_labels.keys())) > 0:
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(pr_img.dataobj._dim_4_labels, fid, sort_keys=True,
+                          indent=4)
+    elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
+        if len(list(pr_img.dataobj._dim_3_4_labels.keys())) > 0:
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(pr_img.dataobj._dim_3_4_labels, fid, sort_keys=True,
+                          indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -69,6 +69,17 @@ def get_opt_parser():
                    for --dwell-time. The field strength must be supplied
                    because it is not encoded in the PAR/REC format.""")))
     p.add_option(
+        Option("-i", "--dimension-info", action="store_true", dest="dim_info",
+               default=False,
+               help=one_line(
+                   """Export .PAR dimension labels corresponding to the fourth
+                   dimension of the data.  The dimension info will be stored in
+                   JSON format with a filename matching the input .PAR, but
+                   with the extension .ordering.json.  Only labels that vary
+                   along the 4th dimension are exported.  (e.g. for a single
+                   a single volume structural scan there are no dynamic labels
+                   and no output file will be created)""")))
+    p.add_option(
         Option("--origin", action="store", dest="origin", default="scanner",
                help=one_line(
                    """Reference point of the q-form transformation of the NIfTI
@@ -135,22 +146,14 @@ def error(msg, exit_code):
     sys.exit(exit_code)
 
 
-def sort_info_to_lists(sort_info):
-    sort_info = deepcopy(sort_info)
-    # convert from elements from numpy array to lists for easy JSON export
-    for key in sort_info:
-        ndim = sort_info[key].ndim
-        if ndim == 1:
-            sort_info[key] = list(sort_info[key])
-        elif ndim == 2:
-            k = sort_info[key]
-            k_list = []
-            for row in range(k.shape[0]):
-                k_list.append(list(k[row]))
-            sort_info[key] = k_list
-        else:
-            raise ValueError("only 1D and 2D arrays supported")
-    return sort_info
+def convert_arrays_to_lists(input_dict):
+    # convert dictionary of numpy arrays to a dictionary of lists
+    output_dict = deepcopy(input_dict)
+    for key, value in output_dict.items():
+        if not isinstance(value, np.ndarray):
+            raise ValueError("all dictionary entries must be numpy arrays")
+        output_dict[key] = value.tolist()
+    return output_dict
 
 
 def proc_file(infile, opts):
@@ -282,17 +285,13 @@ def proc_file(infile, opts):
                         fid.write('%s ' % val)
                     fid.write('\n')
 
-    opts.dim_info = True  # TODO: remove hard-coded value
-    if opts.dim_info and pr_img.dataobj._dim_4_labels is not None:
-        labels = pr_img.dataobj._dim_4_labels
-    elif opts.dim_info and pr_img.dataobj._dim_3_4_labels is not None:
-        labels = pr_img.dataobj._dim_3_4_labels
-    else:
-        labels = None
-    if labels is not None and len(labels) > 0:
-        sort_info = sort_info_to_lists(labels)
-        with open(basefilename + '.ordering.json', 'w') as fid:
-            json.dump(sort_info, fid, sort_keys=True, indent=4)
+    # export data labels varying along the 4th dimensions
+    if opts.dim_info:
+        labels = pr_img.header.get_dimension_labels(collapse_slices=True)
+        if len(labels) > 0:
+            labels = convert_arrays_to_lists(labels)
+            with open(basefilename + '.ordering.json', 'w') as fid:
+                json.dump(labels, fid, sort_keys=True, indent=4)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/bin/parrec2nii
+++ b/bin/parrec2nii
@@ -8,8 +8,7 @@ import numpy as np
 import numpy.linalg as npl
 import sys
 import os
-import json
-from copy import deepcopy
+import csv
 import nibabel
 import nibabel.parrec as pr
 from nibabel.parrec import one_line
@@ -69,16 +68,17 @@ def get_opt_parser():
                    for --dwell-time. The field strength must be supplied
                    because it is not encoded in the PAR/REC format.""")))
     p.add_option(
-        Option("-i", "--dimension-info", action="store_true", dest="dim_info",
+        Option("-i", "--volume-info", action="store_true", dest="vol_info",
                default=False,
                help=one_line(
-                   """Export .PAR dimension labels corresponding to the fourth
+                   """Export .PAR volume labels corresponding to the fourth
                    dimension of the data.  The dimension info will be stored in
-                   JSON format with a filename matching the input .PAR, but
-                   with the extension .ordering.json.  Only labels that vary
-                   along the 4th dimension are exported.  (e.g. for a single
-                   volume structural scan there are no dynamic labels and no
-                   output file will be created)""")))
+                   CSV format with the first row containing dimension labels
+                   and the subsequent rows (one per volume), the corresponding
+                   indices.  Only labels that vary along the 4th dimension are
+                   exported (e.g. for a single volume structural scan there
+                   are no dynamic labels and no output file will be created).
+                   """)))
     p.add_option(
         Option("--origin", action="store", dest="origin", default="scanner",
                help=one_line(
@@ -144,16 +144,6 @@ def verbose(msg, indent=0):
 def error(msg, exit_code):
     sys.stderr.write(msg + '\n')
     sys.exit(exit_code)
-
-
-def convert_arrays_to_lists(input_dict):
-    # convert dictionary of numpy arrays to a dictionary of lists
-    output_dict = deepcopy(input_dict)
-    for key, value in output_dict.items():
-        if not isinstance(value, np.ndarray):
-            raise ValueError("all dictionary entries must be numpy arrays")
-        output_dict[key] = value.tolist()
-    return output_dict
 
 
 def proc_file(infile, opts):
@@ -285,13 +275,16 @@ def proc_file(infile, opts):
                         fid.write('%s ' % val)
                     fid.write('\n')
 
-    # export data labels varying along the 4th dimensions
-    if opts.dim_info:
-        labels = pr_img.header.get_dimension_labels(collapse_slices=True)
+    # export data labels varying along the 4th dimensions if requested
+    if opts.vol_info:
+        labels = pr_img.header.get_volume_labels()
         if len(labels) > 0:
-            labels = convert_arrays_to_lists(labels)
-            with open(basefilename + '.ordering.json', 'w') as fid:
-                json.dump(labels, fid, sort_keys=True, indent=4)
+            vol_keys = list(labels.keys())
+            with open(basefilename + '.ordering.csv', 'w') as csvfile:
+                csvwriter = csv.writer(csvfile, delimiter=',')
+                csvwriter.writerow(vol_keys)
+                for vals in zip(*[labels[k] for k in vol_keys]):
+                    csvwriter.writerow(vals)
 
     # write out dwell time if requested
     if opts.dwell_time:

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1170,9 +1170,8 @@ class PARRECHeader(SpatialHeader):
             dynamic_keys.remove('slice number')
 
         # remove dynamic keys that may not be present in older .PAR versions
-        for key in dynamic_keys:
-            if key not in image_defs.dtype.fields:
-                dynamic_keys.remove(key)
+        dynamic_keys = [d for d in dynamic_keys if d in
+                        image_defs.dtype.fields]
 
         non_unique_keys = []
         for key in dynamic_keys:

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -569,6 +569,21 @@ class PARRECArrayProxy(object):
         self._slice_scaling = header.get_data_scaling(scaling)
         self._rec_shape = header.get_rec_shape()
 
+        try:
+            # store additional slice & volume label information
+            self._dim_4_labels = header.sorted_labels(
+                    sorted_indices=self._slice_indices,
+                    collapse_slices=True)
+            self._dim_3_4_labels = None
+        except:
+            # if non-unique slice orientations or image angulations, need to
+            # also keep labels for the 3rd (slice) dimension
+            self._dim_4_labels = None
+            self._dim_3_4_labels = header.sorted_labels(
+                sorted_indices=self._slice_indices,
+                collapse_slices=False)
+
+
     @property
     def shape(self):
         return self._shape
@@ -1113,6 +1128,75 @@ class PARRECHeader(SpatialHeader):
         # Based on our sorting, they should always be last.
         n_used = np.prod(self.get_data_shape()[2:])
         return sort_order[:n_used]
+
+    def sorted_labels(self, sorted_indices=None, collapse_slices=True):
+        """ return a dictionary of lists of the varying values in
+        ``self.image_defs``.  This is useful for custom data sorting.  only
+        keys that have more than 1 unique value across the dataset will exist
+        in the returned `sort_info` dictionary.
+
+        Parameters
+        ----------
+        sorted_indices : array, optional
+            sorted slice indices as returned by
+            ``self.get_sorted_slice_indices``.
+        collapse_slices : bool, optional
+            if True, only return indices corresponding to the first slice
+
+        Returns
+        -------
+        sort_info : dict
+            Each key corresponds to a dynamically varying sequence dimension.
+            The ordering of values corresponds to that in sorted_indices.
+        """
+
+        # define which keys to store sorting info for
+        dynamic_keys = ['slice number',
+                        'cardiac phase number',
+                        'echo number',
+                        'label type',
+                        'image_type_mr',
+                        'dynamic scan number',
+                        'slice orientation',
+                        'image_display_orientation',  # ????
+                        'image angulation',
+                        'scanning sequence',
+                        'gradient orientation number',
+                        'diffusion b value number']
+
+        if sorted_indices is None:
+            sorted_indices = self.get_sorted_slice_indices()
+
+        if collapse_slices:
+            dynamic_keys.remove('slice number')
+
+        non_unique_keys = []
+        for key in dynamic_keys:
+            if len(np.unique(self.image_defs[key])) > 1:
+                non_unique_keys.append(key)
+
+        if collapse_slices:
+            if 'slice orientation' in non_unique_keys:
+                raise ValueError("for non-unique slice orientation, need "
+                                 "collapse_slice=False")
+            if 'image angulation' in non_unique_keys:
+                raise ValueError("for non-unique image angulation, need "
+                                 "collapse_slice=False")
+            if 'image image_display_orientation' in non_unique_keys:  # ???
+                raise ValueError("for non-unique display orientation, need "
+                                 "collapse_slice=False")
+            sl1_indices = self.image_defs['slice number'][sorted_indices] == 1
+
+        sort_info = {}
+        for key in non_unique_keys:
+            if collapse_slices:
+                sort_info[key] = list(
+                    self.image_defs[key][sorted_indices][sl1_indices])
+            else:
+                sort_info[key] = list(
+                    self.image_defs[key][sorted_indices])
+
+        return sort_info
 
 
 class PARRECImage(SpatialImage):

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1161,7 +1161,7 @@ class PARRECHeader(SpatialHeader):
         # the value at slice 1.
         sl1_indices = image_defs['slice number'][sorted_indices] == 1
 
-        sort_info = OrderedDict(non_unique_keys)
+        sort_info = OrderedDict()
         for key in non_unique_keys:
             sort_info[key] = image_defs[key][sorted_indices][sl1_indices]
         return sort_info

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -249,6 +249,18 @@ class PARRECError(Exception):
 GEN_RE = re.compile(r".\s+(.*?)\s*:\s*(.*)")
 
 
+def _unique_rows(a):
+    """
+    find unique rows of a 2D array.  based on discussion at:
+    http://stackoverflow.com/questions/16970982/find-unique-rows-in-numpy-array
+    """
+    if a.ndim != 2:
+        raise ValueError("expected 2D input")
+    b = np.ascontiguousarray(a).view(
+            np.dtype((np.void, a.dtype.itemsize * a.shape[1])))
+    return np.unique(b).view(a.dtype).reshape(-1, a.shape[1])
+
+
 def _split_header(fobj):
     """ Split header into `version`, `gen_dict`, `image_lines` """
     version = None
@@ -1171,8 +1183,17 @@ class PARRECHeader(SpatialHeader):
             dynamic_keys.remove('slice number')
 
         non_unique_keys = []
+
         for key in dynamic_keys:
-            if len(np.unique(self.image_defs[key])) > 1:
+            ndim = self.image_defs[key].ndim
+            if ndim == 1:
+                num_unique = len(np.unique(self.image_defs[key]))
+            elif ndim == 2:
+                # for 2D cases, e.g. 'image angulation'
+                num_unique = len(_unique_rows(self.image_defs[key]))
+            else:
+                raise ValueError("unexpected image_defs shape > 2D")
+            if num_unique > 1:
                 non_unique_keys.append(key)
 
         if collapse_slices:
@@ -1189,13 +1210,11 @@ class PARRECHeader(SpatialHeader):
 
         sort_info = {}
         for key in non_unique_keys:
-            if collapse_slices:
-                sort_info[key] = list(
-                    self.image_defs[key][sorted_indices][sl1_indices])
-            else:
-                sort_info[key] = list(
-                    self.image_defs[key][sorted_indices])
 
+            if collapse_slices:
+                sort_info[key] = self.image_defs[key][sorted_indices][sl1_indices]
+            else:
+                sort_info[key] = self.image_defs[key][sorted_indices]
         return sort_info
 
 

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -95,6 +95,7 @@ from copy import deepcopy
 import re
 from io import StringIO
 from locale import getpreferredencoding
+from collections import OrderedDict
 
 from .keywordonly import kw_only_meth
 from .spatialimages import SpatialHeader, SpatialImage
@@ -1160,7 +1161,7 @@ class PARRECHeader(SpatialHeader):
         # the value at slice 1.
         sl1_indices = image_defs['slice number'][sorted_indices] == 1
 
-        sort_info = {}
+        sort_info = OrderedDict(non_unique_keys)
         for key in non_unique_keys:
             sort_info[key] = image_defs[key][sorted_indices][sl1_indices]
         return sort_info

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1126,7 +1126,7 @@ class PARRECHeader(SpatialHeader):
         n_used = np.prod(self.get_data_shape()[2:])
         return sort_order[:n_used]
 
-    def get_dimension_labels(self, collapse_slices=True):
+    def get_volume_labels(self, collapse_slices=True):
         """ Dynamic labels corresponding to the final data dimension(s).
 
         This is useful for custom data sorting.  A subset of the info in
@@ -1148,6 +1148,8 @@ class PARRECHeader(SpatialHeader):
             The ordering of each value corresponds to that returned by
             ``self.get_sorted_slice_indices``.
         """
+        sorted_indices = self.get_sorted_slice_indices()
+        image_defs = self.image_defs
 
         # define which keys to store sorting info for
         dynamic_keys = ['slice number',
@@ -1162,9 +1164,6 @@ class PARRECHeader(SpatialHeader):
                         'scanning sequence',
                         'gradient orientation number',
                         'diffusion b value number']
-
-        sorted_indices = self.get_sorted_slice_indices()
-        image_defs = self.image_defs
 
         if collapse_slices:
             dynamic_keys.remove('slice number')
@@ -1187,15 +1186,12 @@ class PARRECHeader(SpatialHeader):
                 non_unique_keys.append(key)
 
         if collapse_slices:
-            if 'slice orientation' in non_unique_keys:
-                raise ValueError("for non-unique slice orientation, need "
-                                 "collapse_slice=False")
-            if 'image angulation' in non_unique_keys:
-                raise ValueError("for non-unique image angulation, need "
-                                 "collapse_slice=False")
-            if 'image_display_orientation' in non_unique_keys:  # ???
-                raise ValueError("for non-unique display orientation, need "
-                                 "collapse_slice=False")
+            for key in ('slice_orientation', 'image_angulation',
+                        'image_display_orientation'):
+                if key in non_unique_keys:
+                    raise ValueError(
+                        'for values of {0} that differ overslices, use '
+                        '"collapse_slice=False"'.format(key))
             sl1_indices = image_defs['slice number'][sorted_indices] == 1
 
         sort_info = {}

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -257,7 +257,7 @@ def _unique_rows(a):
     if a.ndim != 2:
         raise ValueError("expected 2D input")
     b = np.ascontiguousarray(a).view(
-            np.dtype((np.void, a.dtype.itemsize * a.shape[1])))
+        np.dtype((np.void, a.dtype.itemsize * a.shape[1])))
     return np.unique(b).view(a.dtype).reshape(-1, a.shape[1])
 
 
@@ -580,21 +580,6 @@ class PARRECArrayProxy(object):
         self._mmap = mmap
         self._slice_scaling = header.get_data_scaling(scaling)
         self._rec_shape = header.get_rec_shape()
-
-        try:
-            # store additional slice & volume label information
-            self._dim_4_labels = header.sorted_labels(
-                    sorted_indices=self._slice_indices,
-                    collapse_slices=True)
-            self._dim_3_4_labels = None
-        except:
-            # if non-unique slice orientations or image angulations, need to
-            # also keep labels for the 3rd (slice) dimension
-            self._dim_4_labels = None
-            self._dim_3_4_labels = header.sorted_labels(
-                sorted_indices=self._slice_indices,
-                collapse_slices=False)
-
 
     @property
     def shape(self):
@@ -1141,25 +1126,27 @@ class PARRECHeader(SpatialHeader):
         n_used = np.prod(self.get_data_shape()[2:])
         return sort_order[:n_used]
 
-    def sorted_labels(self, sorted_indices=None, collapse_slices=True):
-        """ return a dictionary of lists of the varying values in
-        ``self.image_defs``.  This is useful for custom data sorting.  only
-        keys that have more than 1 unique value across the dataset will exist
-        in the returned `sort_info` dictionary.
+    def get_dimension_labels(self, collapse_slices=True):
+        """ Dynamic labels corresponding to the final data dimension(s).
+
+        This is useful for custom data sorting.  A subset of the info in
+        ``self.image_defs`` is returned in an order that matches the final
+        data dimension(s).  Only labels that have more than one unique value
+        across the dataset will be returned.
 
         Parameters
         ----------
-        sorted_indices : array, optional
-            sorted slice indices as returned by
-            ``self.get_sorted_slice_indices``.
         collapse_slices : bool, optional
-            if True, only return indices corresponding to the first slice
+            If True, only return volume indices (corresponding to the first
+            slice).  If False, return indices corresponding to individual
+            slices as well (with shape matching self.shape[2:]).
 
         Returns
         -------
         sort_info : dict
             Each key corresponds to a dynamically varying sequence dimension.
-            The ordering of values corresponds to that in sorted_indices.
+            The ordering of each value corresponds to that returned by
+            ``self.get_sorted_slice_indices``.
         """
 
         # define which keys to store sorting info for
@@ -1176,21 +1163,25 @@ class PARRECHeader(SpatialHeader):
                         'gradient orientation number',
                         'diffusion b value number']
 
-        if sorted_indices is None:
-            sorted_indices = self.get_sorted_slice_indices()
+        sorted_indices = self.get_sorted_slice_indices()
+        image_defs = self.image_defs
 
         if collapse_slices:
             dynamic_keys.remove('slice number')
 
-        non_unique_keys = []
-
+        # remove dynamic keys that may not be present in older .PAR versions
         for key in dynamic_keys:
-            ndim = self.image_defs[key].ndim
+            if key not in image_defs.dtype.fields:
+                dynamic_keys.remove(key)
+
+        non_unique_keys = []
+        for key in dynamic_keys:
+            ndim = image_defs[key].ndim
             if ndim == 1:
-                num_unique = len(np.unique(self.image_defs[key]))
+                num_unique = len(np.unique(image_defs[key]))
             elif ndim == 2:
                 # for 2D cases, e.g. 'image angulation'
-                num_unique = len(_unique_rows(self.image_defs[key]))
+                num_unique = len(_unique_rows(image_defs[key]))
             else:
                 raise ValueError("unexpected image_defs shape > 2D")
             if num_unique > 1:
@@ -1203,18 +1194,19 @@ class PARRECHeader(SpatialHeader):
             if 'image angulation' in non_unique_keys:
                 raise ValueError("for non-unique image angulation, need "
                                  "collapse_slice=False")
-            if 'image image_display_orientation' in non_unique_keys:  # ???
+            if 'image_display_orientation' in non_unique_keys:  # ???
                 raise ValueError("for non-unique display orientation, need "
                                  "collapse_slice=False")
-            sl1_indices = self.image_defs['slice number'][sorted_indices] == 1
+            sl1_indices = image_defs['slice number'][sorted_indices] == 1
 
         sort_info = {}
         for key in non_unique_keys:
-
             if collapse_slices:
-                sort_info[key] = self.image_defs[key][sorted_indices][sl1_indices]
+                sort_info[key] = image_defs[key][sorted_indices][sl1_indices]
             else:
-                sort_info[key] = self.image_defs[key][sorted_indices]
+                value = image_defs[key][sorted_indices]
+                sort_info[key] = value.reshape(self.get_data_shape()[2:],
+                                               order='F')
         return sort_info
 
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -197,14 +197,6 @@ def test_header_dimension_labels():
     assert_array_equal(vol_labels['dynamic scan number'], [1, 2, 3])
     # check that output is ndarray rather than list
     assert_true(isinstance(vol_labels['dynamic scan number'], np.ndarray))
-    # check case with individual slice labels
-    slice_vol_labels = hdr.get_volume_labels(collapse_slices=False)
-    # verify that both expected keys are present
-    assert_true('slice number' in slice_vol_labels)
-    assert_true('dynamic scan number' in slice_vol_labels)
-    # verify shape of labels matches final dimensions of data
-    assert_equal(slice_vol_labels['slice number'].shape,
-                 hdr.get_data_shape()[2:])
 
 
 def test_orientation():
@@ -720,9 +712,6 @@ class FakeHeader(object):
     def get_rec_shape(self):
         n_slices = np.prod(self._shape[2:])
         return self._shape[:2] + (n_slices,)
-
-    def sorted_labels(self, sorted_indices, collapse_slices):
-        return np.arange(self._shape[-1])
 
 
 def test_parrec_proxy():

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -301,6 +301,11 @@ def test_sorting_dual_echo_T1():
     # second half (volume 2) should all correspond to echo 2
     assert_equal(np.all(sorted_echos[n_half:] == 2), True)
 
+    # check volume labels
+    vol_labels = t1_hdr.get_dimension_labels()
+    assert_equal(list(vol_labels.keys()), ['echo number'])
+    assert_array_equal(vol_labels['echo number'], [1, 2])
+
 
 def test_sorting_multiple_echos_and_contrasts():
     # This .PAR file has 3 echos and 4 image types (real, imaginary, magnitude,
@@ -343,6 +348,14 @@ def test_sorting_multiple_echos_and_contrasts():
     assert_equal(np.all(sorted_types[ntotal//2:3*ntotal//4] == 2), True)
     assert_equal(np.all(sorted_types[3*ntotal//4:ntotal] == 3), True)
 
+    # check volume labels
+    vol_labels = t1_hdr.get_dimension_labels()
+    assert_equal(sorted(list(vol_labels.keys())),
+                 ['echo number', 'image_type_mr'])
+    assert_array_equal(vol_labels['echo number'], [1, 2, 3]*4)
+    assert_array_equal(vol_labels['image_type_mr'],
+                       [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
+
 
 def test_sorting_multiecho_ASL():
     # For this .PAR file has 3 keys corresponding to volumes:
@@ -383,6 +396,15 @@ def test_sorting_multiecho_ASL():
     assert_array_equal(np.all(sorted_echos[2*nslices:3*nslices] == 3), True)
     # check that slices vary fastest
     assert_array_equal(sorted_slices[:nslices], np.arange(1, nslices+1))
+
+    # check volume labels
+    vol_labels = asl_hdr.get_dimension_labels()
+    assert_equal(sorted(list(vol_labels.keys())),
+                 ['dynamic scan number', 'echo number', 'label type'])
+    assert_array_equal(vol_labels['dynamic scan number'], [1]*6 + [2]*6)
+    assert_array_equal(vol_labels['label type'], [1]*3 + [2]*3 + [1]*3 + [2]*3)
+    assert_array_equal(vol_labels['echo number'], [1, 2, 3]*4)
+
 
 def test_vol_number():
     # Test algorithm for calculating volume number

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -189,7 +189,7 @@ def test_header_scaling():
     assert_false(np.all(fp_scaling == dv_scaling))
 
 
-def test_header_dimension_labels():
+def test_header_volume_labels():
     hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
     # check volume labels
     vol_labels = hdr.get_volume_labels()
@@ -342,8 +342,7 @@ def test_sorting_multiple_echos_and_contrasts():
 
     # check volume labels
     vol_labels = t1_hdr.get_volume_labels()
-    assert_equal(sorted(list(vol_labels.keys())),
-                 ['echo number', 'image_type_mr'])
+    assert_equal(list(vol_labels.keys()), ['echo number', 'image_type_mr'])
     assert_array_equal(vol_labels['echo number'], [1, 2, 3]*4)
     assert_array_equal(vol_labels['image_type_mr'],
                        [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
@@ -391,8 +390,8 @@ def test_sorting_multiecho_ASL():
 
     # check volume labels
     vol_labels = asl_hdr.get_volume_labels()
-    assert_equal(sorted(list(vol_labels.keys())),
-                 ['dynamic scan number', 'echo number', 'label type'])
+    assert_equal(list(vol_labels.keys()),
+                 ['echo number', 'label type', 'dynamic scan number'])
     assert_array_equal(vol_labels['dynamic scan number'], [1]*6 + [2]*6)
     assert_array_equal(vol_labels['label type'], [1]*3 + [2]*3 + [1]*3 + [2]*3)
     assert_array_equal(vol_labels['echo number'], [1, 2, 3]*4)

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -189,6 +189,24 @@ def test_header_scaling():
     assert_false(np.all(fp_scaling == dv_scaling))
 
 
+def test_header_dimension_labels():
+    hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
+    # check volume labels
+    vol_labels = hdr.get_dimension_labels()
+    assert_equal(list(vol_labels.keys()), ['dynamic scan number'])
+    assert_array_equal(vol_labels['dynamic scan number'], [1, 2, 3])
+    # check that output is ndarray rather than list
+    assert_true(isinstance(vol_labels['dynamic scan number'], np.ndarray))
+    # check case with individual slice labels
+    slice_vol_labels = hdr.get_dimension_labels(collapse_slices=False)
+    # verify that both expected keys are present
+    assert_true('slice number' in slice_vol_labels)
+    assert_true('dynamic scan number' in slice_vol_labels)
+    # verify shape of labels matches final dimensions of data
+    assert_equal(slice_vol_labels['slice number'].shape,
+                 hdr.get_data_shape()[2:])
+
+
 def test_orientation():
     hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
     assert_array_equal(HDR_DEFS['slice orientation'], 1)

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -192,13 +192,13 @@ def test_header_scaling():
 def test_header_dimension_labels():
     hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
     # check volume labels
-    vol_labels = hdr.get_dimension_labels()
+    vol_labels = hdr.get_volume_labels()
     assert_equal(list(vol_labels.keys()), ['dynamic scan number'])
     assert_array_equal(vol_labels['dynamic scan number'], [1, 2, 3])
     # check that output is ndarray rather than list
     assert_true(isinstance(vol_labels['dynamic scan number'], np.ndarray))
     # check case with individual slice labels
-    slice_vol_labels = hdr.get_dimension_labels(collapse_slices=False)
+    slice_vol_labels = hdr.get_volume_labels(collapse_slices=False)
     # verify that both expected keys are present
     assert_true('slice number' in slice_vol_labels)
     assert_true('dynamic scan number' in slice_vol_labels)
@@ -302,7 +302,7 @@ def test_sorting_dual_echo_T1():
     assert_equal(np.all(sorted_echos[n_half:] == 2), True)
 
     # check volume labels
-    vol_labels = t1_hdr.get_dimension_labels()
+    vol_labels = t1_hdr.get_volume_labels()
     assert_equal(list(vol_labels.keys()), ['echo number'])
     assert_array_equal(vol_labels['echo number'], [1, 2])
 
@@ -349,7 +349,7 @@ def test_sorting_multiple_echos_and_contrasts():
     assert_equal(np.all(sorted_types[3*ntotal//4:ntotal] == 3), True)
 
     # check volume labels
-    vol_labels = t1_hdr.get_dimension_labels()
+    vol_labels = t1_hdr.get_volume_labels()
     assert_equal(sorted(list(vol_labels.keys())),
                  ['echo number', 'image_type_mr'])
     assert_array_equal(vol_labels['echo number'], [1, 2, 3]*4)
@@ -398,7 +398,7 @@ def test_sorting_multiecho_ASL():
     assert_array_equal(sorted_slices[:nslices], np.arange(1, nslices+1))
 
     # check volume labels
-    vol_labels = asl_hdr.get_dimension_labels()
+    vol_labels = asl_hdr.get_volume_labels()
     assert_equal(sorted(list(vol_labels.keys())),
                  ['dynamic scan number', 'echo number', 'label type'])
     assert_array_equal(vol_labels['dynamic scan number'], [1]*6 + [2]*6)

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -681,6 +681,9 @@ class FakeHeader(object):
         n_slices = np.prod(self._shape[2:])
         return self._shape[:2] + (n_slices,)
 
+    def sorted_labels(self, sorted_indices, collapse_slices):
+        return np.arange(self._shape[-1])
+
 
 def test_parrec_proxy():
     # Test PAR / REC proxy class, including mmap flags


### PR DESCRIPTION
This was pulled out of the previously submitted #278 to make reviewing easier.  This complements the functionality in the recently merged #409.

The primary enhancement is a new method in the PARREC header called `get_dimension_labels` that lists which .PAR fields the data stored along the 4th dimension corresponds to.  (i.e. all data >4D is still collapsed into 4 dimensions exactly as before, but labels can be retrieved to make the data ordering unambiguous)

As a concrete example, consider the file `tests/data/T1_3echo_mag_real_imag_phase.PAR` which corresponds to a 3D scan acquired with 3 echos, but where 4 data types were also saved (real, imaginary, magnitude, phase).  In this case:
```python
t1_par = pjoin(DATA_PATH, 'T1_3echo_mag_real_imag_phase.PAR')
with open(t1_par, 'rt') as fobj:
    t1_hdr = PARRECHeader.from_fileobj(fobj, strict_sort=True)

# check volume labels
vol_labels = t1_hdr.get_dimension_labels()
print(vol_labels)
```
gives
```
 {'echo number': array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]),
 'image_type_mr': array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])}
```
which lets us know that the 4th dimension is a combination of echos and image types and that the echo number varies faster than image type along the 4th dimension.

The secondary enhancement is a new option to `parrec2nii` that prints out this arrays of labels as a JSON file (with suffix `.ordering.json`).  I would appreciate feedback on whether this is a reasonable choice of output format or if there is a better alternative.  Once that is decided, I can add a test case for it to `test_scripts.py`.