### PR TITLE
MAINT: switch to codecov for coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ before_install:
     - if [ "${COVERAGE}" == "1" ]; then
       pip install coverage;
       pip install coveralls;
+      pip install codecov;
       fi
 # command to install dependencies
 install:
@@ -135,7 +136,7 @@ script:
           fi
       fi
 after_success:
-    - if [ "${COVERAGE}" == "1" ]; then coveralls; fi
+    - if [ "${COVERAGE}" == "1" ]; then coveralls; codecov; fi
 
 notifications:
     webhooks: http://nipy.bic.berkeley.edu:54856/travis


### PR DESCRIPTION
Scipy, Pandas, scikit-image use codecov.

Example output (via travis-ci):
https://codecov.io/github/matthew-brett/nibabel/nibabel?ref=c576b5d459c12ae8e052bd21fd27f5faff336e46