### PR TITLE
BF: fix recursion error on Python 3.3

### DIFF
--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -728,6 +728,10 @@ class TrkFile(TractogramFile):
         vars['property_names'] = "\n  ".join([asstr(s)
                                               for s in vars['property_name']
                                               if len(s) > 0])
+        # Make all byte strings into strings
+        # Fixes recursion error on Python 3.3
+        vars = dict((k, asstr(v) if hasattr(v, 'decode') else v)
+                    for k, v in vars.items())
         return """\
 MAGIC NUMBER: {MAGIC_NUMBER}
 v.{version}


### PR DESCRIPTION
Python 3.3 seems to get upset with filling format string values from
byte strings.  See:
http://nipy.bic.berkeley.edu/builders/nibabel-py3.3/builds/240/steps/shell_5/logs/stdio

Fixed by this change - see ``try_branch.py`` run at:

http://nipy.bic.berkeley.edu/builders/nibabel-py3.3/builds/248/steps/shell_5/logs/stdio