### PR TITLE
MRG: change to get travis tests passing again.

### DIFF
--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -13,6 +13,9 @@ without error, and always defines:
 * dicom_test : test decorator that skips test if dicom not available.
 """
 
+# Module does (apparently) unused imports; stop flake8 complaining
+# flake8: noqa
+
 import numpy as np
 
 have_dicom = True

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -29,6 +29,8 @@ except ImportError:
 data_path = abspath(pjoin(dirname(__file__), '..', 'tests', 'data'))
 
 
+from .np_features import VIRAL_MEMMAP
+
 def assert_dt_equal(a, b):
     """ Assert two numpy dtype specifiers are equal
 

--- a/nibabel/testing/np_features.py
+++ b/nibabel/testing/np_features.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def _memmap_after_ufunc():
-    """ Return True if memmap arrays always return memmap from ufuncs
+    """ Return True if ufuncs on memmap arrays always return memmap arrays
 
     This should be True for numpy < 1.12, False otherwise.
     """
@@ -15,5 +15,5 @@ def _memmap_after_ufunc():
     return mm_preserved
 
 
-# True if ufunc on memmap retuns a memmap
+# True if ufunc on memmap always returns a memmap
 VIRAL_MEMMAP = _memmap_after_ufunc()

--- a/nibabel/testing/np_features.py
+++ b/nibabel/testing/np_features.py
@@ -1,0 +1,19 @@
+""" Look for changes in numpy behavior over versions
+"""
+
+import numpy as np
+
+
+def _memmap_after_ufunc():
+    """ Return True if memmap arrays always return memmap from ufuncs
+
+    This should be True for numpy < 1.12, False otherwise.
+    """
+    with open(__file__, 'rb') as fobj:
+        mm_arr = np.memmap(fobj, mode='r', shape=(10,), dtype=np.uint8)
+        mm_preserved = isinstance(mm_arr + 1, np.memmap)
+    return mm_preserved
+
+
+# True if ufunc on memmap retuns a memmap
+VIRAL_MEMMAP = _memmap_after_ufunc()

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -728,7 +728,9 @@ def test_parrec_proxy():
     # Test PAR / REC proxy class, including mmap flags
     shape = (10, 20, 30, 5)
     hdr = FakeHeader(shape, np.int32)
-    check_mmap(hdr, 0, PARRECArrayProxy, check_mode=False)
+    check_mmap(hdr, 0, PARRECArrayProxy,
+               has_scaling=True,
+               unscaled_is_view=False)
 
 
 class TestPARRECImage(tsi.MmapImageMixin):

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -735,8 +735,9 @@ class TestPARRECImage(tsi.MmapImageMixin):
     image_class = PARRECImage
     check_mmap_mode = False
 
-    def write_image(self):
-        return parrec.load(EG_PAR), EG_PAR
+    def get_disk_image(self):
+        # The example image does have image scaling to apply
+        return parrec.load(EG_PAR), EG_PAR, True
 
 
 def test_bitpix():

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -342,7 +342,7 @@ class MmapImageMixin(object):
     check_mmap_mode = True
 
     def get_disk_image(self):
-        """ Return an image and an image filname, and scaling bool to test against
+        """ Return image, image filename, and flag for required scaling
 
         Subclasses can do anything to return an image, including loading a
         pre-existing image from disk.
@@ -351,12 +351,10 @@ class MmapImageMixin(object):
         -------
         img : class:`SpatialImage` instance
         fname : str
-            Image filename
+            Image filename.
         has_scaling : bool
             True if the image array has scaling to apply to the raw image array
             data, False otherwise.
-
-        Notes
         """
         img_klass = self.image_class
         shape = (3, 4, 2)

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -340,8 +340,22 @@ class MmapImageMixin(object):
     #: whether to test mode of returned memory map
     check_mmap_mode = True
 
-    def write_image(self):
-        """ Return an image and an image filname to test against
+    def get_disk_image(self):
+        """ Return an image and an image filname, and scaling bool to test against
+
+        Subclasses can do anything to return an image, including loading a
+        pre-existing image from disk.
+
+        Returns
+        -------
+        img : class:`SpatialImage` instance
+        fname : str
+            Image filename
+        has_scaling : bool
+            True if the image array has scaling to apply to the raw image array
+            data, False otherwise.
+
+        Notes
         """
         img_klass = self.image_class
         shape = (3, 4, 2)
@@ -349,14 +363,13 @@ class MmapImageMixin(object):
         img = img_klass(data, None)
         fname = 'test' + img_klass.files_types[0][1]
         img.to_filename(fname)
-        return img, fname
+        return img, fname, False
 
     def test_load_mmap(self):
         # Test memory mapping when loading images
         img_klass = self.image_class
         with InTemporaryDirectory():
-            # This should have no scaling, can be mmapped
-            img, fname = self.write_image()
+            img, fname, has_scaling = self.get_disk_image()
             file_map = img.file_map.copy()
             for func, param1 in ((img_klass.from_filename, fname),
                                  (img_klass.load, fname),

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -24,7 +24,8 @@ from nose.tools import (assert_true, assert_false, assert_equal,
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from .test_helpers import bytesio_round_trip
-from ..testing import clear_and_catch_warnings, suppress_warnings
+from ..testing import (clear_and_catch_warnings, suppress_warnings,
+                       VIRAL_MEMMAP)
 from ..tmpdirs import InTemporaryDirectory
 from .. import load as top_load
 
@@ -384,6 +385,13 @@ class MmapImageMixin(object):
                         ('c', 'c'),
                         ('r', 'r'),
                         (False, None)):
+                    # If the image has scaling, then numpy 1.12 will not return
+                    # a memmap, regardless of the input flags.  Previous
+                    # numpies returned a memmap object, even though the array
+                    # has no mmap memory backing.  See:
+                    # https://github.com/numpy/numpy/pull/7406
+                    if has_scaling and not VIRAL_MEMMAP:
+                        expected_mode = None
                     kwargs = {}
                     if mmap is not None:
                         kwargs['mmap'] = mmap


### PR DESCRIPTION
Exclude shim module from flake8 tests.

Adapt to new numpy 1.12 memmap behavior.