### PR TITLE
BF: always save data in <f4

### DIFF
--- a/nibabel/streamlines/tck.py
+++ b/nibabel/streamlines/tck.py
@@ -220,8 +220,7 @@ class TckFile(TractogramFile):
             tractogram = self.tractogram.to_world(lazy=True)
 
             for t in tractogram:
-                s = t.streamline
-                data = np.r_[s, self.FIBER_DELIMITER]
+                data = np.r_[t.streamline, self.FIBER_DELIMITER]
                 f.write(data.astype(dtype).tostring())
                 nb_streamlines += 1
 

--- a/nibabel/streamlines/tck.py
+++ b/nibabel/streamlines/tck.py
@@ -220,9 +220,9 @@ class TckFile(TractogramFile):
             tractogram = self.tractogram.to_world(lazy=True)
 
             for t in tractogram:
-                s = t.streamline.astype(dtype)
+                s = t.streamline
                 data = np.r_[s, self.FIBER_DELIMITER]
-                f.write(data.tostring())
+                f.write(data.astype(dtype).tostring())
                 nb_streamlines += 1
 
             header[Field.NB_STREAMLINES] = nb_streamlines


### PR DESCRIPTION
Fixes #543 
It seems that index trick `np.r_[...]` (for arrays concatenation) results in an array that has the same endianness of the system without any regard to the endianness of the arrays to be concatenated.

For instance, on a little-endian system:
```
In [1]: import numpy as np
In [2]: A = np.array([1,2,3], dtype=">f4")
In [3]: B = np.array([1,2,3], dtype=">f4")
In [4]: np.r_[A, B].dtype
Out[4]: dtype('float32')
In [5]: np.r_[A, B].dtype.byteorder
Out[5]: '='
```