### PR TITLE
ENH: Support + and += operators for Tractogram

### DIFF
--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -570,6 +570,17 @@ class TestTractogram(unittest.TestCase):
         tractogram.affine_to_rasmm = None
         assert_raises(ValueError, tractogram.to_world)
 
+    def test_tractogram_extend(self):
+        # Load tractogram that contains some metadata.
+        t = DATA['tractogram'].copy()
+        new_t = DATA['tractogram'].copy()
+
+        # Double the tractogram.
+        new_t += t
+        assert_equal(len(new_t), 2*len(t))
+        assert_tractogram_equal(new_t[:len(t)], DATA['tractogram'])
+        assert_tractogram_equal(new_t[len(t):], DATA['tractogram'])
+
 
 class TestLazyTractogram(unittest.TestCase):
 
@@ -640,6 +651,11 @@ class TestLazyTractogram(unittest.TestCase):
     def test_lazy_tractogram_getitem(self):
         assert_raises(NotImplementedError,
                       DATA['lazy_tractogram'].__getitem__, 0)
+
+    def test_lazy_tractogram_extend(self):
+        t = DATA['lazy_tractogram'].copy()
+        new_t = DATA['lazy_tractogram'].copy()
+        assert_raises(NotImplementedError, new_t.__iadd__, t)
 
     def test_lazy_tractogram_len(self):
         modules = [module_tractogram]  # Modules for which to catch warnings.

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -181,6 +181,21 @@ class TestPerArrayDict(unittest.TestCase):
             assert_arrays_equal(sdict[-1][k], v[-1])
             assert_arrays_equal(sdict[[0, -1]][k], v[[0, -1]])
 
+    def test_extend(self):
+        sdict = PerArrayDict(len(DATA['tractogram']),
+                             DATA['data_per_streamline'])
+        sdict2 = PerArrayDict(len(DATA['tractogram']),
+                              DATA['data_per_streamline'])
+
+        sdict += sdict2
+        assert_equal(len(sdict), len(sdict2))
+        for k, v in DATA['tractogram'].data_per_streamline.items():
+            assert_arrays_equal(sdict[k][:len(DATA['tractogram'])], v)
+            assert_arrays_equal(sdict[k][len(DATA['tractogram']):], v)
+
+        # Test incompatible PerArrayDicts.
+        assert_raises(ValueError, sdict.extend, PerArrayDict())
+
 
 class TestPerArraySequenceDict(unittest.TestCase):
 
@@ -232,6 +247,20 @@ class TestPerArraySequenceDict(unittest.TestCase):
             assert_arrays_equal(sdict[::-1][k], v[::-1])
             assert_arrays_equal(sdict[-1][k], v[-1])
             assert_arrays_equal(sdict[[0, -1]][k], v[[0, -1]])
+
+    def test_extend(self):
+        total_nb_rows = DATA['tractogram'].streamlines.total_nb_rows
+        sdict = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
+        sdict2 = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
+
+        sdict += sdict2
+        assert_equal(len(sdict), len(sdict2))
+        for k, v in DATA['tractogram'].data_per_point.items():
+            assert_arrays_equal(sdict[k][:len(DATA['tractogram'])], v)
+            assert_arrays_equal(sdict[k][len(DATA['tractogram']):], v)
+
+        # Test incompatible PerArrayDicts.
+        assert_raises(ValueError, sdict.extend, PerArraySequenceDict())
 
 
 class TestLazyDict(unittest.TestCase):

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import warnings
 import operator
+from collections import defaultdict
 
 from nibabel.testing import assert_arrays_equal
 from nibabel.testing import clear_and_catch_warnings
@@ -17,37 +18,99 @@ from ..tractogram import PerArrayDict, PerArraySequenceDict, LazyDict
 DATA = {}
 
 
