### PR TITLE
BF: Fix Nifti1Header.get/set_intent for unknown intent codes

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1347,7 +1347,7 @@ class Nifti1Header(SpmAnalyzeHeader):
             defaults to ().  Unspecified parameters are set to 0.0
         name : string
             intent name (description). Defaults to ''
-        allow_unknown : bool
+        allow_unknown : {False, True}, optional
             Allow unknown integer intent codes. If False (the default),
             a KeyError is raised on attempts to set the intent
             to an unknown code.

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1375,6 +1375,8 @@ class Nifti1Header(SpmAnalyzeHeader):
         >>> hdr.get_intent()
         ('f test', (0.0, 0.0), '')
         >>> hdr.set_intent(9999, allow_unknown=True) # unknown code
+        >>> hdr.get_intent()
+        ('unknown code 9999', (), '')
         '''
         hdr = self._structarr
         known_intent = code in intent_codes

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1301,13 +1301,20 @@ class Nifti1Header(SpmAnalyzeHeader):
         hdr = self._structarr
         recoder = self._field_recoders['intent_code']
         code = int(hdr['intent_code'])
+        known_intent = code in recoder
         if code_repr == 'code':
             label = code
         elif code_repr == 'label':
-            label = recoder.label[code]
+            if known_intent:
+                label = recoder.label[code]
+            else:
+                label = ''
         else:
             raise TypeError('repr can be "label" or "code"')
-        n_params = len(recoder.parameters[code])
+        if known_intent:
+            n_params = len(recoder.parameters[code])
+        else:
+            n_params = 0
         params = (float(hdr['intent_p%d' % (i + 1)]) for i in range(n_params))
         name = asstr(np.asscalar(hdr['intent_name']))
         return label, tuple(params), name
@@ -1356,8 +1363,13 @@ class Nifti1Header(SpmAnalyzeHeader):
         ('f test', (0.0, 0.0), '')
         '''
         hdr = self._structarr
-        icode = intent_codes.code[code]
-        p_descr = intent_codes.parameters[code]
+        known_intent = code in intent_codes
+        if known_intent:
+            icode = intent_codes.code[code]
+            p_descr = intent_codes.parameters[code]
+        else:
+            icode = code
+            p_descr = 3
         if len(params) and len(params) != len(p_descr):
             raise HeaderDataError('Need params of form %s, or empty'
                                   % (p_descr,))

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -13,6 +13,7 @@ NIfTI1 format defined at http://nifti.nimh.nih.gov/nifti-1/
 from __future__ import division, print_function
 import warnings
 from io import BytesIO
+from six import string_types
 
 import numpy as np
 import numpy.linalg as npl
@@ -232,6 +233,17 @@ intent_codes = Recoder((
     (2003, 'rgb vector', (), "NIFTI_INTENT_RGB_VECTOR"),
     (2004, 'rgba vector', (), "NIFTI_INTENT_RGBA_VECTOR"),
     (2005, 'shape', (), "NIFTI_INTENT_SHAPE"),
+    # FSL-specific intent codes - FNIRT
+    (2006, 'fnirt disp field', (), 'FSL_FNIRT_DISPLACEMENT_FIELD'),
+    (2007, 'fnirt cubic spline coef', (), 'FSL_CUBIC_SPLINE_COEFFICIENTS'),
+    (2008, 'fnirt dct coef', (), 'FSL_DCT_COEFFICIENTS'),
+    (2009, 'fnirt quad spline coef', (), 'FSL_QUADRATIC_SPLINE_COEFFICIENTS'),
+    # FSL-specific intent codes - TOPUP
+    (2016, 'topup cubic spline coef ', (),
+     'FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS'),
+    (2017, 'topup quad spline coef', (),
+     'FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS'),
+    (2018, 'topup field', (), 'FSL_TOPUP_FIELD'),
 ), fields=('code', 'label', 'parameters', 'niistring'))
 
 
@@ -1308,18 +1320,15 @@ class Nifti1Header(SpmAnalyzeHeader):
             if known_intent:
                 label = recoder.label[code]
             else:
-                label = ''
+                label = 'unknown code ' + str(code)
         else:
             raise TypeError('repr can be "label" or "code"')
-        if known_intent:
-            n_params = len(recoder.parameters[code])
-        else:
-            n_params = 0
+        n_params = len(recoder.parameters[code]) if known_intent else 0
         params = (float(hdr['intent_p%d' % (i + 1)]) for i in range(n_params))
         name = asstr(np.asscalar(hdr['intent_name']))
         return label, tuple(params), name
 
