### PR TITLE
TEST: Test oldest matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     # Absolute minimum dependencies plus oldest MPL
     - python: 2.7
       env:
-        - DEPENDS=numpy==1.5.1 matplotlib==1.3.1 PYDICOM=0
+        - DEPENDS="numpy==1.5.1 matplotlib==1.3.1" PYDICOM=0
     # Minimum pydicom dependency
     - python: 2.7
       env:


### PR DESCRIPTION
Noticed this while poking around at Travis. This is being [interpreted](https://travis-ci.org/nipy/nibabel/jobs/122325909#L225-L227) as

```ShellSession
$ export DEPENDS=numpy==1.5.1
$ export matplotlib==1.3.1
$ export PYDICOM=0
```

Fix to:

```ShellSession
$ export DEPENDS="numpy==1.5.1 matplotlib==1.3.1"
$ export PYDICOM=0
```