+def make_fake_streamline(nb_points, data_per_point_shapes={},
+                         data_for_streamline_shapes={}, rng=None):
+    """ Make a single streamline according to provided requirements. """
+    if rng is None:
+        rng = np.random.RandomState()
+
+    streamline = rng.randn(nb_points, 3).astype("f4")
+
+    data_per_point = {}
+    for k, shape in data_per_point_shapes.items():
+        data_per_point[k] = rng.randn(*((nb_points,) + shape)).astype("f4")
+
+    data_for_streamline = {}
+    for k, shape in data_for_streamline.items():
+        data_for_streamline[k] = rng.randn(*shape).astype("f4")
+
+    return streamline, data_per_point, data_for_streamline
+
+
+def make_fake_tractogram(list_nb_points, data_per_point_shapes={},
+                         data_for_streamline_shapes={}, rng=None):
+    """ Make multiple streamlines according to provided requirements. """
+    all_streamlines = []
+    all_data_per_point = defaultdict(lambda: [])
+    all_data_per_streamline = defaultdict(lambda: [])
+    for nb_points in list_nb_points:
+        data = make_fake_streamline(nb_points, data_per_point_shapes,
+                                    data_for_streamline_shapes, rng)
+        streamline, data_per_point, data_for_streamline = data
+
+        all_streamlines.append(streamline)
+        for k, v in data_per_point.items():
+            all_data_per_point[k].append(v)
+
+        for k, v in data_for_streamline.items():
+            all_data_per_streamline[k].append(v)
+
+    return all_streamlines, all_data_per_point, all_data_per_streamline
+
+
+def make_dummy_streamline(nb_points):
+    """ Make the streamlines that have been used to create test data files."""
+    if nb_points == 1:
+        streamline = np.arange(1*3, dtype="f4").reshape((1, 3))
+        data_per_point = {"fa": np.array([[0.2]], dtype="f4"),
+                          "colors": np.array([(1, 0, 0)]*1, dtype="f4")}
+        data_for_streamline = {"mean_curvature": np.array([1.11], dtype="f4"),
+                               "mean_torsion": np.array([1.22], dtype="f4"),
+                               "mean_colors": np.array([1, 0, 0], dtype="f4")}
+
+    elif nb_points == 2:
+        streamline = np.arange(2*3, dtype="f4").reshape((2, 3))
+        data_per_point = {"fa": np.array([[0.3],
+                                          [0.4]], dtype="f4"),
+                          "colors": np.array([(0, 1, 0)]*2, dtype="f4")}
+        data_for_streamline = {"mean_curvature": np.array([2.11], dtype="f4"),
+                               "mean_torsion": np.array([2.22], dtype="f4"),
+                               "mean_colors": np.array([0, 1, 0], dtype="f4")}
+
+    elif nb_points == 5:
+        streamline = np.arange(5*3, dtype="f4").reshape((5, 3))
+        data_per_point = {"fa": np.array([[0.5],
+                                          [0.6],
+                                          [0.6],
+                                          [0.7],
+                                          [0.8]], dtype="f4"),
+                          "colors": np.array([(0, 0, 1)]*5, dtype="f4")}
+        data_for_streamline = {"mean_curvature": np.array([3.11], dtype="f4"),
+                               "mean_torsion": np.array([3.22], dtype="f4"),
+                               "mean_colors": np.array([0, 0, 1], dtype="f4")}
+
+    return streamline, data_per_point, data_for_streamline
+
+
 def setup():
     global DATA
     DATA['rng'] = np.random.RandomState(1234)
-    DATA['streamlines'] = [np.arange(1*3, dtype="f4").reshape((1, 3)),
-                           np.arange(2*3, dtype="f4").reshape((2, 3)),
-                           np.arange(5*3, dtype="f4").reshape((5, 3))]
 