-    def set_intent(self, code, params=(), name=''):
+    def set_intent(self, code, params=(), name='', allow_unknown=False):
         ''' Set the intent code, parameters and name
 
         If parameters are not specified, assumed to be all zero. Each
@@ -1338,6 +1347,10 @@ class Nifti1Header(SpmAnalyzeHeader):
             defaults to ().  Unspecified parameters are set to 0.0
         name : string
             intent name (description). Defaults to ''
+        allow_unknown : bool
+            Allow unknown integer intent codes. If False (the default),
+            a KeyError is raised on attempts to set the intent
+            to an unknown code.
 
         Returns
         -------
@@ -1346,7 +1359,7 @@ class Nifti1Header(SpmAnalyzeHeader):
         Examples
         --------
         >>> hdr = Nifti1Header()
-        >>> hdr.set_intent(0)  # unknown code
+        >>> hdr.set_intent(0)  # no intent
         >>> hdr.set_intent('z score')
         >>> hdr.get_intent()
         ('z score', (), '')
@@ -1361,15 +1374,21 @@ class Nifti1Header(SpmAnalyzeHeader):
         >>> hdr.set_intent('f test')
         >>> hdr.get_intent()
         ('f test', (0.0, 0.0), '')
+        >>> hdr.set_intent(9999, allow_unknown=True) # unknown code
         '''
         hdr = self._structarr
         known_intent = code in intent_codes
+        if not known_intent:
+            # We can set intent via an unknown integer code, but can't via an
+            # unknown string label
+            if not allow_unknown or isinstance(code, string_types):
+                raise KeyError('Unknown intent code: ' + str(code))
         if known_intent:
             icode = intent_codes.code[code]
             p_descr = intent_codes.parameters[code]
         else:
             icode = code
