### PR TITLE
Import BytesIO from io

### DIFF
--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -11,6 +11,7 @@ from __future__ import division, print_function, absolute_import
 from distutils.version import LooseVersion
 
 import numpy as np
+from io import BytesIO
 
 from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Label,
                      Cifti2LabelTable, Cifti2VertexIndices,
@@ -21,7 +22,6 @@ from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Label,
                      CIFTI_MODEL_TYPES, _underscore, Cifti2HeaderError)
 from .. import xmlutils as xml
 from ..spatialimages import HeaderDataError
-from ..externals.six import BytesIO
 from ..batteryrunners import Report
 from ..nifti1 import Nifti1Extension, extension_codes, intent_codes
 from ..nifti2 import Nifti2Header, Nifti2Image

--- a/nibabel/dft.py
+++ b/nibabel/dft.py
@@ -22,7 +22,7 @@ import sqlite3
 
 import numpy
 
-from six import BytesIO
+from io import BytesIO
 
 from .nifti1 import Nifti1Header
 

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -13,7 +13,6 @@ import io
 
 import numpy as np
 
-from six import BytesIO
 from .. import load, save
 from ...openers import ImageOpener
 from ..mghformat import MGHHeader, MGHError, MGHImage
@@ -171,7 +170,7 @@ def test_header_updating():
     mgz = load(MGZ_FNAME)
     hdr = mgz.header
     # Test against mri_info output
