### PR TITLE
FIX: Copy affine_to_rasmm when slicing a Tractogram object

### DIFF
--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -374,7 +374,7 @@ class TestTractogram(unittest.TestCase):
                          DATA['tractogram'].data_per_streamline[::-1],
                          DATA['tractogram'].data_per_point[::-1])
 
-        # Make sure slicing conserve the affine_to_rasmm property.
+        # Make sure slicing conserves the affine_to_rasmm property.
         tractogram = DATA['tractogram'].copy()
         tractogram.affine_to_rasmm = DATA['rng'].rand(4, 4)
         tractogram_view = tractogram[::2]

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -18,6 +18,7 @@ DATA = {}
 
 def setup():
     global DATA
+    DATA['rng'] = np.random.RandomState(1234)
     DATA['streamlines'] = [np.arange(1*3, dtype="f4").reshape((1, 3)),
                            np.arange(2*3, dtype="f4").reshape((2, 3)),
                            np.arange(5*3, dtype="f4").reshape((5, 3))]
@@ -372,6 +373,13 @@ class TestTractogram(unittest.TestCase):
                          DATA['streamlines'][::-1],
                          DATA['tractogram'].data_per_streamline[::-1],
                          DATA['tractogram'].data_per_point[::-1])
+
+        # Make sure slicing conserve the affine_to_rasmm property.
+        tractogram = DATA['tractogram'].copy()
+        tractogram.affine_to_rasmm = DATA['rng'].rand(4, 4)
+        tractogram_view = tractogram[::2]
+        assert_array_equal(tractogram_view.affine_to_rasmm,
+                           tractogram.affine_to_rasmm)
 
     def test_tractogram_add_new_data(self):
         # Tractogram with only streamlines

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -335,7 +335,8 @@ class Tractogram(object):
         if isinstance(idx, (numbers.Integral, np.integer)):
             return TractogramItem(pts, data_per_streamline, data_per_point)
 
-        return Tractogram(pts, data_per_streamline, data_per_point)
+        return Tractogram(pts, data_per_streamline, data_per_point,
+                          affine_to_rasmm=self.affine_to_rasmm)
 
     def __len__(self):
         return len(self.streamlines)


### PR DESCRIPTION
This PR simply makes sure to set the `affine_to_rasmm` when creating a new `Tractogram` object that is the result of advanced indexing or slicing. It also adds a test to check it is working properly.