-    DATA['fa'] = [np.array([[0.2]], dtype="f4"),
-                  np.array([[0.3],
-                            [0.4]], dtype="f4"),
-                  np.array([[0.5],
-                            [0.6],
-                            [0.6],
-                            [0.7],
-                            [0.8]], dtype="f4")]
-
-    DATA['colors'] = [np.array([(1, 0, 0)]*1, dtype="f4"),
-                      np.array([(0, 1, 0)]*2, dtype="f4"),
-                      np.array([(0, 0, 1)]*5, dtype="f4")]
-
-    DATA['mean_curvature'] = [np.array([1.11], dtype="f4"),
-                              np.array([2.11], dtype="f4"),
-                              np.array([3.11], dtype="f4")]
-
-    DATA['mean_torsion'] = [np.array([1.22], dtype="f4"),
-                            np.array([2.22], dtype="f4"),
-                            np.array([3.22], dtype="f4")]
-
-    DATA['mean_colors'] = [np.array([1, 0, 0], dtype="f4"),
-                           np.array([0, 1, 0], dtype="f4"),
-                           np.array([0, 0, 1], dtype="f4")]
+    DATA['streamlines'] = []
+    DATA['fa'] = []
+    DATA['colors'] = []
+    DATA['mean_curvature'] = []
+    DATA['mean_torsion'] = []
+    DATA['mean_colors'] = []
+    for nb_points in [1, 2, 5]:
+        data = make_dummy_streamline(nb_points)
+        streamline, data_per_point, data_for_streamline = data
+        DATA['streamlines'].append(streamline)
+        DATA['fa'].append(data_per_point['fa'])
+        DATA['colors'].append(data_per_point['colors'])
+        DATA['mean_curvature'].append(data_for_streamline['mean_curvature'])
+        DATA['mean_torsion'].append(data_for_streamline['mean_torsion'])
+        DATA['mean_colors'].append(data_for_streamline['mean_colors'])
 
     DATA['data_per_point'] = {'colors': DATA['colors'],
                               'fa': DATA['fa']}
@@ -280,9 +343,14 @@ class TestPerArraySequenceDict(unittest.TestCase):
         total_nb_rows = DATA['tractogram'].streamlines.total_nb_rows
         sdict = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
 
-        new_data = {'colors': 2 * np.array(DATA['colors']),
-                    'fa': 3 * np.array(DATA['fa'])}
-        sdict2 = PerArraySequenceDict(total_nb_rows, new_data)
+        # Test compatible PerArrayDicts.
+        list_nb_points = [2, 7, 4]
+        data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
+                                 "fa": DATA['fa'][0].shape[1:]}
+        _, new_data, _ = make_fake_tractogram(list_nb_points,
+                                              data_per_point_shapes,
+                                              rng=DATA['rng'])
+        sdict2 = PerArraySequenceDict(np.sum(list_nb_points), new_data)
 
         sdict.extend(sdict2)
         assert_equal(len(sdict), len(sdict2))
@@ -297,16 +365,22 @@ class TestPerArraySequenceDict(unittest.TestCase):
         assert_raises(ValueError, sdict.extend, PerArraySequenceDict())
 
         # Other dict has more entries.
-        new_data = {'colors': 2 * np.array(DATA['colors']),
-                    'fa': 3 * np.array(DATA['fa']),
-                    'other': 4 * np.array(DATA['fa'])}
-        sdict2 = PerArraySequenceDict(total_nb_rows, new_data)
+        data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
+                                 "fa": DATA['fa'][0].shape[1:],
+                                 "other": (7,)}
+        _, new_data, _ = make_fake_tractogram(list_nb_points,
+                                              data_per_point_shapes,
+                                              rng=DATA['rng'])
+        sdict2 = PerArraySequenceDict(np.sum(list_nb_points), new_data)
         assert_raises(ValueError, sdict.extend, sdict2)
 
         # Other dict has the right number of entries but wrong shape.
-        new_data = {'colors': 2 * np.array(DATA['colors']),
-                    'other': 2 * np.array(DATA['colors']),}
-        sdict2 = PerArraySequenceDict(total_nb_rows, new_data)
+        data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
+                                 "fa": DATA['fa'][0].shape[1:] + (3,)}
+        _, new_data, _ = make_fake_tractogram(list_nb_points,
+                                              data_per_point_shapes,
+                                              rng=DATA['rng'])
+        sdict2 = PerArraySequenceDict(np.sum(list_nb_points), new_data)
         assert_raises(ValueError, sdict.extend, sdict2)
 
 
@@ -650,12 +724,14 @@ class TestTractogram(unittest.TestCase):
         # Load tractogram that contains some metadata.
         t = DATA['tractogram'].copy()
 
-        for op, in_place in ((operator.add, False), (operator.iadd, True), (extender, True)):
+        for op, in_place in ((operator.add, False), (operator.iadd, True),
+                             (extender, True)):
             first_arg = t.copy()
             new_t = op(first_arg, t)
             assert_equal(new_t is first_arg, in_place)
             assert_tractogram_equal(new_t[:len(t)], DATA['tractogram'])
             assert_tractogram_equal(new_t[len(t):], DATA['tractogram'])
