### PR TITLE
Clarified error messages in LazyTractogram

### DIFF
--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -587,6 +587,8 @@ class TestLazyTractogram(unittest.TestCase):
         # generators get exhausted and are not reusable unlike generator function.
         assert_raises(TypeError, LazyTractogram, streamlines)
         assert_raises(TypeError, LazyTractogram,
+                      data_per_point={"none": None})
+        assert_raises(TypeError, LazyTractogram,
                       data_per_streamline=data_per_streamline)
         assert_raises(TypeError, LazyTractogram, DATA['streamlines'],
                       data_per_point=data_per_point)

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -167,7 +167,7 @@ class LazyDict(collections.MutableMapping):
     def __setitem__(self, key, value):
         if not callable(value):
             msg = ("Values in a `LazyDict` must be generator functions."
-                   " Those are functions which whenever are called return an"
+                   " These are functions which, when called, return an"
                    " instantiated generator.")
             raise TypeError(msg)
         self.store[key] = value
@@ -608,8 +608,8 @@ class LazyTractogram(Tractogram):
     def _set_streamlines(self, value):
         if value is not None and not callable(value):
             msg = ("`streamlines` must be a generator function. That is a"
-                   " function which whenever is called returns an"
-                   " instantiated generator.")
+                   " function which, when called, returns an instantiated"
+                   " generator.")
             raise TypeError(msg)
         self._streamlines = value
 

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -165,8 +165,11 @@ class LazyDict(collections.MutableMapping):
         return self.store[key]()
 
     def __setitem__(self, key, value):
-        if value is not None and not callable(value):  # TODO: why None?
-            raise TypeError("`value` must be a generator function or None.")
+        if not callable(value):
+            msg = ("Values in a `LazyDict` must be generator functions."
+                   " Those are functions which whenever are called return an"
+                   " instantiated generator.")
+            raise TypeError(msg)
         self.store[key] = value
 
     def __delitem__(self, key):
@@ -604,7 +607,10 @@ class LazyTractogram(Tractogram):
 
     def _set_streamlines(self, value):
         if value is not None and not callable(value):
-            raise TypeError("`streamlines` must be a generator function.")
+            msg = ("`streamlines` must be a generator function. That is a"
+                   " function which whenever is called returns an"
+                   " instantiated generator.")
+            raise TypeError(msg)
         self._streamlines = value
 
     @property


### PR DESCRIPTION
This PR clarifies what "generator function" means in relevant error messages. It also makes sure all values contained in a `LazyDict` object are callable.