### PR TITLE
Improve error handling for `img.__getitem__`

### DIFF
--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -656,7 +656,7 @@ class SpatialImage(FileBasedImage):
                      klass.header_class.from_header(img.header),
                      extra=img.extra.copy())
 
-    def __getitem__(self):
+    def __getitem__(self, idx=None):
         ''' No slicing or dictionary interface for images
         '''
         raise TypeError("Cannot slice image objects; consider slicing image "

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -656,7 +656,7 @@ class SpatialImage(FileBasedImage):
                      klass.header_class.from_header(img.header),
                      extra=img.extra.copy())
 
-    def __getitem__(self, idx=None):
+    def __getitem__(self, idx):
         ''' No slicing or dictionary interface for images
         '''
         raise TypeError("Cannot slice image objects; consider slicing image "

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -315,12 +315,11 @@ class TestSpatialImage(TestCase):
         # Can't slice into the image object:
         with assert_raises(TypeError) as exception_manager:
             img[0, 0, 0]
-
+        # Make sure the right message gets raised:
         assert_equal(str(exception_manager.exception),
                      ("Cannot slice image objects; consider slicing image "
                       "array data with `img.dataobj[slice]` or "
                       "`img.get_data()[slice]`"))
-
         assert_true(in_data is img.dataobj)
         out_data = img.get_data()
         assert_true(in_data is out_data)

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -312,6 +312,15 @@ class TestSpatialImage(TestCase):
         in_data_template = np.arange(24, dtype=np.int16).reshape((2, 3, 4))
         in_data = in_data_template.copy()
         img = img_klass(in_data, None)
+        # Can't slice into the image object:
+        with assert_raises(TypeError) as exception_manager:
+            img[0, 0, 0]
+
+        assert_equal(str(exception_manager.exception),
+                     ("Cannot slice image objects; consider slicing image "
+                      "array data with `img.dataobj[slice]` or "
+                      "`img.get_data()[slice]`"))
+
         assert_true(in_data is img.dataobj)
         out_data = img.get_data()
         assert_true(in_data is out_data)


### PR DESCRIPTION
Usually, when using `__getitem__`, one passes an index/slice to the function. In the current implementation, this would raise the relatively cryptic: 

    TypeError: __getitem__() takes 1 positional argument but 2 were given

And the much more explanatory error message implemented in `__getitem__` would remain unraised. 

My proposal: implement an `idx` kwarg here, so that indexing gets through to the error message. I also implemented a test (and learned a few things about `assert_raises` along the way!). 