+
 
 class TestLazyTractogram(unittest.TestCase):
 
@@ -670,7 +746,8 @@ class TestLazyTractogram(unittest.TestCase):
                                'mean_colors': (x for x in DATA['mean_colors'])}
 
         # Creating LazyTractogram with generators is not allowed as
-        # generators get exhausted and are not reusable unlike generator function.
+        # generators get exhausted and are not reusable unlike generator
+        # function.
         assert_raises(TypeError, LazyTractogram, streamlines)
         assert_raises(TypeError, LazyTractogram,
                       data_per_streamline=data_per_streamline)
@@ -701,7 +778,8 @@ class TestLazyTractogram(unittest.TestCase):
         tractogram = LazyTractogram.from_data_func(_empty_data_gen)
         check_tractogram(tractogram)
 
-        # Create `LazyTractogram` from a generator function yielding TractogramItem.
+        # Create `LazyTractogram` from a generator function yielding
+        # TractogramItem.
         data = [DATA['streamlines'], DATA['fa'], DATA['colors'],
                 DATA['mean_curvature'], DATA['mean_torsion'],
                 DATA['mean_colors']]
@@ -839,8 +917,8 @@ class TestLazyTractogram(unittest.TestCase):
         # Check we copied the data and not simply created new references.
         assert_true(tractogram is not DATA['lazy_tractogram'])
 
-        # When copying LazyTractogram, the generator function yielding streamlines
-        # should stay the same.
+        # When copying LazyTractogram, the generator function yielding
+        # streamlines should stay the same.
         assert_true(tractogram._streamlines
                     is DATA['lazy_tractogram']._streamlines)
 

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -265,7 +265,7 @@ class TestPerArrayDict(unittest.TestCase):
             assert_arrays_equal(sdict[k][len(DATA['tractogram']):],
                                 new_data[k])
 
-        # Extending with an empty PerArrayDicts should change nothing.
+        # Extending with an empty PerArrayDict should change nothing.
         sdict_orig = copy.deepcopy(sdict)
         sdict.extend(PerArrayDict())
         for k in sdict_orig.keys():
@@ -280,10 +280,17 @@ class TestPerArrayDict(unittest.TestCase):
         sdict2 = PerArrayDict(len(DATA['tractogram']), new_data)
         assert_raises(ValueError, sdict.extend, sdict2)
 
+        # Other dict has not the same entries (key mistmached).
+        new_data = {'mean_curvature': 2 * np.array(DATA['mean_curvature']),
+                    'mean_torsion': 3 * np.array(DATA['mean_torsion']),
+                    'other': 4 * np.array(DATA['mean_colors'])}
+        sdict2 = PerArrayDict(len(DATA['tractogram']), new_data)
+        assert_raises(ValueError, sdict.extend, sdict2)
+
         # Other dict has the right number of entries but wrong shape.
         new_data = {'mean_curvature': 2 * np.array(DATA['mean_curvature']),
                     'mean_torsion': 3 * np.array(DATA['mean_torsion']),
-                    'other': 4 * np.array(DATA['mean_torsion'])}
+                    'mean_colors': 4 * np.array(DATA['mean_torsion'])}
         sdict2 = PerArrayDict(len(DATA['tractogram']), new_data)
         assert_raises(ValueError, sdict.extend, sdict2)
 
@@ -343,7 +350,7 @@ class TestPerArraySequenceDict(unittest.TestCase):
         total_nb_rows = DATA['tractogram'].streamlines.total_nb_rows
         sdict = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
 
-        # Test compatible PerArrayDicts.
+        # Test compatible PerArraySequenceDicts.
         list_nb_points = [2, 7, 4]
         data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
                                  "fa": DATA['fa'][0].shape[1:]}
@@ -360,17 +367,26 @@ class TestPerArraySequenceDict(unittest.TestCase):
             assert_arrays_equal(sdict[k][len(DATA['tractogram']):],
                                 new_data[k])
 
-        # Extending with an empty PerArrayDicts should change nothing.
+        # Extending with an empty PerArraySequenceDicts should change nothing.
         sdict_orig = copy.deepcopy(sdict)
         sdict.extend(PerArraySequenceDict())
         for k in sdict_orig.keys():
             assert_arrays_equal(sdict[k], sdict_orig[k])
 
