### PR TITLE
doc: Properly find the version

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,8 +22,6 @@
 import sys
 import os
 
-import nibabel
-
 # Check for external Sphinx extensions we depend on
 try:
     import numpydoc
@@ -89,7 +87,7 @@ copyright = u'2006-2016, %(MAINTAINER)s <%(AUTHOR_EMAIL)s>' % rel
 # built documents.
 #
 # The short X.Y version.
-version = nibabel.__version__
+version = rel['VERSION']
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
The conf.py can't import nibabel if nibabel isn't installed, as is the
case when installing nibabel for the first time.
