### PR TITLE
MRG: add routine to deprecate with from/to versions

### DIFF
--- a/nibabel/arraywriters.py
+++ b/nibabel/arraywriters.py
@@ -194,7 +194,9 @@ class ArrayWriter(object):
             raise WriterError('Deprecated `nan2zero` argument to `to_fileobj` '
                               'must be same as class value set in __init__')
         warnings.warn('Please remove `nan2zero` from call to ' '`to_fileobj` '
-                      'and use in instance __init__ instead',
+                      'and use in instance __init__ instead.\n'
+                      '* deprecated in version: 2.0\n'
+                      '* will raise error in version: 4.0\n',
                       DeprecationWarning, stacklevel=3)
 
     def _needs_nan2zero(self):

--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -1,7 +1,10 @@
-""" Module to help with deprecating classes and modules
+""" Module to help with deprecating objects and classes
 """
 
 import warnings
+
+from .deprecator import Deprecator
+from .info import cmp_pkg_version
 
 
 class ModuleProxy(object):
@@ -63,3 +66,18 @@ class FutureWarningMixin(object):
                       FutureWarning,
                       stacklevel=2)
         super(FutureWarningMixin, self).__init__(*args, **kwargs)
+
+
+class VisibleDeprecationWarning(UserWarning):
+    """ Deprecation warning that will be shown by default
+
+    Python >= 2.7 does not show standard DeprecationWarnings by default:
+
+    http://docs.python.org/dev/whatsnew/2.7.html#the-future-for-python-2-x
+
+    Use this class for cases where we do want to show deprecations by default.
+    """
+    pass
+
+
+deprecate_with_version = Deprecator(cmp_pkg_version)

--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -1,0 +1,168 @@
+""" Class for recording and reporting deprecations
+"""
+
+import functools
+import warnings
+import re
+
+_LEADING_WHITE = re.compile('^(\s*)')
+
+
+class ExpiredDeprecationError(RuntimeError):
+    """ Error for expired deprecation
+
+    Error raised when a called function or method has passed out of its
+    deprecation period.
+    """
+    pass
+
+
+def _ensure_cr(text):
+    """ Remove trailing whitespace and add carriage return
+
+    Ensures that `text` always ends with a carriage return
+    """
+    return text.rstrip() + '\n'
+
+
+def _add_dep_doc(old_doc, dep_doc):
+    """ Add deprecation message `dep_doc` to docstring in `old_doc`
+
+    Parameters
+    ----------
+    old_doc : str
+        Docstring from some object.
+    dep_doc : str
+        Deprecation warning to add to top of docstring, after initial line.
+
+    Returns
+    -------
+    new_doc : str
+        `old_doc` with `dep_doc` inserted after any first lines of docstring.
+    """
+    dep_doc = _ensure_cr(dep_doc)
+    if not old_doc:
+        return dep_doc
+    old_doc = _ensure_cr(old_doc)
+    old_lines = old_doc.splitlines()
+    new_lines = []
+    for line_no, line in enumerate(old_lines):
+        if line.strip():
+            new_lines.append(line)
+        else:
+            break
+    next_line = line_no + 1
+    if next_line >= len(old_lines):
+        # nothing following first paragraph, just append message
+        return old_doc + '\n' + dep_doc
+    indent = _LEADING_WHITE.match(old_lines[next_line]).group()
+    dep_lines = [indent + L for L in [''] + dep_doc.splitlines() + ['']]
+    return '\n'.join(new_lines + dep_lines + old_lines[next_line:]) + '\n'
+
+
+class Deprecator(object):
+    """ Class to make decorator marking function or method as deprecated
+
+    The decorated function / method will:
+
+    * Raise the given `warning_class` warning when the function / method gets
+      called, up to (and including) version `until` (if specified);
+    * Raise the given `error_class` error when the function / method gets
+      called, when the package version is greater than version `until` (if
+      specified).
+
+    Parameters
+    ----------
+    version_comparator : callable
+        Callable accepting string as argument, and return 1 if string
+        represents a higher version than encoded in the `version_comparator`, 0
+        if the version is equal, and -1 if the version is lower.  For example,
+        the `version_comparator` may compare the input version string to the
+        current package version string.
+    warn_class : class, optional
+        Class of warning to generate for deprecation.
+    error_class : class, optional
+        Class of error to generate when `version_comparator` returns 1 for a
+        given argument of ``until`` in the ``__call__`` method (see below).
+    """
+
+    def __init__(self,
+                 version_comparator,
+                 warn_class=DeprecationWarning,
+                 error_class=ExpiredDeprecationError):
+        self.version_comparator = version_comparator
+        self.warn_class = warn_class
+        self.error_class = error_class
+
+    def is_bad_version(self, version_str):
+        """ Return True if `version_str` is too high
+
+        Tests `version_str` with ``self.version_comparator``
+
+        Parameters
+        ----------
+        version_str : str
+            String giving version to test
+
+        Returns
+        -------
+        is_bad : bool
+            True if `version_str` is for version below that expected by
+            ``self.version_comparator``, False otherwise.
+        """
+        return self.version_comparator(version_str) == -1
+
+    def __call__(self, message, since='', until='',
+                 warn_class=None, error_class=None):
+        """ Return decorator function function for deprecation warning / error
+
+        Parameters
+        ----------
+        message : str
+            Message explaining deprecation, giving possible alternatives.
+        since : str, optional
+            Released version at which object was first deprecated.
+        until : str, optional
+            Last released version at which this function will still raise a
+            deprecation warning.  Versions higher than this will raise an
+            error.
+        warn_class : None or class, optional
+            Class of warning to generate for deprecation (overrides instance
+            default).
+        error_class : None or class, optional
+            Class of error to generate when `version_comparator` returns 1 for a
+            given argument of ``until`` (overrides class default).
+
+        Returns
+        -------
+        deprecator : func
+            Function returning a decorator.
+        """
+        warn_class = warn_class if warn_class else self.warn_class
+        error_class = error_class if error_class else self.error_class
+        messages = [message]
+        if (since, until) != ('', ''):
+            messages.append('')
+        if since:
+            messages.append('* deprecated from version: ' + since)
+        if until:
+            messages.append('* {} {} as of version: {}'.format(
+                "Raises" if self.is_bad_version(until) else "Will raise",
+                error_class,
+                until))
+        message = '\n'.join(messages)
+
+        def deprecator(func):
+
+            @functools.wraps(func)
+            def deprecated_func(*args, **kwargs):
+                if until and self.is_bad_version(until):
+                    raise error_class(message)
+                warnings.warn(message, warn_class, stacklevel=2)
+                return func(*args, **kwargs)
+
+            deprecated_func.__doc__ = _add_dep_doc(deprecated_func.__doc__,
+                                                   message)
+            return deprecated_func
+
+        return deprecator

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -53,6 +53,7 @@ from .spatialimages import SpatialImage
 from .arraywriters import make_array_writer
 from .wrapstruct import WrapStruct
 from .fileslice import canonical_slicers, predict_shape, slice2outax
+from .deprecated import deprecate_with_version
 
 BLOCK_SIZE = 512
 
@@ -846,6 +847,10 @@ class EcatImage(SpatialImage):
         return self._subheader
 
     @classmethod
+    @deprecate_with_version('from_filespec class method is deprecated.\n'
+                            'Please use the ``from_file_map`` class method '
+                            'instead.',
+                            '2.1', '4.0')
     def from_filespec(klass, filespec):
         return klass.from_filename(filespec)
 

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -269,14 +269,6 @@ class FileBasedImage(object):
         return klass.from_file_map(file_map)
 
     @classmethod
-    def from_filespec(klass, filespec):
-        warnings.warn('``from_filespec`` class method is deprecated\n'
-                      'Please use the ``from_filename`` class method '
-                      'instead',
-                      DeprecationWarning, stacklevel=2)
-        klass.from_filename(filespec)
-
-    @classmethod
     def from_file_map(klass, file_map):
         raise NotImplementedError
 

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -8,13 +8,12 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 ''' Common interface for any image format--volume or surface, binary or xml.'''
 
-import warnings
-
 from .externals.six import string_types
 from .fileholders import FileHolder
 from .filename_parser import (types_filenames, TypesFilenamesError,
                               splitext_addext)
 from .openers import ImageOpener
+from .deprecated import deprecate_with_version
 
 
 class ImageFileError(Exception):
@@ -212,16 +211,13 @@ class FileBasedImage(object):
         '''
         raise TypeError("Cannot slice image objects.")
 
+    @deprecate_with_version('get_header method is deprecated.\n'
+                            'Please use the ``img.header`` property '
+                            'instead.',
+                            '2.1', '4.0')
     def get_header(self):
         """ Get header from image
