### PR TITLE
Update get_csa_header to return none on CSAReadError

### DIFF
--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -65,10 +65,11 @@ def get_csa_header(dcm_data, csa_type='image'):
     element_no = section_start + element_offset
     try:
         tag = dcm_data[(0x29, element_no)]
-    except KeyError:
+        return read(tag.value)
+    except (KeyError,CSAReadError):
         # The element could be missing due to anonymization
         return None
-    return read(tag.value)
+    
 
 
 def read(csa_str):


### PR DESCRIPTION
Some non-MRI dicom datasets have just strings in CSA Header tags e.g Siemens PET dicoms . This causes the read on line 68 to throw an error because the string is not a CSA header. Unfortunately this throws out other packages such as dcmstack which use nibabel. The proposed fix returns none if a read error is encountered when such strings are parsed. It is possible such strings may pass the initial check for 0 < n_tags <=128 which throws the CSAReadError but fail later in which case the except block can be be modified to handle those exceptions as well.