### PR TITLE
Format string {} not allowed in Python 2.6

### DIFF
--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -146,7 +146,7 @@ class Deprecator(object):
         if since:
             messages.append('* deprecated from version: ' + since)
         if until:
-            messages.append('* {} {} as of version: {}'.format(
+            messages.append('* {0} {1} as of version: {2}'.format(
                 "Raises" if self.is_bad_version(until) else "Will raise",
                 error_class,
                 until))


### PR DESCRIPTION
pypi indicates that the current version of nibabel works for any version of Python, but the use of a literal '{}' (i.e. without indices) in a format string is only supported started in Python 2.7.