-        # Test incompatible PerArrayDicts.
+        # Test incompatible PerArraySequenceDicts.
         # Other dict has more entries.
         data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
                                  "fa": DATA['fa'][0].shape[1:],
                                  "other": (7,)}
+        _, new_data, _ = make_fake_tractogram(list_nb_points,
+                                              data_per_point_shapes,
+                                              rng=DATA['rng'])
+        sdict2 = PerArraySequenceDict(np.sum(list_nb_points), new_data)
+        assert_raises(ValueError, sdict.extend, sdict2)
+
+        # Other dict has not the same entries (key mistmached).
+        data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
+                                 "other": DATA['fa'][0].shape[1:]}
         _, new_data, _ = make_fake_tractogram(list_nb_points,
                                               data_per_point_shapes,
                                               rng=DATA['rng'])

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -187,7 +187,7 @@ class TestPerArrayDict(unittest.TestCase):
         sdict2 = PerArrayDict(len(DATA['tractogram']),
                               DATA['data_per_streamline'])
 
-        sdict += sdict2
+        sdict.extend(sdict2)
         assert_equal(len(sdict), len(sdict2))
         for k, v in DATA['tractogram'].data_per_streamline.items():
             assert_arrays_equal(sdict[k][:len(DATA['tractogram'])], v)
@@ -253,7 +253,7 @@ class TestPerArraySequenceDict(unittest.TestCase):
         sdict = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
         sdict2 = PerArraySequenceDict(total_nb_rows, DATA['data_per_point'])
 
-        sdict += sdict2
+        sdict.extend(sdict2)
         assert_equal(len(sdict), len(sdict2))
         for k, v in DATA['tractogram'].data_per_point.items():
             assert_arrays_equal(sdict[k][:len(DATA['tractogram'])], v)
@@ -602,9 +602,15 @@ class TestTractogram(unittest.TestCase):
     def test_tractogram_extend(self):
         # Load tractogram that contains some metadata.
         t = DATA['tractogram'].copy()
-        new_t = DATA['tractogram'].copy()
 
         # Double the tractogram.
+        new_t = t + t
+        assert_equal(len(new_t), 2*len(t))
+        assert_tractogram_equal(new_t[:len(t)], DATA['tractogram'])
+        assert_tractogram_equal(new_t[len(t):], DATA['tractogram'])
+
+        # Double the tractogram inplace.
+        new_t = DATA['tractogram'].copy()
         new_t += t
         assert_equal(len(new_t), 2*len(t))
         assert_tractogram_equal(new_t[:len(t)], DATA['tractogram'])

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 import unittest
 import numpy as np
 import warnings
@@ -264,10 +265,13 @@ class TestPerArrayDict(unittest.TestCase):
             assert_arrays_equal(sdict[k][len(DATA['tractogram']):],
                                 new_data[k])
 
-        # Test incompatible PerArrayDicts.
-        # Other dict is missing entries.
-        assert_raises(ValueError, sdict.extend, PerArrayDict())
+        # Extending with an empty PerArrayDicts should change nothing.
+        sdict_orig = copy.deepcopy(sdict)
+        sdict.extend(PerArrayDict())
+        for k in sdict_orig.keys():
+            assert_arrays_equal(sdict[k], sdict_orig[k])
 
