### PR TITLE
BF: a couple of tiny fixes

### DIFF
--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -95,7 +95,7 @@ from copy import deepcopy
 import re
 from io import StringIO
 from locale import getpreferredencoding
-from collections import OrderedDict
+from nibabel.externals import OrderedDict
 
 from .keywordonly import kw_only_meth
 from .spatialimages import SpatialHeader, SpatialImage

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -338,7 +338,7 @@ def test_parrec2nii_with_data():
         assert_true(exists('DTI.ordering.csv'))
         with open('DTI.ordering.csv', 'r') as csvfile:
             csvreader = csv.reader(csvfile, delimiter=',')
-            csv_keys = csvreader.__next__()  # header row
+            csv_keys = next(csvreader)  # header row
             nlines = 0  # count number of non-header rows
             for line in csvreader:
                 nlines += 1


### PR DESCRIPTION
Use externals version of OrderedDict for parrec.

Use ``next(something)`` instead of ``something.__next__``.