### PR TITLE
TST: make test shear matrix full rank

### DIFF
--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -357,7 +357,9 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         another_aff = np.diag([3, 4, 5, 1])
         # Affine with shears
         nasty_aff = from_matvec(np.arange(9).reshape((3, 3)), [9, 10, 11])
+        nasty_aff[0, 0] = 1  # Make full rank
         fixed_aff = unshear_44(nasty_aff)
+        assert_false(np.allclose(fixed_aff, nasty_aff))
         for in_meth, out_meth in ((hdr.set_qform, hdr.get_qform),
                                   (hdr.set_sform, hdr.get_sform)):
             in_meth(nice_aff, 2)


### PR DESCRIPTION
Matrix with shears was rank deficient, so small deviations in the SVD
output were making the tests fail - see:
http://nipy.bic.berkeley.edu/builders/nibabel-py2.7-debian-ppc/builds/106/steps/shell_6/logs/stdio

Make test matrix full rank to avoid test failures.