-    exp_aff = np.loadtxt(BytesIO(b"""
+    exp_aff = np.loadtxt(io.BytesIO(b"""
     1.0000   2.0000   3.0000   -13.0000
     2.0000   3.0000   1.0000   -11.5000
     3.0000   1.0000   2.0000   -11.5000
@@ -182,7 +181,7 @@ def test_header_updating():
     assert_equal(hdr['delta'], 1)
     assert_almost_equal(hdr['Mdc'], exp_aff[:3, :3].T)
     # Save, reload, same thing
-    img_fobj = BytesIO()
+    img_fobj = io.BytesIO()
     mgz2 = _mgh_rt(mgz, img_fobj)
     hdr2 = mgz2.header
     assert_almost_equal(hdr2.get_affine(), exp_aff, 6)
@@ -206,7 +205,7 @@ def test_cosine_order():
     aff[0] = [2, 1, 0, 10]
     img = MGHImage(data, aff)
     assert_almost_equal(img.affine, aff, 6)
-    img_fobj = BytesIO()
+    img_fobj = io.BytesIO()
     img2 = _mgh_rt(img, img_fobj)
     hdr2 = img2.header
     RZS = aff[:3, :3]

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -10,7 +10,7 @@
 import warnings
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 
 from .spatialimages import HeaderDataError, HeaderTypeError
 

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -6,7 +6,7 @@ import numpy as np
 from os.path import join as pjoin
 
 import nibabel as nib
-from six import BytesIO
+from io import BytesIO
 from nibabel.tmpdirs import InTemporaryDirectory
 
 from nibabel.testing import data_path

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from os.path import join as pjoin
 
-from six import BytesIO
+from io import BytesIO
 
 from nibabel.testing import data_path
 from nibabel.testing import clear_and_catch_warnings, assert_arr_dict_equal

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -12,7 +12,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
-from six import BytesIO
+from io import BytesIO
 from ..tmpdirs import InTemporaryDirectory
 
 import numpy as np

--- a/nibabel/tests/test_arraywriters.py
+++ b/nibabel/tests/test_arraywriters.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 import itertools
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 from ..arraywriters import (SlopeInterArrayWriter, SlopeArrayWriter,
                             WriterError, ScalingError, ArrayWriter,
                             make_array_writer, get_slope_inter)

--- a/nibabel/tests/test_dft.py
+++ b/nibabel/tests/test_dft.py
@@ -3,7 +3,7 @@
 
 import os
 from os.path import join as pjoin, dirname
-from six import BytesIO
+from io import BytesIO
 from ..testing import suppress_warnings
 
 import numpy as np

--- a/nibabel/tests/test_fileholders.py
+++ b/nibabel/tests/test_fileholders.py
@@ -1,7 +1,7 @@
 """ Testing fileholders
 """
 
-from six import BytesIO
+from io import BytesIO
 
 
 from ..fileholders import FileHolder

--- a/nibabel/tests/test_files_interface.py
+++ b/nibabel/tests/test_files_interface.py
@@ -13,7 +13,7 @@
 import numpy as np
 
 from .. import Nifti1Image, Nifti1Pair, MGHImage, all_image_classes
-from six import BytesIO
+from io import BytesIO
 from ..fileholders import FileHolderError
 from ..spatialimages import SpatialImage
 

--- a/nibabel/tests/test_image_load_save.py
+++ b/nibabel/tests/test_image_load_save.py
@@ -8,7 +8,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 ''' Tests for loader function '''
 from __future__ import division, print_function, absolute_import
-from six import BytesIO
+from io import BytesIO
 
 import shutil
 from os.path import dirname, join as pjoin

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -18,7 +18,7 @@ from nibabel import nifti1 as nifti1
 from nibabel.affines import from_matvec
 from nibabel.casting import type_info, have_binary128
 from nibabel.eulerangles import euler2mat
-from six import BytesIO
+from io import BytesIO
 from nibabel.nifti1 import (load, Nifti1Header, Nifti1PairHeader, Nifti1Image,
                             Nifti1Pair, Nifti1Extension, Nifti1DicomExtension,
                             Nifti1Extensions, data_type_codes, extension_codes,

--- a/nibabel/tests/test_round_trip.py
+++ b/nibabel/tests/test_round_trip.py
@@ -5,7 +5,7 @@ Test arrays with a range of numerical values, integer and floating point.
 
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 from .. import Nifti1Image, Nifti1Header
 from ..spatialimages import HeaderDataError, supported_np_types
 from ..arraywriters import ScalingError

--- a/nibabel/tests/test_scaling.py
+++ b/nibabel/tests/test_scaling.py
@@ -11,7 +11,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 from ..volumeutils import (calculate_scale, scale_min_max, finite_range,
                            apply_read_scaling, array_to_file, array_from_file)
 from ..casting import type_info

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 from ..spatialimages import (SpatialHeader, SpatialImage, HeaderDataError,
                              Header, ImageDataError)
 

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -10,7 +10,7 @@
 import numpy as np
 import itertools
 
-from six import BytesIO
+from io import BytesIO
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal, dec
 

--- a/nibabel/tests/test_trackvis.py
+++ b/nibabel/tests/test_trackvis.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import numpy as np
 
-from six import BytesIO
+from io import BytesIO
 from .. import trackvis as tv
 from ..orientations import aff2axcodes
 from ..volumeutils import native_code, swapped_code

--- a/nibabel/tests/test_utils.py
+++ b/nibabel/tests/test_utils.py
@@ -12,7 +12,7 @@ from __future__ import division
 import os
 from os.path import exists
 
-from six import BytesIO
+from io import BytesIO
 import tempfile
 import warnings
 import functools

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -26,7 +26,8 @@ _field_recoders -> field_recoders
 import logging
 import numpy as np
 
-from six import BytesIO, StringIO
+from io import BytesIO
+from six import StringIO
 from ..wrapstruct import WrapStructError, WrapStruct, LabeledWrapStruct
 from ..batteryrunners import Report
 


### PR DESCRIPTION
```Python
>>> import nibabel
[...]/nibabel/cifti2/parse_cifti2.py:24: FutureWarning: We no longer carry a copy of the 'six' package in nibabel; Please import the 'six' package directly
  from ..externals.six import BytesIO
```

This PR also updates a bunch of `from six import BytesIO` imports I found while making sure that was the only thing still importing from `externals.six`.