-
-        Please use the `header` property instead of `get_header`; we will
-        deprecate this method in future versions of nibabel.
         """
-        warnings.warn('``get_header`` is deprecated.\n'
-                      'Please use the ``img.header`` property '
-                      'instead',
-                      DeprecationWarning, stacklevel=2)
         return self.header
 
     def get_filename(self):
@@ -273,11 +269,11 @@ class FileBasedImage(object):
         raise NotImplementedError
 
     @classmethod
+    @deprecate_with_version('from_files class method is deprecated.\n'
+                            'Please use the ``from_file_map`` class method '
+                            'instead.',
+                            '1.0', '3.0')
     def from_files(klass, file_map):
-        warnings.warn('``from_files`` class method is deprecated\n'
-                      'Please use the ``from_file_map`` class method '
-                      'instead',
-                      DeprecationWarning, stacklevel=2)
         return klass.from_file_map(file_map)
 
     @classmethod
@@ -318,11 +314,11 @@ class FileBasedImage(object):
         return file_map
 
     @classmethod
+    @deprecate_with_version('filespec_to_files class method is deprecated.\n'
+                            'Please use the "filespec_to_file_map" class '
+                            'method instead.',
+                            '1.0', '3.0')
     def filespec_to_files(klass, filespec):
-        warnings.warn('``filespec_to_files`` class method is deprecated\n'
-                      'Please use the ``filespec_to_file_map`` class method '
-                      'instead',
-                      DeprecationWarning, stacklevel=2)
         return klass.filespec_to_file_map(filespec)
 
     def to_filename(self, filename):
@@ -342,20 +338,19 @@ class FileBasedImage(object):
         self.file_map = self.filespec_to_file_map(filename)
         self.to_file_map()
 
+    @deprecate_with_version('to_filespec method is deprecated.\n'
+                            'Please use the "to_filename" method instead.',
+                            '1.0', '3.0')
     def to_filespec(self, filename):
-        warnings.warn('``to_filespec`` is deprecated, please '
-                      'use ``to_filename`` instead',
-                      DeprecationWarning, stacklevel=2)
         self.to_filename(filename)
 
     def to_file_map(self, file_map=None):
         raise NotImplementedError
 
+    @deprecate_with_version('to_files method is deprecated.\n'
+                            'Please use the "to_file_map" method instead.',
+                            '1.0', '3.0')
     def to_files(self, file_map=None):
-        warnings.warn('``to_files`` method is deprecated\n'
-                      'Please use the ``to_file_map`` method '
-                      'instead',
-                      DeprecationWarning, stacklevel=2)
         self.to_file_map(file_map)
 
     @classmethod

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -14,7 +14,6 @@ from http://www.nitrc.org/projects/gifti/
 from __future__ import division, print_function, absolute_import
 
 import sys
-import warnings
 
 import numpy as np
 
@@ -23,6 +22,7 @@ from ..filebasedimages import FileBasedImage
 from ..nifti1 import data_type_codes, xform_codes, intent_codes
 from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes, KIND2FMT)
+from ..deprecated import deprecate_with_version
 
 # {en,de}codestring in deprecated in Python3, but
 # {en,de}codebytes not available in Python2.
@@ -47,7 +47,10 @@ class GiftiMetaData(xml.XmlSerializable):
             meda.data.append(nv)
         return meda
 
-    @np.deprecate_with_doc("Use the metadata property instead.")
+    @deprecate_with_version(
+        'get_metadata method deprecated. '
+        "Use the metadata property instead."
+        '2.1', '4.0')
     def get_metadata(self):
         return self.metadata
 
@@ -156,7 +159,10 @@ class GiftiLabel(xml.XmlSerializable):
         self.blue = blue
         self.alpha = alpha
 
-    @np.deprecate_with_doc("Use the rgba property instead.")
+    @deprecate_with_version(
+        'get_rgba method deprecated. '
+        "Use the rgba property instead."
+        '2.1', '4.0')
     def get_rgba(self):
         return self.rgba
 
@@ -249,7 +255,9 @@ class GiftiCoordSystem(xml.XmlSerializable):
         print('Affine Transformation Matrix: \n', self.xform)
 
 
-@np.deprecate_with_doc("This is an internal API that will be discontinued.")
+@deprecate_with_version(
+    "data_tag is an internal API that will be discontinued.",
+    '2.1', '4.0')
 def data_tag(dataarray, encoding, datatype, ordering):
     class DataTag(xml.XmlSerializable):
 
@@ -371,16 +379,20 @@ class GiftiDataArray(xml.XmlSerializable):
 
     # Setter for backwards compatibility with pymvpa
     @num_dim.setter
+    @deprecate_with_version(
+        "num_dim will be read-only in future versions of nibabel",
+        '2.1', '4.0')
     def num_dim(self, value):
-        warnings.warn(
-            "num_dim will be read-only in future versions of nibabel",
-            DeprecationWarning, stacklevel=2)
         if value != len(self.dims):
             raise ValueError('num_dim value {0} != number of dimensions '
                              'len(self.dims) {1}'
                              .format(value, len(self.dims)))
 
     @classmethod
+    @deprecate_with_version(
+        'from_array method is deprecated. '
+        'Please use GiftiDataArray constructor instead.',
+        '2.1', '4.0')
     def from_array(klass,
                    darray,
                    intent="NIFTI_INTENT_NONE",
@@ -419,10 +431,6 @@ class GiftiDataArray(xml.XmlSerializable):
         -------
         da : instance of our own class
         """
