### PR TITLE
Fix rotation matrix around the first array axis

### DIFF
--- a/doc/source/coordinate_systems.rst
+++ b/doc/source/coordinate_systems.rst
@@ -386,8 +386,8 @@ A rotation of $\gamma$ radians around the first array axis:
     \end{bmatrix} =
     \begin{bmatrix}
     1 & 0 & 0 \\
-    0 & \cos(\gamma) & 0 & -\sin(\gamma) \\
-    0 & \sin(\gamma) & 0 & \cos(\gamma) \\
+    0 & \cos(\gamma) & -\sin(\gamma) \\
+    0 & \sin(\gamma) & \cos(\gamma) \\
     \end{bmatrix}
     \begin{bmatrix}
     i\\


### PR DESCRIPTION
The "rotation of γ radians around the first array axis" matrix looked like a 3 by 4 matrix. Removed the zeros so that it's 3 by 3.