+        # Test incompatible PerArrayDicts.
         # Other dict has more entries.
         new_data = {'mean_curvature': 2 * np.array(DATA['mean_curvature']),
                     'mean_torsion': 3 * np.array(DATA['mean_torsion']),
@@ -356,10 +360,13 @@ class TestPerArraySequenceDict(unittest.TestCase):
             assert_arrays_equal(sdict[k][len(DATA['tractogram']):],
                                 new_data[k])
 
-        # Test incompatible PerArrayDicts.
-        # Other dict is missing entries.
-        assert_raises(ValueError, sdict.extend, PerArraySequenceDict())
+        # Extending with an empty PerArrayDicts should change nothing.
+        sdict_orig = copy.deepcopy(sdict)
+        sdict.extend(PerArraySequenceDict())
+        for k in sdict_orig.keys():
+            assert_arrays_equal(sdict[k], sdict_orig[k])
 
+        # Test incompatible PerArrayDicts.
         # Other dict has more entries.
         data_per_point_shapes = {"colors": DATA['colors'][0].shape[1:],
                                  "fa": DATA['fa'][0].shape[1:],
@@ -727,6 +734,16 @@ class TestTractogram(unittest.TestCase):
             assert_equal(new_t is first_arg, in_place)
             assert_tractogram_equal(new_t[:len(t)], DATA['tractogram'])
             assert_tractogram_equal(new_t[len(t):], DATA['tractogram'])
+
+        # Test extending an empty Tractogram.
+        t = Tractogram()
+        t += DATA['tractogram']
+        assert_tractogram_equal(t, DATA['tractogram'])
+
+        # and the other way around.
+        t = DATA['tractogram'].copy()
+        t += Tractogram()
+        assert_tractogram_equal(t, DATA['tractogram'])
 
 
 class TestLazyTractogram(unittest.TestCase):

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -123,9 +123,13 @@ class PerArrayDict(SliceableDataDict):
         other : :class:`PerArrayDict` object
             Its data will be appended to the data of this dictionary.
 
+        Returns
+        -------
+        None
+
         Notes
         -----
-        The entries in both dictionaries must match.
+        The keys in both dictionaries must be the same.
         """
         if sorted(self.keys()) != sorted(other.keys()):
             msg = ("Entry mismatched between the two PerArrayDict objects."
@@ -173,9 +177,13 @@ class PerArraySequenceDict(PerArrayDict):
         other : :class:`PerArraySequenceDict` object
             Its data will be appended to the data of this dictionary.
 
+        Returns
+        -------
+        None
+
         Notes
         -----
-        The entries in both dictionaries must match.
+        The keys in both dictionaries must be the same.
         """
         if sorted(self.keys()) != sorted(other.keys()):
             msg = ("Key mismatched between the two PerArrayDict objects."
@@ -481,10 +489,15 @@ class Tractogram(object):
         other : :class:`Tractogram` object
             Its data will be appended to the data of this tractogram.
 
+        Returns
+        -------
+        None
+
         Notes
         -----
-        The entries of `self.data_per_streamline` and `self.data_per_point`
-        must match those contained in the other tractogram.
+        The entries in both dictionaries `self.data_per_streamline` and
+        `self.data_per_point` must match respectively those contained in the .
+        the other tractogram.
         """
         self.streamlines.extend(other.streamlines)
         self.data_per_streamline.extend(other.data_per_streamline)

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -113,14 +113,22 @@ class PerArrayDict(SliceableDataDict):
         self.store[key] = value
 
     def extend(self, other):
-        if len(self) != len(other):
-            msg = ("Size mismatched between the two PerArrayDict objects."
-                   " This PerArrayDict has {0} elements whereas the other "
-                   " has {1} elements.").format(len(self), len(other))
-            raise ValueError(msg)
+        """ Appends the elements of another :class:`PerArrayDict`.
 
+        That is, for each entry in this dictionary, we append the elements
+        coming from the other dictionary at the corresponding entry.
+
+        Parameters
+        ----------
+        other : :class:`PerArrayDict` object
+            Its data will be appended to the data of this dictionary.
+
+        Notes
+        -----
+        The entries in both dictionaries must match.
+        """
         if sorted(self.keys()) != sorted(other.keys()):
-            msg = ("Key mismatched between the two PerArrayDict objects."
+            msg = ("Entry mismatched between the two PerArrayDict objects."
                    " This PerArrayDict contains '{0}' whereas the other "
                    " contains '{1}'.").format(sorted(self.keys()),
                                               sorted(other.keys()))
@@ -159,12 +167,20 @@ class PerArraySequenceDict(PerArrayDict):
         self.store[key] = value
 
     def extend(self, other):
-        if len(self) != len(other):
-            msg = ("Size mismatched between the two PerArrayDict objects."
-                   " This PerArrayDict has {0} elements whereas the other "
-                   " has {1} elements.").format(len(self), len(other))
-            raise ValueError(msg)
+        """ Appends the elements of another :class:`PerArraySequenceDict`.
 
+        That is, for each entry in this dictionary, we append the elements
+        coming from the other dictionary at the corresponding entry.
+
+        Parameters
+        ----------
+        other : :class:`PerArraySequenceDict` object
+            Its data will be appended to the data of this dictionary.
+
+        Notes
+        -----
+        The entries in both dictionaries must match.
+        """
         if sorted(self.keys()) != sorted(other.keys()):
             msg = ("Key mismatched between the two PerArrayDict objects."
                    " This PerArrayDict contains '{0}' whereas the other "
@@ -463,7 +479,21 @@ class Tractogram(object):
         return self.apply_affine(self.affine_to_rasmm, lazy=lazy)
 
     def extend(self, other):
-        # TODO: Make sure the other tractogram is compatible.
+        """ Appends the data of another :class:`Tractogram`.
+
+        Data that will be appended includes the streamlines and the content
+        of both dictionaries `data_per_streamline` and `data_per_point`.
+
+        Parameters
+        ----------
+        other : :class:`Tractogram` object
+            Its data will be appended to the data of this tractogram.
+
+        Notes
+        -----
+        The entries of `self.data_per_streamline` and `self.data_per_point`
+        must match those contained in the other tractogram.
+        """
         self.streamlines.extend(other.streamlines)
         self.data_per_streamline += other.data_per_streamline
         self.data_per_point += other.data_per_point
@@ -708,7 +738,8 @@ class LazyTractogram(Tractogram):
         raise NotImplementedError('LazyTractogram does not support indexing.')
 
     def extend(self, other):
-        raise NotImplementedError('LazyTractogram does not support concatenation.')
+        msg = 'LazyTractogram does not support concatenation.'
+        raise NotImplementedError(msg)
 
     def __iter__(self):
         count = 0

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -496,7 +496,7 @@ class Tractogram(object):
         Notes
         -----
         The entries in both dictionaries `self.data_per_streamline` and
-        `self.data_per_point` must match respectively those contained in the .
+        `self.data_per_point` must match respectively those contained in
         the other tractogram.
         """
         self.streamlines.extend(other.streamlines)

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -138,8 +138,8 @@ class PerArrayDict(SliceableDataDict):
         -----
         The keys in both dictionaries must be the same.
         """
-        if (len(self) > 0 and len(other) > 0
-            and sorted(self.keys()) != sorted(other.keys())):
+        if (len(self) > 0 and len(other) > 0 and
+                sorted(self.keys()) != sorted(other.keys())):
             msg = ("Entry mismatched between the two PerArrayDict objects."
                    " This PerArrayDict contains '{0}' whereas the other "
                    " contains '{1}'.").format(sorted(self.keys()),

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -138,10 +138,6 @@ class PerArrayDict(SliceableDataDict):
         for key in self.keys():
             self[key] = np.concatenate([self[key], other[key]])
 
-    def __iadd__(self, other):
-        self.extend(other)
-        return self
-
 
 class PerArraySequenceDict(PerArrayDict):
     """ Dictionary for which key access can do slicing on the values.
@@ -191,10 +187,6 @@ class PerArraySequenceDict(PerArrayDict):
         self.n_rows += other.n_rows
         for key in self.keys():
             self[key].extend(other[key])
-
-    def __iadd__(self, other):
-        self.extend(other)
-        return self
 
 
 class LazyDict(collections.MutableMapping):
@@ -495,12 +487,17 @@ class Tractogram(object):
         must match those contained in the other tractogram.
         """
         self.streamlines.extend(other.streamlines)
-        self.data_per_streamline += other.data_per_streamline
-        self.data_per_point += other.data_per_point
+        self.data_per_streamline.extend(other.data_per_streamline)
+        self.data_per_point.extend(other.data_per_point)
 
     def __iadd__(self, other):
         self.extend(other)
         return self
+
+    def __add__(self, other):
+        tractogram = self.copy()
+        tractogram += other
+        return tractogram
 
 
 class LazyTractogram(Tractogram):


### PR DESCRIPTION
This PR adds the functionality of concatenating two Tractogram objects using either `tractogram += other_tractogram` or `tractogram = tractogram1 + tractogram2`.

This will definitively interest @jchoude, @arnaudbore, @Garyfallidis, @FrancoisRheaultUS and many others.