### PR TITLE
Bugfix to WrapStruct.get

### DIFF
--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -183,6 +183,22 @@ class _TestWrapStructBase(TestCase):
         assert_equal(hdr.get(keys[0]), vals[0])
         assert_equal(hdr.get(keys[0], 'default'), vals[0])
 
+        # make sure .get returns values 
+        # which evaluate to False. We
+        # have to use a different falsy
+        # value depending on the data
+        # type of the first header field.
+        if np.issubdtype(hdr_dt[0], np.number):
+            falsyval = 0
+        else:
+            falsyval = ''
+
+        hdr[keys[0]] = falsyval
+        assert_equal(hdr[keys[0]], falsyval)
+        assert_equal(hdr.get(keys[0]), falsyval)
+        assert_equal(hdr.get(keys[0], -1), falsyval)
+
+
     def test_endianness_ro(self):
         # endianness is a read only property
         ''' Its use in initialization tested in the init tests.

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -191,7 +191,7 @@ class _TestWrapStructBase(TestCase):
         if np.issubdtype(hdr_dt[0], np.number):
             falsyval = 0
         else:
-            falsyval = ''
+            falsyval = b''
 
         hdr[keys[0]] = falsyval
         assert_equal(hdr[keys[0]], falsyval)

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -183,15 +183,10 @@ class _TestWrapStructBase(TestCase):
         assert_equal(hdr.get(keys[0]), vals[0])
         assert_equal(hdr.get(keys[0], 'default'), vals[0])
 
-        # make sure .get returns values 
-        # which evaluate to False. We
-        # have to use a different falsy
-        # value depending on the data
-        # type of the first header field.
-        if np.issubdtype(hdr_dt[0], np.number):
-            falsyval = 0
-        else:
-            falsyval = b''
+        # make sure .get returns values which evaluate to False. We have to
+        # use a different falsy value depending on the data type of the first
+        # header field.
+        falsyval = 0 if np.issubdtype(hdr_dt[0], np.number) else b''
 
         hdr[keys[0]] = falsyval
         assert_equal(hdr[keys[0]], falsyval)

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -343,7 +343,8 @@ class WrapStruct(object):
 
     def get(self, k, d=None):
         ''' Return value for the key k if present or d otherwise'''
-        return (k in self.keys()) and self._structarr[k] or d
+        if k in self.keys(): return self._structarr[k]
+        else:                return d
 
     def check_fix(self, logger=None, error_level=None):
         ''' Check structured data with checks

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -343,8 +343,10 @@ class WrapStruct(object):
 
     def get(self, k, d=None):
         ''' Return value for the key k if present or d otherwise'''
-        if k in self.keys(): return self._structarr[k]
-        else:                return d
+        if k in self.keys():
+            return self._structarr[k]
+        else:
+            return d
 
     def check_fix(self, logger=None, error_level=None):
         ''' Check structured data with checks

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -343,10 +343,7 @@ class WrapStruct(object):
 
     def get(self, k, d=None):
         ''' Return value for the key k if present or d otherwise'''
-        if k in self.keys():
-            return self._structarr[k]
-        else:
-            return d
+        return self._structarr[k] if k in self.keys() else d
 
     def check_fix(self, logger=None, error_level=None):
         ''' Check structured data with checks


### PR DESCRIPTION
A minor bug in `WrapStruct.get` - it fails for header fields with values that evaluates to `False` (e.g. `0`):

```
(fslpy) PMcMBPr15:nibabel paulmc$ fslhd MNI152_T1_2mm_nosqform.nii.gz | grep "_code"
slice_code     0
intent_code    0
qform_code     0
sform_code     0
file_code      1
(fslpy) PMcMBPr15:nibabel paulmc$ ipython
imPython 2.7.11 (v2.7.11:6d1b6a68f775, Dec  5 2015, 12:54:16)
Type "copyright", "credits" or "license" for more information.

IPython 5.1.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import nibabel as nib
nibabel/cifti2/parse_cifti2.py:24: FutureWarning: We no longer carry a copy of the 'six' package in nibabel; Please import the 'six' package directly
  from ..externals.six import BytesIO

In [2]: img = nib.load('MNI152_T1_2mm_nosqform.nii.gz')

In [3]: print img.header['sform_code']
0

In [4]: print img.header.get('sform_code')
None

In [5]: print img.header.get('sform_code', -1)
-1

In [6]: print nib.__version__
2.2.0dev
```