-        warnings.warn(
-            "Please use GiftiDataArray constructor instead of from_array "
-            "class method",
-            DeprecationWarning, stacklevel=2)
         return klass(data=darray,
                      intent=intent,
                      datatype=datatype,
@@ -463,7 +471,10 @@ class GiftiDataArray(xml.XmlSerializable):
 
         return data_array
 
-    @np.deprecate_with_doc("Use the to_xml() function instead.")
+    @deprecate_with_version(
+        'to_xml_open method deprecated. '
+        'Use the to_xml() function instead.',
+        '2.1', '4.0')
     def to_xml_open(self):
         out = """<DataArray Intent="%s"
 \tDataType="%s"
@@ -487,7 +498,10 @@ class GiftiDataArray(xml.XmlSerializable):
                       self.ext_offset,
                       )
 
-    @np.deprecate_with_doc("Use the to_xml() function instead.")
+    @deprecate_with_version(
+        'to_xml_close method deprecated. '
+        'Use the to_xml() function instead.',
+        '2.1', '4.0')
     def to_xml_close(self):
         return "</DataArray>\n"
 
@@ -507,7 +521,10 @@ class GiftiDataArray(xml.XmlSerializable):
             print('Coordinate System:')
             print(self.coordsys.print_summary())
 
-    @np.deprecate_with_doc("Use the metadata property instead.")
+    @deprecate_with_version(
+        'get_metadata method deprecated. '
+        "Use the metadata property instead."
+        '2.1', '4.0')
     def get_metadata(self):
         return self.meta.metadata
 
@@ -591,11 +608,17 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
             raise TypeError("Not a valid GiftiLabelTable instance")
         self._labeltable = labeltable
 
-    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    @deprecate_with_version(
+        'set_labeltable method deprecated. '
+        "Use the gifti_img.labeltable property instead.",
+        '2.1', '4.0')
     def set_labeltable(self, labeltable):
         self.labeltable = labeltable
 
-    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    @deprecate_with_version(
+        'get_labeltable method deprecated. '
+        "Use the gifti_img.labeltable property instead.",
+        '2.1', '4.0')
     def get_labeltable(self):
         return self.labeltable
 
@@ -615,11 +638,17 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
             raise TypeError("Not a valid GiftiMetaData instance")
         self._meta = meta
 
-    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    @deprecate_with_version(
+        'set_meta method deprecated. '
+        "Use the gifti_img.meta property instead.",
+        '2.1', '4.0')
     def set_metadata(self, meta):
         self.meta = meta
 
-    @np.deprecate_with_doc("Use the gifti_img.labeltable property instead.")
+    @deprecate_with_version(
+        'get_meta method deprecated. '
+        "Use the gifti_img.meta property instead.",
+        '2.1', '4.0')
     def get_meta(self):
         return self.meta
 
@@ -651,7 +680,10 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         it = intent_codes.code[intent]
         return [x for x in self.darrays if x.intent == it]
 
-    @np.deprecate_with_doc("Use get_arrays_from_intent instead.")
+    @deprecate_with_version(
+        'getArraysFromIntent method deprecated. '
+        "Use get_arrays_from_intent instead.",
+        '2.1', '4.0')
     def getArraysFromIntent(self, intent):
         return self.get_arrays_from_intent(intent)
 

--- a/nibabel/gifti/giftiio.py
+++ b/nibabel/gifti/giftiio.py
@@ -10,10 +10,12 @@
 # Stephan Gerhard, Oktober 2010
 ##############
 
-import numpy as np
+from ..deprecated import deprecate_with_version
 
 
-@np.deprecate_with_doc("Use nibabel.load() instead.")
+@deprecate_with_version('giftiio.read function deprecated. '
+                        "Use nibabel.load() instead.",
+                        '2.1', '4.0')
 def read(filename):
     """ Load a Gifti image from a file
 
@@ -31,7 +33,9 @@ def read(filename):
     return load(filename)
 
 
-@np.deprecate_with_doc("Use nibabel.save() instead.")
+@deprecate_with_version('giftiio.write function deprecated. '
+                        "Use nibabel.load() instead.",
+                        '2.1', '4.0')
 def write(image, filename):
     """ Save the current image to a new file
 

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -24,6 +24,7 @@ from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes)
 from ..nifti1 import data_type_codes, xform_codes, intent_codes
 from ..xmlutils import XmlParser
+from ..deprecated import deprecate_with_version
 
 
 class GiftiParseError(ExpatError):
@@ -342,7 +343,9 @@ class GiftiImageParser(XmlParser):
 
 class Outputter(GiftiImageParser):
 
-    @np.deprecate_with_doc("Use GiftiImageParser instead.")
+    @deprecate_with_version('Outputter class deprecated. '
+                            "Use GiftiImageParser instead.",
+                            '2.1', '4.0')
     def __init__(self):
         super(Outputter, self).__init__()
 
@@ -351,6 +354,8 @@ class Outputter(GiftiImageParser):
         self.__init__()
 
 
-@np.deprecate_with_doc("Use GiftiImageParser.parse() instead.")
+@deprecate_with_version('parse_gifti_file deprecated. '
+                        "Use GiftiImageParser.parse() instead.",
+                        '2.1', '4.0')
 def parse_gifti_file(fname=None, fptr=None, buffer_size=None):
     GiftiImageParser(buffer_size=buffer_size).parse(fname=fname, fptr=fptr)

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -206,17 +206,29 @@ def test_labeltable():
     img.labeltable = new_table
     assert_equal(len(img.labeltable.labels), 2)
 
+    # Test deprecations
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+        newer_table = GiftiLabelTable()
+        newer_table.labels += ['test', 'me', 'again']
+        img.set_labeltable(newer_table)
+        assert_equal(len(w), 1)
+        assert_equal(len(img.get_labeltable().labels), 3)
+        assert_equal(len(w), 2)
+
 
 def test_metadata():
     nvpair = GiftiNVPairs('key', 'value')
-    da = GiftiMetaData(nvpair=nvpair)
-    assert_equal(da.data[0].name, 'key')
-    assert_equal(da.data[0].value, 'value')
+    md = GiftiMetaData(nvpair=nvpair)
+    assert_equal(md.data[0].name, 'key')
+    assert_equal(md.data[0].value, 'value')
     # Test deprecation
     with clear_and_catch_warnings() as w:
         warnings.filterwarnings('always', category=DeprecationWarning)
-        assert_equal(len(GiftiDataArray().get_metadata()), 0)
+        assert_equal(md.get_metadata(), dict(key='value'))
         assert_equal(len(w), 1)
+        assert_equal(len(GiftiDataArray().get_metadata()), 0)
+        assert_equal(len(w), 2)
 
 
 def test_gifti_label_rgba():

--- a/nibabel/gifti/tests/test_giftiio.py
+++ b/nibabel/gifti/tests/test_giftiio.py
@@ -11,7 +11,8 @@ import warnings
 
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_raises)
-from ...testing import clear_and_catch_warnings
+from nibabel.testing import clear_and_catch_warnings
+from nibabel.tmpdirs import InTemporaryDirectory
 
 
 from .test_parse_gifti_fast import (DATA_FILE1, DATA_FILE2, DATA_FILE3,
@@ -29,7 +30,10 @@ class TestGiftiIO(object):
 def test_read_deprecated():
     with clear_and_catch_warnings() as w:
         warnings.simplefilter('always', DeprecationWarning)
-        from nibabel.gifti.giftiio import read
+        from nibabel.gifti.giftiio import read, write
 
-        read(DATA_FILE1)
+        img = read(DATA_FILE1)
         assert_equal(len(w), 1)
+        with InTemporaryDirectory():
+            write(img, 'test.gii')
+        assert_equal(len(w), 2)

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -7,7 +7,6 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 ''' Define supported image classes and names '''
-import warnings
 
 from .analyze import AnalyzeImage
 from .freesurfer import MGHImage
@@ -20,6 +19,7 @@ from .parrec import PARRECImage
 from .spm99analyze import Spm99AnalyzeImage
 from .spm2analyze import Spm2AnalyzeImage
 from .volumeutils import Recoder
+from .deprecated import deprecate_with_version
 
 from .optpkg import optional_package
 _, have_scipy, _ = optional_package('scipy')
@@ -35,9 +35,9 @@ all_image_classes = [Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
 # DEPRECATED: mapping of names to classes and class functionality
 class ClassMapDict(dict):
 
+    @deprecate_with_version('class_map is deprecated.',
+                            '2.1', '4.0')
     def __getitem__(self, *args, **kwargs):
-        warnings.warn("class_map is deprecated.", DeprecationWarning,
-                      stacklevel=2)
         return super(ClassMapDict, self).__getitem__(*args, **kwargs)
 
 class_map = ClassMapDict(
@@ -90,9 +90,9 @@ class_map = ClassMapDict(
 
 class ExtMapRecoder(Recoder):
 
+    @deprecate_with_version('ext_map is deprecated.',
+                            '2.1', '4.0')
     def __getitem__(self, *args, **kwargs):
-        warnings.warn("ext_map is deprecated.", DeprecationWarning,
-                      stacklevel=2)
         return super(ExtMapRecoder, self).__getitem__(*args, **kwargs)
 
 # mapping of extensions to default image class names

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -1,12 +1,21 @@
-""" This file contains defines parameters for nibabel that we use to fill
-settings in setup.py, the nibabel top-level docstring, and for building the
-docs.  In setup.py in particular, we exec this file, so it cannot import
-nibabel
+""" Define distrubution parameters for nibabel, including package version
+
+This file contains defines parameters for nibabel that we use to fill settings
+in setup.py, the nibabel top-level docstring, and for building the docs.  In
+setup.py in particular, we exec this file, so it cannot import nibabel.
 """
 
+import re
+from distutils.version import StrictVersion
+
 # nibabel version information.  An empty _version_extra corresponds to a
-# full release.  '.dev' as a _version_extra string means this is a development
-# version
+# full release.  *Any string* in `_version_extra` labels the version as
+# pre-release.  So, if `_version_extra` is not empty, the version is taken to
+# be earlier than the same version where `_version_extra` is empty (see
+# `cmp_pkg_version` below).
+#
+# We usually use `dev` as `_version_extra` to label this as a development
+# (pre-release) version.
 _version_major = 2
 _version_minor = 1
 _version_micro = 0
@@ -18,6 +27,62 @@ __version__ = "%s.%s.%s%s" % (_version_major,
                               _version_minor,
                               _version_micro,
                               _version_extra)
+
+
+def _parse_version(version_str):
+    """ Parse version string `version_str` in our format
+    """
+    match = re.match('([0-9.]*\d)(.*)', version_str)
+    if match is None:
+        raise ValueError('Invalid version ' + version_str)
+    return match.groups()
+
+
+def _cmp(a, b):
+    """ Implementation of ``cmp`` for Python 3
+    """
+    return (a > b) - (a < b)
+
+
+def cmp_pkg_version(version_str, pkg_version_str=__version__):
+    """ Compare `version_str` to current package version
+
+    To be valid, a version must have a numerical major version followed by a
+    dot, followed by a numerical minor version.  It may optionally be followed
+    by a dot and a numerical micro version, and / or by an "extra" string.
+    *Any* extra string labels the version as pre-release, so `1.2.0somestring`
+    compares as prior to (pre-release for) `1.2.0`, where `somestring` can be
+    any string.
+
+    Parameters
+    ----------
+    version_str : str
+        Version string to compare to current package version
+    pkg_version_str : str, optional
+        Version of our package.  Optional, set fom ``__version__`` by default.
+
+    Returns
+    -------
+    version_cmp : int
+        1 if `version_str` is a later version than `pkg_version_str`, 0 if
+        same, -1 if earlier.
+
+    Examples
+    --------
+    >>> cmp_pkg_version('1.2.1', '1.2.0')
+    1
+    >>> cmp_pkg_version('1.2.0dev', '1.2.0')
+    -1
+    """
+    version, extra = _parse_version(version_str)
+    pkg_version, pkg_extra = _parse_version(pkg_version_str)
+    if version != pkg_version:
+        return _cmp(StrictVersion(version), StrictVersion(pkg_version))
+    return (0 if extra == pkg_extra
+            else 1 if extra == ''
+            else -1 if pkg_extra == ''
+            else _cmp(extra, pkg_extra))
+
 
 CLASSIFIERS = ["Development Status :: 4 - Beta",
                "Environment :: Console",

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -131,12 +131,11 @@ def save(img, filename):
 def read_img_data(img, prefer='scaled'):
     """ Read data from image associated with files
 
-    We've deprecated this function and will remove it soon. If you want
-    unscaled data, please use ``img.dataobj.get_unscaled()`` instead.  If you
-    want scaled data, use ``img.get_data()`` (which will cache the loaded
-    array) or ``np.array(img.dataobj)`` (which won't cache the array). If you
-    want to load the data as for a modified header, save the image with the
-    modified header, and reload.
+    If you want unscaled data, please use ``img.dataobj.get_unscaled()``
+    instead.  If you want scaled data, use ``img.get_data()`` (which will cache
+    the loaded array) or ``np.array(img.dataobj)`` (which won't cache the
+    array). If you want to load the data as for a modified header, save the
+    image with the modified header, and reload.
 
     Parameters
     ----------

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -11,7 +11,6 @@
 
 import os.path as op
 import numpy as np
-import warnings
 
 from .filename_parser import splitext_addext
 from .openers import ImageOpener
@@ -19,6 +18,7 @@ from .filebasedimages import ImageFileError
 from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .py3k import FileNotFoundError
+from .deprecated import deprecate_with_version
 
 
 def load(filename, **kwargs):
@@ -48,7 +48,9 @@ def load(filename, **kwargs):
                          filename)
 
 
-@np.deprecate
+@deprecate_with_version('guessed_image_type deprecated.'
+                        '2.1',
+                        '4.0')
 def guessed_image_type(filename):
     """ Guess image type from file `filename`
 
@@ -62,8 +64,6 @@ def guessed_image_type(filename):
     image_class : class
         Class corresponding to guessed image type
     """
-    warnings.warn('guessed_image_type is deprecated', DeprecationWarning,
-                  stacklevel=2)
     sniff = None
     for image_klass in all_image_classes:
         is_valid, sniff = image_klass.path_maybe_image(filename, sniff)
@@ -124,8 +124,10 @@ def save(img, filename):
     converted.to_filename(filename)
 
 
-@np.deprecate_with_doc('Please use ``img.dataobj.get_unscaled()`` '
-                       'instead')
+@deprecate_with_version('read_img_data deprecated.'
+                        'Please use ``img.dataobj.get_unscaled()`` instead.'
+                        '2.0.1',
+                        '4.0')
 def read_img_data(img, prefer='scaled'):
     """ Read data from image associated with files
 
@@ -210,7 +212,9 @@ def read_img_data(img, prefer='scaled'):
         return hdr.raw_data_from_fileobj(fileobj)
 
 
-@np.deprecate
+@deprecate_with_version('which_analyze_type deprecated.'
+                        '2.1',
+                        '4.0')
 def which_analyze_type(binaryblock):
     """ Is `binaryblock` from NIfTI1, NIfTI2 or Analyze header?
 
@@ -238,8 +242,6 @@ def which_analyze_type(binaryblock):
     * if ``sizeof_hdr`` is 348 or byteswapped 348 assume Analyze
     * Return None
     """
-    warnings.warn('which_analyze_type is deprecated', DeprecationWarning,
-                  stacklevel=2)
     from .nifti1 import header_dtype
     hdr_struct = np.ndarray(shape=(), dtype=header_dtype, buffer=binaryblock)
     bs_hdr_struct = hdr_struct.byteswap()

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -13,6 +13,8 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 import numpy.linalg as npl
 
+from .deprecated import deprecate_with_version
+
 
 class OrientationError(Exception):
     pass
@@ -228,7 +230,10 @@ def inv_ornt_aff(ornt, shape):
     return np.dot(undo_flip, undo_reorder)
 
 
-@np.deprecate_with_doc("Please use inv_ornt_aff instead")
+@deprecate_with_version('orientation_affine deprecated. '
+                        'Please use inv_ornt_aff instead'
+                        '1.3',
+                        '3.0')
 def orientation_affine(ornt, shape):
     return inv_ornt_aff(ornt, shape)
 

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -139,6 +139,7 @@ from .affines import from_matvec, dot_reduce, apply_affine
 from .nifti1 import unit_codes
 from .fileslice import fileslice, strided_scalar
 from .openers import ImageOpener
+from .deprecated import deprecate_with_version
 
 # PSL to RAS affine
 PSL_TO_RAS = np.array([[0, 0, -1, 0],  # L -> R
@@ -822,23 +823,21 @@ class PARRECHeader(SpatialHeader):
                               'not suppported.'.format(name, props))
         return props[0]
 
+    @deprecate_with_version('get_voxel_size deprecated. '
+                            'Please use "get_zooms" instead.',
+                            '2.0', '4.0')
     def get_voxel_size(self):
         """Returns the spatial extent of a voxel.
 
         Does not include the slice gap in the slice extent.
 
-        This function is deprecated and we will remove it in future versions of
-        nibabel.  Please use ``get_zooms`` instead.  If you need the slice
-        thickness not including the slice gap, use ``self.image_defs['slice
-        thickness']``.
+        If you need the slice thickness not including the slice gap, use
+        ``self.image_defs['slice thickness']``.
 
         Returns
         -------
         vox_size: shape (3,) ndarray
         """
-        warnings.warn('Please use "get_zooms" instead of "get_voxel_size"',
-                      DeprecationWarning,
-                      stacklevel=2)
         # slice orientation for the whole image series
         slice_thickness = self._get_unique_image_prop('slice thickness')
         voxsize_inplane = self._get_unique_image_prop('pixel spacing')

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -627,11 +627,12 @@ class SpatialImage(FileBasedImage):
     def set_data_dtype(self, dtype):
         self._header.set_data_dtype(dtype)
 
+    @deprecate_with_version('get_affine method is deprecated.\n'
+                            'Please use the ``img.affine`` property '
+                            'instead.',
+                            '2.1', '4.0')
     def get_affine(self):
         """ Get affine from image
-
-        Please use the `affine` property instead of `get_affine`; we will
-        deprecate this method in future versions of nibabel.
         """
         return self.affine
 

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -133,14 +133,13 @@ work:
 
 '''
 
-import warnings
-
 import numpy as np
 
 from .filebasedimages import FileBasedHeader, FileBasedImage
 from .filebasedimages import ImageFileError  # flake8: noqa; for back-compat
 from .viewers import OrthoSlicer3D
 from .volumeutils import shape_zoom_affine
+from .deprecated import deprecate_with_version
 
 
 class HeaderDataError(Exception):
@@ -308,9 +307,11 @@ def supported_np_types(obj):
 class Header(SpatialHeader):
     '''Alias for SpatialHeader; kept for backwards compatibility.'''
 
+    @deprecate_with_version('Header class is deprecated.\n'
+                            'Please use SpatialHeader instead.'
+                            'instead.',
+                            '2.1', '4.0')
     def __init__(self, *args, **kwargs):
-        warnings.warn('Header is deprecated, use SpatialHeader',
-                      DeprecationWarning, stacklevel=2)
         super(Header, self).__init__(*args, **kwargs)
 
 
@@ -373,11 +374,10 @@ class SpatialImage(FileBasedImage):
         self._data_cache = None
 
     @property
+    @deprecate_with_version('_data attribute not part of public API. '
+                            'please use "dataobj" property instead.',
+                            '2.0', '4.0')
     def _data(self):
-        warnings.warn('Please use ``dataobj`` instead of ``_data``; '
-                      'We will remove this wrapper for ``_data`` soon',
-                      FutureWarning,
-                      stacklevel=2)
         return self._dataobj
 
     @property
@@ -612,14 +612,13 @@ class SpatialImage(FileBasedImage):
     def shape(self):
         return self._dataobj.shape
 
+    @deprecate_with_version('get_shape method is deprecated.\n'
+                            'Please use the ``img.shape`` property '
+                            'instead.',
+                            '1.2', '3.0')
     def get_shape(self):
         """ Return shape for image
-
-        This function deprecated; please use the ``shape`` property instead
         """
-        warnings.warn('Please use the shape property instead of get_shape',
-                      DeprecationWarning,
-                      stacklevel=2)
         return self.shape
 
     def get_data_dtype(self):

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -66,3 +66,18 @@ class TestNibabelDeprecator(_TestDF):
     """ Test deprecations against nibabel version """
 
     dep_func = deprecate_with_version
+
+
+def test_dev_version():
+    # Test that a dev version doesn't trigger deprecation error
+
+    @deprecate_with_version('foo', until='2.0')
+    def func():
+        return 99
+
+    try:
+        info.cmp_pkg_version.__defaults__ = ('2.0dev',)
+        # No error, even though version is dev version of current
+        assert_equal(func(), 99)
+    finally:
+        info.cmp_pkg_version.__defaults__ = ('2.0',)

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -3,10 +3,23 @@
 
 import warnings
 
-from nose.tools import (assert_true, assert_false, assert_raises,
-                        assert_equal, assert_not_equal)
+from nibabel import info
+from nibabel.deprecated import (ModuleProxy, FutureWarningMixin,
+                                deprecate_with_version)
 
-from ..deprecated import ModuleProxy, FutureWarningMixin
+from nose.tools import (assert_true, assert_equal)
+
+from nibabel.tests.test_deprecator import TestDeprecatorFunc as _TestDF
+
+
+def setup():
+    # Hack nibabel version string
+    info.cmp_pkg_version.__defaults__ = ('2.0',)
+
+
+def teardown():
+    # Hack nibabel version string back again
+    info.cmp_pkg_version.__defaults__ = (info.__version__,)
 
 
 def test_module_proxy():
@@ -47,3 +60,9 @@ def test_futurewarning_mixin():
         warn = warns.pop(0)
         assert_equal(warn.category, FutureWarning)
         assert_equal(str(warn.message), 'Oh no, not this one')
+
+
+class TestNibabelDeprecator(_TestDF):
+    """ Test deprecations against nibabel version """
+
+    dep_func = deprecate_with_version

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -1,0 +1,168 @@
+""" Testing deprecator module / Deprecator class
+"""
+
+import sys
+import warnings
+from functools import partial
+
+from nose.tools import (assert_true, assert_raises, assert_equal)
+
+from nibabel.deprecator import (_ensure_cr, _add_dep_doc,
+                                ExpiredDeprecationError, Deprecator)
+
+from ..testing import clear_and_catch_warnings
+
+_OWN_MODULE = sys.modules[__name__]
+
+
+def test__ensure_cr():
+    # Make sure text ends with carriage return
+    assert_equal(_ensure_cr('  foo'), '  foo\n')
+    assert_equal(_ensure_cr('  foo\n'), '  foo\n')
+    assert_equal(_ensure_cr('  foo  '), '  foo\n')
+    assert_equal(_ensure_cr('foo  '), 'foo\n')
+    assert_equal(_ensure_cr('foo  \n bar'), 'foo  \n bar\n')
+    assert_equal(_ensure_cr('foo  \n\n'), 'foo\n')
+
+
+def test__add_dep_doc():
+    # Test utility function to add deprecation message to docstring
+    assert_equal(_add_dep_doc('', 'foo'), 'foo\n')
+    assert_equal(_add_dep_doc('bar', 'foo'), 'bar\n\nfoo\n')
+    assert_equal(_add_dep_doc('   bar', 'foo'), '   bar\n\nfoo\n')
+    assert_equal(_add_dep_doc('   bar', 'foo\n'), '   bar\n\nfoo\n')
+    assert_equal(_add_dep_doc('bar\n\n', 'foo'), 'bar\n\nfoo\n')
+    assert_equal(_add_dep_doc('bar\n    \n', 'foo'), 'bar\n\nfoo\n')
+    assert_equal(_add_dep_doc(' bar\n\nSome explanation', 'foo\nbaz'),
+                 ' bar\n\nfoo\nbaz\n\nSome explanation\n')
+    assert_equal(_add_dep_doc(' bar\n\n  Some explanation', 'foo\nbaz'),
+                 ' bar\n  \n  foo\n  baz\n  \n  Some explanation\n')
+
+
+class CustomError(Exception):
+    """ Custom error class for testing expired deprecation errors """
+
+
+def cmp_func(v):
+    """ Comparison func tests against version 2.0 """
+    return (float(v) > 2) - (float(v) < 2)
+
+
+def func_no_doc():
+    pass
+
+
+def func_doc(i):
+    "A docstring"
+
+
+def func_doc_long(i, j):
+    "A docstring\n\n   Some text"
+
+
+class TestDeprecatorFunc(object):
+    """ Test deprecator function specified in ``dep_func`` """
+
+    dep_func = Deprecator(cmp_func)
+
+    def test_dep_func(self):
+        # Test function deprecation
+        dec = self.dep_func
+        func = dec('foo')(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+            assert_true(w[0].category is DeprecationWarning)
+        assert_equal(func.__doc__, 'foo\n')
+        func = dec('foo')(func_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(1), None)
+            assert_equal(len(w), 1)
+        assert_equal(func.__doc__, 'A docstring\n\nfoo\n')
+        func = dec('foo')(func_doc_long)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(1, 2), None)
+            assert_equal(len(w), 1)
+        assert_equal(func.__doc__, 'A docstring\n   \n   foo\n   \n   Some text\n')
+
+        # Try some since and until versions
+        func = dec('foo', '1.1')(func_no_doc)
+        assert_equal(func.__doc__, 'foo\n\n* deprecated from version: 1.1\n')
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+        func = dec('foo', until='2.4')(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+        assert_equal(func.__doc__,
+                    'foo\n\n* Will raise {} as of version: 2.4\n'
+                    .format(ExpiredDeprecationError))
+        func = dec('foo', until='1.8')(func_no_doc)
+        assert_raises(ExpiredDeprecationError, func)
+        assert_equal(func.__doc__,
+                    'foo\n\n* Raises {} as of version: 1.8\n'
+                    .format(ExpiredDeprecationError))
+        func = dec('foo', '1.2', '1.8')(func_no_doc)
+        assert_raises(ExpiredDeprecationError, func)
+        assert_equal(func.__doc__,
+                    'foo\n\n* deprecated from version: 1.2\n'
+                    '* Raises {} as of version: 1.8\n'
+                    .format(ExpiredDeprecationError))
+        func = dec('foo', '1.2', '1.8')(func_doc_long)
+        assert_equal(func.__doc__,
+                    'A docstring\n   \n   foo\n   \n'
+                    '   * deprecated from version: 1.2\n'
+                    '   * Raises {} as of version: 1.8\n   \n'
+                    '   Some text\n'
+                    .format(ExpiredDeprecationError))
+        assert_raises(ExpiredDeprecationError, func)
+
+        # Check different warnings and errors
+        func = dec('foo', warn_class=UserWarning)(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+            assert_true(w[0].category is UserWarning)
+
+        func = dec('foo', error_class=CustomError)(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+            assert_true(w[0].category is DeprecationWarning)
+
+        func = dec('foo', until='1.8', error_class=CustomError)(func_no_doc)
+        assert_raises(CustomError, func)
+
+
+class TestDeprecatorMaker(object):
+    """ Test deprecator class creation with custom warnings and errors """
+
+    dep_maker = partial(Deprecator, cmp_func)
+
+    def test_deprecator_maker(self):
+        dec = self.dep_maker(warn_class=UserWarning)
+        func = dec('foo')(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+            assert_true(w[0].category is UserWarning)
+
+        dec = self.dep_maker(error_class=CustomError)
+        func = dec('foo')(func_no_doc)
+        with clear_and_catch_warnings(modules=[_OWN_MODULE]) as w:
+            warnings.simplefilter('always')
+            assert_equal(func(), None)
+            assert_equal(len(w), 1)
+            assert_true(w[0].category is DeprecationWarning)
+
+        func = dec('foo', until='1.8')(func_no_doc)
+        assert_raises(CustomError, func)

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -9,6 +9,7 @@
 from __future__ import division, print_function, absolute_import
 
 import os
+import warnings
 
 import numpy as np
 
@@ -21,7 +22,7 @@ from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from ..testing import data_path, suppress_warnings
+from ..testing import data_path, suppress_warnings, clear_and_catch_warnings
 from ..tmpdirs import InTemporaryDirectory
 
 from .test_wrapstruct import _TestWrapStructBase
@@ -261,7 +262,20 @@ class TestEcatImage(TestCase):
         assert_equal(data.min(), vals['min'])
         assert_array_almost_equal(data.mean(), vals['mean'])
 
-    def test_mlist_regreesion(self):
+    def test_mlist_regression(self):
         # Test mlist is as same as for nibabel 1.3.0
         assert_array_equal(self.img.get_mlist(),
                            [[16842758, 3, 3011, 1]])
+
+
+def test_from_filespec_deprecation():
+    # Check from_filespec raises Deprecation
+    with clear_and_catch_warnings() as w:
+        warnings.simplefilter('always', DeprecationWarning)
+        # No warning for standard load
+        img_loaded = EcatImage.load(ecat_file)
+        assert_equal(len(w), 0)
+        # Warning for from_filespec
+        img_speced = EcatImage.from_filespec(ecat_file)
+        assert_equal(len(w), 1)
+        assert_array_equal(img_loaded.get_data(), img_speced.get_data())

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -153,6 +153,14 @@ class GenericImageAPI(ValidateAPI):
         # Read only
         assert_raises(AttributeError, setattr, img, 'shape', np.eye(4))
 
+    def validate_shape_deprecated(self, imaker, params):
+        # Check deprecated get_shape API
+        with clear_and_catch_warnings() as w:
+            warnings.simplefilter('always', DeprecationWarning)
+            img = imaker()
+            assert_equal(img.get_shape(), params['shape'])
+            assert_equal(len(w), 1)
+
     def validate_dtype(self, imaker, params):
         # data / storage dtype
         img = imaker()
@@ -246,7 +254,7 @@ class GenericImageAPI(ValidateAPI):
         with warnings.catch_warnings(record=True) as warns:
             warnings.simplefilter("always")
             assert_data_similar(img._data, params)
-            assert_equal(warns.pop(0).category, FutureWarning)
+            assert_equal(warns.pop(0).category, DeprecationWarning)
         # Check setting _data raises error
         fake_data = np.zeros(img.shape).astype(img.get_data_dtype())
         assert_raises(AttributeError, setattr, img, '_data', fake_data)

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -113,11 +113,14 @@ class GenericImageAPI(ValidateAPI):
     def validate_affine_deprecated(self, imaker, params):
         # Check deprecated affine API
         img = imaker()
-        assert_almost_equal(img.get_affine(), params['affine'], 6)
-        assert_equal(img.get_affine().dtype, np.float64)
-        aff = img.get_affine()
-        aff[0, 0] = 1.5
-        assert_true(aff is img.get_affine())
+        with clear_and_catch_warnings() as w:
+            warnings.simplefilter('always', DeprecationWarning)
+            assert_almost_equal(img.get_affine(), params['affine'], 6)
+            assert_equal(len(w), 1)
+            assert_equal(img.get_affine().dtype, np.float64)
+            aff = img.get_affine()
+            aff[0, 0] = 1.5
+            assert_true(aff is img.get_affine())
 
     def validate_header(self, imaker, params):
         # Check header API
@@ -134,9 +137,9 @@ class GenericImageAPI(ValidateAPI):
 
     def validate_header_deprecated(self, imaker, params):
         # Check deprecated header API
+        img = imaker()
         with clear_and_catch_warnings() as w:
             warnings.simplefilter('always', DeprecationWarning)
-            img = imaker()
             hdr = img.get_header()
             assert_equal(len(w), 1)
             assert_true(hdr is img.header)

--- a/nibabel/tests/test_imageclasses.py
+++ b/nibabel/tests/test_imageclasses.py
@@ -2,6 +2,7 @@
 """
 
 from os.path import dirname, join as pjoin
+import warnings
 
 import numpy as np
 
@@ -12,9 +13,13 @@ from nibabel.analyze import AnalyzeImage
 from nibabel.nifti1 import Nifti1Image
 from nibabel.nifti2 import Nifti2Image
 
-from nibabel.imageclasses import spatial_axes_first
+from nibabel import imageclasses
+from nibabel.imageclasses import spatial_axes_first, class_map, ext_map
 
-from nose.tools import (assert_true, assert_false)
+from nose.tools import (assert_true, assert_false, assert_equal)
+
+from nibabel.testing import clear_and_catch_warnings
+
 
 DATA_DIR = pjoin(dirname(__file__), 'data')
 
@@ -46,3 +51,15 @@ def test_spatial_axes_first():
         img = nib.load(pjoin(DATA_DIR, fname))
         assert_true(len(img.shape) == 4)
         assert_false(spatial_axes_first(img))
+
+
+def test_deprecations():
+    with clear_and_catch_warnings(modules=[imageclasses]) as w:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+        nifti_single = class_map['nifti_single']
+        assert_equal(nifti_single['class'], Nifti1Image)
+        assert_equal(len(w), 1)
+        nifti_ext = ext_map['.nii']
+        assert_equal(nifti_ext, 'nifti_single')
+        assert_equal(len(w), 2)
+

--- a/nibabel/tests/test_info.py
+++ b/nibabel/tests/test_info.py
@@ -1,0 +1,47 @@
+""" Testing info module
+"""
+
+import nibabel as nib
+from nibabel import info
+from nibabel.info import cmp_pkg_version
+
+from nose.tools import (assert_raises, assert_equal)
+
+
+def test_version():
+    # Test info version is the same as our own version
+    assert_equal(info.__version__, nib.__version__)
+
+
+def test_cmp_pkg_version():
+    # Test version comparator
+    assert_equal(cmp_pkg_version(info.__version__), 0)
+    assert_equal(cmp_pkg_version('0.0'), -1)
+    assert_equal(cmp_pkg_version('1000.1000.1'), 1)
+    assert_equal(cmp_pkg_version(info.__version__, info.__version__), 0)
+    for test_ver, pkg_ver, exp_out in (('1.0', '1.0', 0),
+                                       ('1.0.0', '1.0', 0),
+                                       ('1.0', '1.0.0', 0),
+                                       ('1.1', '1.1', 0),
+                                       ('1.2', '1.1', 1),
+                                       ('1.1', '1.2', -1),
+                                       ('1.1.1', '1.1.1', 0),
+                                       ('1.1.2', '1.1.1', 1),
+                                       ('1.1.1', '1.1.2', -1),
+                                       ('1.1', '1.1dev', 1),
+                                       ('1.1dev', '1.1', -1),
+                                       ('1.2.1', '1.2.1rc1', 1),
+                                       ('1.2.1rc1', '1.2.1', -1),
+                                       ('1.2.1rc1', '1.2.1rc', 1),
+                                       ('1.2.1rc', '1.2.1rc1', -1),
+                                       ('1.2.1rc1', '1.2.1rc', 1),
+                                       ('1.2.1rc', '1.2.1rc1', -1),
+                                       ('1.2.1b', '1.2.1a', 1),
+                                       ('1.2.1a', '1.2.1b', -1),
+                                      ):
+        assert_equal(cmp_pkg_version(test_ver, pkg_ver), exp_out)
+    assert_raises(ValueError, cmp_pkg_version, 'foo.2')
+    assert_raises(ValueError, cmp_pkg_version, 'foo.2', '1.0')
+    assert_raises(ValueError, cmp_pkg_version, '1.0', 'foo.2')
+    assert_raises(ValueError, cmp_pkg_version, '1')
+    assert_raises(ValueError, cmp_pkg_version, 'foo')

--- a/nibabel/tests/test_utils.py
+++ b/nibabel/tests/test_utils.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from ..tmpdirs import InTemporaryDirectory
 from ..openers import ImageOpener
+from .. import volumeutils
 from ..volumeutils import (array_from_file,
                            _is_compressed_fobj,
                            array_to_file,
@@ -54,7 +55,7 @@ from numpy.testing import (assert_array_almost_equal,
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 from ..testing import (assert_dt_equal, assert_allclose_safely,
-                       suppress_warnings)
+                       suppress_warnings, clear_and_catch_warnings)
 
 #: convenience variables for numpy types
 FLOAT_TYPES = np.sctypes['float']
@@ -1033,10 +1034,12 @@ def test_fname_ext_ul_case():
 def test_allopen():
     # This import into volumeutils is for compatibility.  The code is the
     # ``openers`` module.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with clear_and_catch_warnings() as w:
+        warnings.filterwarnings('once', category=DeprecationWarning)
         # Test default mode is 'rb'
         fobj = allopen(__file__)
+        # Check we got the deprecation warning
+        assert_equal(len(w), 1)
         assert_equal(fobj.mode, 'rb')
         # That we can set it
         fobj = allopen(__file__, 'r')

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -1552,11 +1552,10 @@ class BinOpener(Opener):
     """ Deprecated class that used to handle .mgz through specialized logic."""
     __doc__ = Opener.__doc__
 
+    @deprecate_with_version('BinOpener class deprecated. '
+                            "Please use Opener class instead."
+                            '2.1', '4.0')
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "Please use %s class instead of %s" % (Opener.__class__.__name__,
-                                                   self.__class__.__name__),
-            DeprecationWarning, stacklevel=2)
         return super(BinOpener, self).__init__(*args, **kwargs)
 
 
@@ -1592,17 +1591,17 @@ def fname_ext_ul_case(fname):
     return fname
 
 
+@deprecate_with_version('allopen is deprecated. '
+                        'Please use "Opener" class instead.',
+                        '2.0', '4.0')
 def allopen(fileish, *args, **kwargs):
     """ Compatibility wrapper for old ``allopen`` function
 
     Wraps creation of ``Opener`` instance, while picking up module global
     ``default_compresslevel``.
 
-    Please see docstring for ``Opener`` for details.
+    Please see docstring of ``Opener`` for details.
     """
-    warnings.warn("Please use Opener class instead of this function",
-                  DeprecationWarning,
-                  stacklevel=2)
 
     class MyOpener(Opener):
         default_compresslevel = default_compresslevel

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from .casting import (shared_range, type_info, OK_FLOATS)
 from .openers import Opener
+from .deprecated import deprecate_with_version
 
 sys_is_le = sys.byteorder == 'little'
 native_code = sys_is_le and '<' or '>'
@@ -373,7 +374,10 @@ def make_dt_codes(codes_seqs):
     return Recoder(dt_codes, fields + ['dtype', 'sw_dtype'], DtypeMapper)
 
 
-@np.deprecate_with_doc('Please use arraywriter classes instead')
+@deprecate_with_version('can_cast deprecated. '
+                        'Please use arraywriter classes instead',
+                        '1.2',
+                        '3.0')
 def can_cast(in_type, out_type, has_intercept=False, has_slope=False):
     ''' Return True if we can safely cast ``in_type`` to ``out_type``
 
@@ -1007,7 +1011,10 @@ def working_type(in_type, slope=1.0, inter=0.0):
     return val.dtype.type
 
 
-@np.deprecate_with_doc('Please use arraywriter classes instead')
+@deprecate_with_version('calculate_scale deprecated. '
+                        'Please use arraywriter classes instead',
+                        '1.2',
+                        '3.0')
 def calculate_scale(data, out_dtype, allow_intercept):
     ''' Calculate scaling and optional intercept for data
 
@@ -1052,7 +1059,10 @@ def calculate_scale(data, out_dtype, allow_intercept):
     return get_slope_inter(writer) + (mn, mx)
 
 
-@np.deprecate_with_doc('Please use arraywriter classes instead')
+@deprecate_with_version('scale_min_max deprecated. Please use arraywriter '
+                        'classes instead.',
+                        '1.2',
+                        '3.0')
 def scale_min_max(mn, mx, out_type, allow_intercept):
     ''' Return scaling and intercept min, max of data, given output type
 


### PR DESCRIPTION
Add deprecation routine that allows you to specify at which version
deprecation began, and at which version deprecation will raise an error.