### PR TITLE
MRG: check for MINC using processing routines

### DIFF
--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -105,6 +105,13 @@ ext_map = ExtMapRecoder((
     ('par', '.par'),
 ))
 
+# Image classes known to require spatial axes to be first in index ordering.
+# When adding an image class, consider whether the new class should be listed
+# here.
+KNOWN_SPATIAL_FIRST = (Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
+                       Spm2AnalyzeImage, Spm99AnalyzeImage, AnalyzeImage,
+                       MGHImage, PARRECImage)
+
 
 def spatial_axes_first(img):
     """ True if spatial image axes for `img` always preceed other axes
@@ -122,4 +129,4 @@ def spatial_axes_first(img):
     """
     if len(img.shape) < 4:
         return True
-    return not isinstance(img, Minc1Image)
+    return type(img) in KNOWN_SPATIAL_FIRST

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -104,3 +104,22 @@ ext_map = ExtMapRecoder((
     ('mgz', '.mgz'),
     ('par', '.par'),
 ))
+
+
+def spatial_axes_first(img):
+    """ True if spatial image axes for `img` always preceed other axes
+
+    Parameters
+    ----------
+    img : object
+        Image object implementing at least ``shape`` attribute.
+
+    Returns
+    -------
+    spatial_axes_first : bool
+        True if image only has spatial axes (number of axes < 4) or image type
+        known to have spatial axes preceeding other axes.
+    """
+    if len(img.shape) < 4:
+        return True
+    return not isinstance(img, Minc1Image)

--- a/nibabel/tests/test_imageclasses.py
+++ b/nibabel/tests/test_imageclasses.py
@@ -1,0 +1,48 @@
+""" Testing imageclasses module
+"""
+
+from os.path import dirname, join as pjoin
+
+import numpy as np
+
+from nibabel.optpkg import optional_package
+
+import nibabel as nib
+from nibabel.analyze import AnalyzeImage
+from nibabel.nifti1 import Nifti1Image
+from nibabel.nifti2 import Nifti2Image
+
+from nibabel.imageclasses import spatial_axes_first
+
+from nose.tools import (assert_true, assert_false)
+
+DATA_DIR = pjoin(dirname(__file__), 'data')
+
+have_h5py = optional_package('h5py')[1]
+
+MINC_3DS = ('minc1_1_scale.mnc',)
+MINC_4DS = ('minc1_4d.mnc',)
+if have_h5py:
+    MINC_3DS = MINC_3DS + ('minc2_1_scale.mnc',)
+    MINC_4DS = MINC_4DS + ('minc2_4d.mnc',)
+
+
+def test_spatial_axes_first():
+    # Function tests is spatial axes are first three axes in image
+    # Always True for Nifti and friends
+    affine = np.eye(4)
+    for shape in ((2, 3), (4, 3, 2), (5, 4, 1, 2), (2, 3, 5, 2, 1)):
+        for img_class in (AnalyzeImage, Nifti1Image, Nifti2Image):
+            data = np.zeros(shape)
+            img = img_class(data, affine)
+            assert_true(spatial_axes_first(img))
+    # True for MINC images < 4D
+    for fname in MINC_3DS:
+        img = nib.load(pjoin(DATA_DIR, fname))
+        assert_true(len(img.shape) == 3)
+        assert_true(spatial_axes_first(img))
+    # False for MINC images < 4D
+    for fname in MINC_4DS:
+        img = nib.load(pjoin(DATA_DIR, fname))
+        assert_true(len(img.shape) == 4)
+        assert_false(spatial_axes_first(img))


### PR DESCRIPTION
The processing routines assume that image have spatial axes before time etc
axes, but this may well not be true for MINC images.

Barf on MINC images > 3D for now.  Later maybe we can investigate the image
axis names to work out which axes are spatial.