### PR TITLE
RF+TST: restore GiftiDataArray num_dim setter

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -369,6 +369,17 @@ class GiftiDataArray(xml.XmlSerializable):
     def num_dim(self):
         return len(self.dims)
 
+    # Setter for backwards compatibility with pymvpa
+    @num_dim.setter
+    def num_dim(self, value):
+        warnings.warn(
+            "num_dim will be read-only in future versions of nibabel",
+            DeprecationWarning, stacklevel=2)
+        if value != len(self.dims):
+            raise ValueError('num_dim value {0} != number of dimensions '
+                             'len(self.dims) {1}'
+                             .format(value, len(self.dims)))
+
     @classmethod
     def from_array(klass,
                    darray,

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -182,6 +182,19 @@ def test_to_xml_open_close_deprecations():
         assert_equal(len(w), 1)
 
 
+def test_num_dim_deprecation():
+    da = GiftiDataArray(np.ones((2, 3, 4)))
+    # num_dim is property, set automatically from len(da.dims)
+    assert_equal(da.num_dim, 3)
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+        # OK setting num_dim to correct value, but raises DeprecationWarning
+        da.num_dim = 3
+        assert_equal(len(w), 1)
+        # Any other value gives a ValueError
+        assert_raises(ValueError, setattr, da, 'num_dim', 4)
+
+
 def test_labeltable():
     img = GiftiImage()
     assert_equal(len(img.labeltable.labels), 0)


### PR DESCRIPTION
We removed the `GiftiDataArray.num_dim` attribute in favor of a
property, but pymvpa was expecting to be able to set the value.  Add a
setter that raises a ValueError if the value is incorrect, and gives a
deprecation warning regardless.