### PR TITLE
RF/ENH: remove file prior writing in to_filename

### DIFF
--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -8,6 +8,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 ''' Common interface for any image format--volume or surface, binary or xml.'''
 
+import os
 import warnings
 
 from .externals.six import string_types
@@ -347,7 +348,15 @@ class FileBasedImage(object):
         -------
         None
         '''
-        self.file_map = self.filespec_to_file_map(filename)
+        self.file_map = file_map = self.filespec_to_file_map(filename)
+        for _, fh in file_map.items():
+            if not isinstance(fh, FileHolder):
+                continue
+            if os.path.exists(fh.filename):
+                # Remove previous file where new file would be saved
+                # Necessary e.g. for cases where file is a symlink pointing
+                # to some non-writable file (e.g. under git annex control)
+                os.unlink(fh.filename)
         self.to_file_map()
 
     def to_filespec(self, filename):


### PR DESCRIPTION
Closes #465 

Disclaimer: I am still not sure if that is the most kosher behavior. PR is primarily to test the idea, e.g. if it breaks any tests.

May be such behaviour could be controlled/enabled by some configuration/environment setting (e.g. `NIBABEL_REMOVE_BEFORE_WRITE=1`) so in those cases when it is clearly necessary we could at least easily enable it.