-            p_descr = 3
+            p_descr = ('p1', 'p2', 'p3')
         if len(params) and len(params) != len(p_descr):
             raise HeaderDataError('Need params of form %s, or empty'
                                   % (p_descr,))

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -233,12 +233,14 @@ intent_codes = Recoder((
     (2003, 'rgb vector', (), "NIFTI_INTENT_RGB_VECTOR"),
     (2004, 'rgba vector', (), "NIFTI_INTENT_RGBA_VECTOR"),
     (2005, 'shape', (), "NIFTI_INTENT_SHAPE"),
-    # FSL-specific intent codes - FNIRT
+    # FSL-specific intent codes - codes used by FNIRT
+    # ($FSLDIR/warpfns/fnirt_file_reader.h:104)
     (2006, 'fnirt disp field', (), 'FSL_FNIRT_DISPLACEMENT_FIELD'),
     (2007, 'fnirt cubic spline coef', (), 'FSL_CUBIC_SPLINE_COEFFICIENTS'),
     (2008, 'fnirt dct coef', (), 'FSL_DCT_COEFFICIENTS'),
     (2009, 'fnirt quad spline coef', (), 'FSL_QUADRATIC_SPLINE_COEFFICIENTS'),
-    # FSL-specific intent codes - TOPUP
+    # FSL-specific intent codes - codes used by TOPUP
+    # ($FSLDIR/topup/topup_file_io.h:104)
     (2016, 'topup cubic spline coef ', (),
      'FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS'),
     (2017, 'topup quad spline coef', (),

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1373,12 +1373,12 @@ class Nifti1Header(SpmAnalyzeHeader):
         if len(params) and len(params) != len(p_descr):
             raise HeaderDataError('Need params of form %s, or empty'
                                   % (p_descr,))
+        hdr['intent_code'] = icode
+        hdr['intent_name'] = name
         all_params = [0] * 3
         all_params[:len(params)] = params[:]
         for i, param in enumerate(all_params):
             hdr['intent_p%d' % (i + 1)] = param
-        hdr['intent_code'] = icode
-        hdr['intent_name'] = name
 
     def get_slice_duration(self):
         ''' Get slice duration

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -561,8 +561,12 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         ehdr.set_intent('t test', (10,), name='some score')
         assert_equal(ehdr.get_intent(),
                      ('t test', (10.0,), 'some score'))
-        # invalid intent name
-        assert_raises(ValueError, ehdr.set_intent, 'no intention')
+        # unknown intent name or code - unknown name will fail even when
+        # allow_unknown=True
+        assert_raises(KeyError, ehdr.set_intent, 'no intention')
+        assert_raises(KeyError, ehdr.set_intent, 'no intention',
+                      allow_unknown=True)
+        assert_raises(KeyError, ehdr.set_intent, 32767)
         # too many parameters
         assert_raises(HeaderDataError, ehdr.set_intent, 't test', (10, 10))
         # too few parameters
@@ -575,12 +579,23 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         ehdr.set_intent('t test', (10,))
         assert_equal((ehdr['intent_p2'], ehdr['intent_p3']), (0, 0))
         # store intent that is not in nifti1.intent_codes recoder
-        ehdr.set_intent(code=9999)
-        assert_equal(ehdr.get_intent(), ('', (), ''))
+        ehdr.set_intent(9999, allow_unknown=True)
+        assert_equal(ehdr.get_intent(), ('unknown code 9999', (), ''))
         assert_equal(ehdr.get_intent('code'), (9999, (), ''))
-        ehdr.set_intent(code=9999, name='custom intent')
-        assert_equal(ehdr.get_intent(), ('', (), 'custom intent'))
-        assert_equal(ehdr.get_intent('code'), (9999, (), 'custom intent')) 
+        ehdr.set_intent(9999, name='custom intent', allow_unknown=True)
+        assert_equal(ehdr.get_intent(),
+                     ('unknown code 9999', (), 'custom intent'))
+        assert_equal(ehdr.get_intent('code'), (9999, (), 'custom intent'))
+        # store unknown intent with parameters. set_intent will set the
+        # parameters, but get_intent won't return them
+        ehdr.set_intent(code=9999, params=(1, 2, 3), allow_unknown=True)
+        assert_equal(ehdr.get_intent(), ('unknown code 9999', (), ''))
+        assert_equal(ehdr.get_intent('code'), (9999, (), ''))
+        # unknown intent requires either zero, or three, parameters
+        assert_raises(HeaderDataError, ehdr.set_intent, 999, (1,),
+                      allow_unknown=True)
+        assert_raises(HeaderDataError, ehdr.set_intent, 999, (1,2),
+                      allow_unknown=True) 
 
     def test_set_slice_times(self):
         hdr = self.header_class()

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -562,7 +562,7 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         assert_equal(ehdr.get_intent(),
                      ('t test', (10.0,), 'some score'))
         # invalid intent name
-        assert_raises(KeyError, ehdr.set_intent, 'no intention')
+        assert_raises(ValueError, ehdr.set_intent, 'no intention')
         # too many parameters
         assert_raises(HeaderDataError, ehdr.set_intent, 't test', (10, 10))
         # too few parameters
@@ -574,6 +574,13 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         assert_equal(ehdr['intent_name'], b'')
         ehdr.set_intent('t test', (10,))
         assert_equal((ehdr['intent_p2'], ehdr['intent_p3']), (0, 0))
+        # store intent that is not in nifti1.intent_codes recoder
+        ehdr.set_intent(code=9999)
+        assert_equal(ehdr.get_intent(), ('', (), ''))
+        assert_equal(ehdr.get_intent('code'), (9999, (), ''))
+        ehdr.set_intent(code=9999, name='custom intent')
+        assert_equal(ehdr.get_intent(), ('', (), 'custom intent'))
+        assert_equal(ehdr.get_intent('code'), (9999, (), 'custom intent')) 
 
     def test_set_slice_times(self):
         hdr = self.header_class()


### PR DESCRIPTION
The `nibabel.nifti1.Nifti1Header.get_intent` and `set_intent` methods fail for intent codes which are not listed in `nibabel.nifti1.intent_codes`. For example:

```
In [1]: import nibabel as nib
   ...: import numpy   as np
   ...:
   ...: data = np.random.random((10, 10, 10))
   ...: xform = np.eye(4)
   ...:
   ...: img = nib.nifti1.Nifti1Image(data, xform)
   ...: hdr = img.header
   ...:
   ...: # Getting/setting the intent code directly works fine
   ...: hdr['intent_code'] = 2006
   ...: print(hdr['intent_code'])
   ...:
2006

In [2]: print(hdr.get_intent())
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-b920d8c34544> in <module>()
----> 1 print(hdr.get_intent())

/Users/paulmc/Projects/nibabel/nibabel/nifti1.pyc in get_intent(self, code_repr)
   1305             label = code
   1306         elif code_repr == 'label':
-> 1307             label = recoder.label[code]
   1308         else:
   1309             raise TypeError('repr can be "label" or "code"')

KeyError: 2006

In [3]: hdr.set_intent(2006)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-c617589adad8> in <module>()
----> 1 hdr.set_intent(2006)

/Users/paulmc/Projects/nibabel/nibabel/nifti1.pyc in set_intent(self, code, params, name)
   1357         '''
   1358         hdr = self._structarr
-> 1359         icode = intent_codes.code[code]
   1360         p_descr = intent_codes.parameters[code]
   1361         if len(params) and len(params) != len(p_descr):

KeyError: 2006
```
