### PR TITLE
MAINT: use new pre-release Rackspace container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,15 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
-addons:
-  apt:
-    packages:
-      - libhdf5-serial-dev
-      # For numpy --pre wheels
-      - libatlas-base-dev
 env:
     global:
         - DEPENDS="numpy scipy matplotlib h5py pillow"
         - PYDICOM=1
         - INSTALL_TYPE="setup"
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
+        - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
         - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
+        - PRE_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
 python:
     - 3.4
     - 3.5
@@ -58,10 +54,14 @@ matrix:
     - python: 2.7
       env:
         - PYDICOM="v1.0"
-    # test against pre-release builds
+    # test 2.7 against pre-release builds of everything
     - python: 2.7
       env:
-        - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS"
+        - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
+    # test 3.5 against pre-release builds of everything
+    - python: 3.5
+      env:
+        - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     # Documentation doctests
     - python: 2.7
       env:


### PR DESCRIPTION
Look in new container for pre-release builds of numpy, scipy, matplotlib.

Don't install apt packages, the wheels provide these libraries.