### PR TITLE
RF+API: add qform, sform code 1 for parrec2nii

### DIFF
--- a/nibabel/parrec2nii_cmd.py
+++ b/nibabel/parrec2nii_cmd.py
@@ -221,7 +221,8 @@ def proc_file(infile, opts):
     nhdr = nimg.header
     nhdr.set_data_dtype(out_dtype)
     nhdr.set_slope_inter(slope, intercept)
-    nhdr.set_qform(affine, code=2)
+    nhdr.set_sform(affine, code=1)
+    nhdr.set_qform(affine, code=1)
 
     if 'parse' in opts.minmax:
         # need to get the scaled data

--- a/nibabel/tests/test_parrec2nii.py
+++ b/nibabel/tests/test_parrec2nii.py
@@ -1,6 +1,5 @@
 """ Tests for the parrec2nii exe code
 """
-import imp
 from os.path import join, isfile, basename
 
 import numpy
@@ -9,7 +8,7 @@ from numpy import array as npa
 import nibabel
 from nibabel import parrec2nii_cmd as parrec2nii
 
-from mock import Mock, MagicMock
+from mock import Mock, MagicMock, patch
 from nose.tools import assert_true
 from numpy.testing import (assert_almost_equal, assert_array_equal)
 
@@ -30,26 +29,21 @@ PAR_AFFINE = numpy.array(
  [   0.        ,    0.  ,          0.        ,    1.        ]])
 
 
-def teardown():
-    # Reload tested module to clear run-time settings in tests
-    imp.reload(parrec2nii)
-
-
-def test_parrec2nii_sets_qform_sform_code1():
-    # Unit test that ensures that set_qform() is called on the new header.
-    imp.reload(parrec2nii)
+@patch('nibabel.parrec2nii_cmd.verbose')
+@patch('nibabel.parrec2nii_cmd.io_orientation')
+@patch('nibabel.parrec2nii_cmd.nifti1')
+@patch('nibabel.parrec2nii_cmd.pr')
+def test_parrec2nii_sets_qform_sform_code1(*args):
+    # Check that set_sform(), set_qform() are called on the new header.
     parrec2nii.verbose.switch = False
 
-    parrec2nii.io_orientation = Mock()
-    parrec2nii.io_orientation.return_value = [[0, 1],[1, 1],[2, 1]] # LAS+ 
+    parrec2nii.io_orientation.return_value = [[0, 1],[1, 1],[2, 1]] # LAS+
 
-    parrec2nii.nifti1 = Mock()
     nimg = Mock()
     nhdr = MagicMock()
     nimg.header = nhdr
     parrec2nii.nifti1.Nifti1Image.return_value = nimg
 
-    parrec2nii.pr = Mock()
     pr_img = Mock()
     pr_hdr = Mock()
     pr_hdr.get_data_scaling.return_value = (npa([]), npa([]))
@@ -73,11 +67,11 @@ def test_parrec2nii_sets_qform_sform_code1():
     nhdr.set_sform.assert_called_with(AN_OLD_AFFINE, code=1)
 
 
-def test_parrec2nii_save_load_qform_code():
+@patch('nibabel.parrec2nii_cmd.verbose')
+def test_parrec2nii_save_load_qform_code(*args):
     # Tests that after parrec2nii saves file, it has the sform and qform 'code'
     # set to '1', which means 'scanner', so that other software, e.g. FSL picks
     # up the qform.
-    imp.reload(parrec2nii)
     parrec2nii.verbose.switch = False
 
     opts = Mock()

--- a/nibabel/tests/test_parrec2nii.py
+++ b/nibabel/tests/test_parrec2nii.py
@@ -35,9 +35,8 @@ def teardown():
     imp.reload(parrec2nii)
 
 
-def test_parrec2nii_sets_qform_with_code2():
-    """Unit test that ensures that set_qform() is called on the new header.
-    """
+def test_parrec2nii_sets_qform_sform_code1():
+    # Unit test that ensures that set_qform() is called on the new header.
     imp.reload(parrec2nii)
     parrec2nii.verbose.switch = False
 
@@ -75,10 +74,9 @@ def test_parrec2nii_sets_qform_with_code2():
 
 
 def test_parrec2nii_save_load_qform_code():
-    """Tests that after parrec2nii saves file, it has the qform 'code'
-    set to '2', which means 'aligned', so that other software, e.g. FSL
-    picks up the qform.
-    """
+    # Tests that after parrec2nii saves file, it has the sform and qform 'code'
+    # set to '1', which means 'scanner', so that other software, e.g. FSL picks
+    # up the qform.
     imp.reload(parrec2nii)
     parrec2nii.verbose.switch = False
 

--- a/nibabel/tests/test_parrec2nii.py
+++ b/nibabel/tests/test_parrec2nii.py
@@ -70,7 +70,8 @@ def test_parrec2nii_sets_qform_with_code2():
 
     infile = 'nonexistent.PAR'
     parrec2nii.proc_file(infile, opts)
-    nhdr.set_qform.assert_called_with(pr_hdr.get_affine(), code=2)
+    nhdr.set_qform.assert_called_with(AN_OLD_AFFINE, code=1)
+    nhdr.set_sform.assert_called_with(AN_OLD_AFFINE, code=1)
 
 
 def test_parrec2nii_save_load_qform_code():
@@ -98,6 +99,6 @@ def test_parrec2nii_save_load_qform_code():
             outfname = join(pth, basename(fname)).replace('.PAR', '.nii')
             assert_true(isfile(outfname))
             img = nibabel.load(outfname)
-            assert_almost_equal(img.get_affine(), PAR_AFFINE, 4)
-            assert_array_equal(img.header['qform_code'], 2)
-            assert_array_equal(img.header['sform_code'], 2)
+            assert_almost_equal(img.affine, PAR_AFFINE, 4)
+            assert_array_equal(img.header['qform_code'], 1)
+            assert_array_equal(img.header['sform_code'], 1)


### PR DESCRIPTION
As discussed in https://github.com/nipy/nibabel/pull/478