### PR TITLE
RF+TST: allow dtype specifiers as fileslice input

### DIFF
--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -719,17 +719,19 @@ def fileslice(fileobj, sliceobj, shape, dtype, offset=0, order='C',
     Parameters
     ----------
     fileobj : file-like object
-        binary file-like object. Implements ``read`` and ``seek``
+        file-like object, opened for reading in binary mode. Implements
+        ``read`` and ``seek``.
     sliceobj : object
-        something that can be used to slice an array as in ``arr[sliceobj]``
+        something that can be used to slice an array as in ``arr[sliceobj]``.
     shape : sequence
-        shape of full array inside `fileobj`
-    dtype : dtype object
-        dtype of array inside `fileobj`
+        shape of full array inside `fileobj`.
+    dtype : dtype specifier
+        dtype of array inside `fileobj`, or input to ``numpy.dtype`` to specify
+        array dtype.
     offset : int, optional
         offset of array data within `fileobj`
     order : {'C', 'F'}, optional
-        memory layout of array in `fileobj`
+        memory layout of array in `fileobj`.
     heuristic : callable, optional
         function taking slice object, axis length, stride length as arguments,
         returning one of 'full', 'contiguous', None.  See
@@ -743,7 +745,8 @@ def fileslice(fileobj, sliceobj, shape, dtype, offset=0, order='C',
     """
     if is_fancy(sliceobj):
         raise ValueError("Cannot handle fancy indexing")
-    itemsize = dtype.itemsize
+    dtype = np.dtype(dtype)
+    itemsize = int(dtype.itemsize)
     segments, sliced_shape, post_slicers = calc_slicedefs(
         sliceobj, shape, itemsize, offset, order)
     n_bytes = reduce(operator.mul, sliced_shape, 1) * itemsize

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -740,6 +740,16 @@ def test_fileslice():
                     _check_slicer(sliceobj, arr, fobj, offset, order)
 
 
+def test_fileslice_dtype():
+    # Test that any valid dtype specifier works for fileslice
+    sliceobj = (slice(None), slice(2))
+    for dt in (np.dtype('int32'), np.int32, 'i4', 'int32', '>i4', '<i4'):
+        arr = np.arange(24, dtype=dt).reshape((2, 3, 4))
+        fobj = BytesIO(arr.tostring())
+        new_slice = fileslice(fobj, sliceobj, arr.shape, dt)
+        assert_array_equal(arr[sliceobj], new_slice)
+
+
 def test_fileslice_errors():
     # Test fileslice causes error on fancy indexing
     arr = np.arange(24).reshape((2, 3, 4))


### PR DESCRIPTION
Fileslice function previously insisted on np.dtype object as dtype
specifier.  Allow any dtype specifier.