### PR TITLE
Error for file not found

### DIFF
--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -20,6 +20,7 @@ from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .py3k import FileNotFoundError
 
+
 def load(filename, **kwargs):
     ''' Load file given filename, guessing at file type
 

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -9,6 +9,7 @@
 # module imports
 """ Utilities to load and save image objects """
 
+import os.path as op
 import numpy as np
 import warnings
 
@@ -34,6 +35,8 @@ def load(filename, **kwargs):
     img : ``SpatialImage``
        Image of guessed type
     '''
+    if not op.exists(filename):
+        raise FileNotFoundError("No such file: '%s'" % filename)
     sniff = None
     for image_klass in all_image_classes:
         is_valid, sniff = image_klass.path_maybe_image(filename, sniff)

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -18,7 +18,7 @@ from .openers import ImageOpener
 from .filebasedimages import ImageFileError
 from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
-
+from .py3k import FileNotFoundError
 
 def load(filename, **kwargs):
     ''' Load file given filename, guessing at file type
@@ -36,7 +36,7 @@ def load(filename, **kwargs):
        Image of guessed type
     '''
     if not op.exists(filename):
-        raise IOError("No such file: '%s'" % filename)
+        raise FileNotFoundError("No such file: '%s'" % filename)
     sniff = None
     for image_klass in all_image_classes:
         is_valid, sniff = image_klass.path_maybe_image(filename, sniff)

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -36,7 +36,7 @@ def load(filename, **kwargs):
        Image of guessed type
     '''
     if not op.exists(filename):
-        raise FileNotFoundError("No such file: '%s'" % filename)
+        raise IOError("No such file: '%s'" % filename)
     sniff = None
     for image_klass in all_image_classes:
         is_valid, sniff = image_klass.path_maybe_image(filename, sniff)

--- a/nibabel/py3k.py
+++ b/nibabel/py3k.py
@@ -40,6 +40,7 @@ if sys.version_info[0] >= 3:
     strchar = 'U'
     ints2bytes = lambda seq: bytes(seq)
     ZEROB = bytes([0])
+    FileNotFoundError = FileNotFoundError
 else:
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
@@ -62,6 +63,8 @@ else:
     ints2bytes = lambda seq: ''.join(chr(i) for i in seq)
     ZEROB = chr(0)
 
+    class FileNotFoundError(IOError):
+        pass
 
 def getexception():
     return sys.exc_info()[1]

--- a/nibabel/py3k.py
+++ b/nibabel/py3k.py
@@ -63,6 +63,7 @@ else:
     ints2bytes = lambda seq: ''.join(chr(i) for i in seq)
     ZEROB = chr(0)
 
+
     class FileNotFoundError(IOError):
         pass
 

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -22,6 +22,7 @@ from numpy.testing import (assert_almost_equal,
 
 from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal, assert_not_equal)
+from ..py3k import FileNotFoundError
 
 data_path = pjoin(dirname(__file__), 'data')
 
@@ -54,7 +55,7 @@ def test_read_img_data():
 
 
 def test_file_not_found():
-    assert_raises(IOError, load, 'does_not_exist.nii.gz')
+    assert_raises(FileNotFoundError, load, 'does_not_exist.nii.gz')
 
 
 def test_read_img_data_nifti():

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -54,7 +54,7 @@ def test_read_img_data():
 
 
 def test_file_not_found():
-    assert_raises(FileNotFoundError, load, 'does_not_exist.nii.gz')
+    assert_raises(IOError, load, 'does_not_exist.nii.gz')
 
 
 def test_read_img_data_nifti():

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -53,6 +53,10 @@ def test_read_img_data():
             del img
 
 
+def test_file_not_found():
+    assert_raises(FileNotFoundError, load, 'does_not_exist.nii.gz')
+
+
 def test_read_img_data_nifti():
     shape = (2, 3, 4)
     data = np.random.normal(size=shape)


### PR DESCRIPTION
Currently, when a file doesn't exist (for example, if you typo'd the file-name), you get a relatively cryptic error: "couldn't work out file-type for file foo.nii.gz". I propose that we check if the file exists first, and raise an informative error up front if it doesn't exist.