### PR TITLE
Conditionally use indexed_gzip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 env:
     global:
         - DEPENDS="six numpy scipy matplotlib h5py pillow"
+        - OPTIONAL_DEPENDS=""
         - PYDICOM=1
         - INSTALL_TYPE="setup"
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -84,6 +85,13 @@ matrix:
     - python: 3.5
       env:
         - DOC_DOC_TEST=1
+    # Run tests with indexed_gzip present
+    - python: 2.7
+      env:
+        - OPTIONAL_DEPENDS="indexed_gzip"
+    - python: 3.5
+      env:
+        - OPTIONAL_DEPENDS="indexed_gzip"
 before_install:
     - source tools/travis_tools.sh
     - python -m pip install --upgrade pip
@@ -93,7 +101,7 @@ before_install:
     - python --version # just to check
     - pip install -U pip wheel  # needed at one point
     - retry pip install nose flake8 mock  # always
-    - pip install $EXTRA_PIP_FLAGS $DEPENDS
+    - pip install $EXTRA_PIP_FLAGS $DEPENDS $OPTIONAL_DEPENDS
     # pydicom <= 0.9.8 doesn't install on python 3
     - if [ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]; then
         if [ "$PYDICOM" == "1" ]; then

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -959,8 +959,8 @@ class AnalyzeImage(SpatialImage):
             ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_like`` is an
-            open file handle, this setting has no effect.
+            same as if ``keep_file_open is False``. If ``file_map`` refers
+            to an open file handle, this setting has no effect.
 
         Returns
         -------
@@ -1011,8 +1011,7 @@ class AnalyzeImage(SpatialImage):
             ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_like`` is an
-            open file handle, this setting has no effect.
+            same as if ``keep_file_open is False``.
 
         Returns
         -------

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -934,7 +934,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open=False):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open='indexed'):
         ''' class method to create image from mapping in `file_map ``
 
         Parameters
@@ -950,11 +950,17 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open: If ``file_like`` is a file name, the default behaviour
-            is to open a new file handle every time the data is accessed. If
-            this flag is set to `True``, the file handle will be opened on the
-            first access, and kept open until this ``ArrayProxy`` is garbage-
-            collected.
+        keep_file_open : { 'indexed', True, False }, optional, keyword only
+            `keep_file_open` controls whether a new file handle is created
+            every time the image is accessed, or a single file handle is
+            created and used for the lifetime of this ``ArrayProxy``. If
+            ``True``, a single file handle is created and used. If ``False``,
+            a new file handle is created every time the image is accessed. If
+            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            dependency is present, a single file handle is created and
+            persisted. If ``indexed_gzip`` is not available, behaviour is the
+            same as if ``keep_file_open is False``. If ``file_like`` is an
+            open file handle, this setting has no effect.
 
         Returns
         -------
@@ -982,7 +988,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True, keep_file_open=False):
+    def from_filename(klass, filename, mmap=True, keep_file_open='indexed'):
         ''' class method to create image from filename `filename`
 
         Parameters
@@ -996,11 +1002,17 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open: If ``file_like`` is a file name, the default behaviour
-            is to open a new file handle every time the data is accessed. If
-            this flag is set to `True``, the file handle will be opened on the
-            first access, and kept open until this ``ArrayProxy`` is garbage-
-            collected.
+        keep_file_open : { 'indexed', True, False }, optional, keyword only
+            `keep_file_open` controls whether a new file handle is created
+            every time the image is accessed, or a single file handle is
+            created and used for the lifetime of this ``ArrayProxy``. If
+            ``True``, a single file handle is created and used. If ``False``,
+            a new file handle is created every time the image is accessed. If
+            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            dependency is present, a single file handle is created and
+            persisted. If ``indexed_gzip`` is not available, behaviour is the
+            same as if ``keep_file_open is False``. If ``file_like`` is an
+            open file handle, this setting has no effect.
 
         Returns
         -------

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -950,7 +950,7 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -960,8 +960,9 @@ class AnalyzeImage(SpatialImage):
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
             ``keep_file_open is False``. If ``file_map`` refers to an open
-            file handle, this setting has no effect. The default value is
-            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
+            file handle, this setting has no effect. The default value
+            (``None``) will result in the value of
+            ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT`` being used.
 
         Returns
         -------
@@ -1003,8 +1004,7 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -1013,8 +1013,9 @@ class AnalyzeImage(SpatialImage):
             ``'auto'``, and the optional ``indexed_gzip`` dependency is
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
-            ``keep_file_open is False``. The default value is set to the value
-            of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
+            ``keep_file_open is False``. The default value (``None``) will
+            result in the value of
+            ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT`` being used.
 
         Returns
         -------

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -934,8 +934,8 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
-        ''' class method to create image from mapping in `file_map ``
+    def from_file_map(klass, file_map, mmap=True, keep_file_open=None):
+        '''class method to create image from mapping in `file_map ``
 
         Parameters
         ----------
@@ -956,11 +956,12 @@ class AnalyzeImage(SpatialImage):
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_map`` refers
-            to an open file handle, this setting has no effect.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. If ``file_map`` refers to an open
+            file handle, this setting has no effect. The default value is
+            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
 
         Returns
         -------
@@ -988,8 +989,8 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True, keep_file_open='auto'):
-        ''' class method to create image from filename `filename`
+    def from_filename(klass, filename, mmap=True, keep_file_open=None):
+        '''class method to create image from filename `filename`
 
         Parameters
         ----------
@@ -1002,16 +1003,18 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+
         keep_file_open : { 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. The default value is set to the value
+            of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
 
         Returns
         -------

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -934,7 +934,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open='indexed'):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
         ''' class method to create image from mapping in `file_map ``
 
         Parameters
@@ -950,13 +950,13 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'indexed', True, False }, optional, keyword only
+        keep_file_open : { 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
             same as if ``keep_file_open is False``. If ``file_like`` is an
@@ -988,7 +988,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True, keep_file_open='indexed'):
+    def from_filename(klass, filename, mmap=True, keep_file_open='auto'):
         ''' class method to create image from filename `filename`
 
         Parameters
@@ -1002,13 +1002,13 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'indexed', True, False }, optional, keyword only
+        keep_file_open : { 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
             same as if ``keep_file_open is False``. If ``file_like`` is an

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -934,7 +934,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open=False):
         ''' class method to create image from mapping in `file_map ``
 
         Parameters
@@ -950,6 +950,11 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+        keep_file_open: If ``file_like`` is a file name, the default behaviour
+            is to open a new file handle every time the data is accessed. If
+            this flag is set to `True``, the file handle will be opened on the
+            first access, and kept open until this ``ArrayProxy`` is garbage-
+            collected.
 
         Returns
         -------
@@ -964,7 +969,8 @@ class AnalyzeImage(SpatialImage):
         imgf = img_fh.fileobj
         if imgf is None:
             imgf = img_fh.filename
-        data = klass.ImageArrayProxy(imgf, hdr_copy, mmap=mmap)
+        data = klass.ImageArrayProxy(imgf, hdr_copy, mmap=mmap,
+                                     keep_file_open=keep_file_open)
         # Initialize without affine to allow header to pass through unmodified
         img = klass(data, None, header, file_map=file_map)
         # set affine from header though
@@ -976,7 +982,7 @@ class AnalyzeImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True):
+    def from_filename(klass, filename, mmap=True, keep_file_open=False):
         ''' class method to create image from filename `filename`
 
         Parameters
@@ -990,6 +996,11 @@ class AnalyzeImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+        keep_file_open: If ``file_like`` is a file name, the default behaviour
+            is to open a new file handle every time the data is accessed. If
+            this flag is set to `True``, the file handle will be opened on the
+            first access, and kept open until this ``ArrayProxy`` is garbage-
+            collected.
 
         Returns
         -------
@@ -998,7 +1009,8 @@ class AnalyzeImage(SpatialImage):
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
         file_map = klass.filespec_to_file_map(filename)
-        return klass.from_file_map(file_map, mmap=mmap)
+        return klass.from_file_map(file_map, mmap=mmap,
+                                   keep_file_open=keep_file_open)
 
     load = from_filename
 

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -138,10 +138,20 @@ class ArrayProxy(object):
         '''If this ``ArrayProxy`` was created with ``keep_file_open=True``,
         the open file object is closed if necessary.
         '''
-        if self._keep_file_open and hasattr(self, '_opener'):
-            if not self._opener.closed:
-                self._opener.close()
-                self._opener = None
+        if hasattr(self, '_opener') and not self._opener.closed:
+            self._opener.close()
+            self._opener = None
+
+    def __getstate__(self):
+        '''Returns the state of this ``ArrayProxy`` during pickling. '''
+        state = self.__dict__.copy()
+        state.pop('_lock', None)
+        return state
+
+    def __setstate__(self, state):
+        '''Sets the state of this ``ArrayProxy`` during unpickling. '''
+        self.__dict__.update(state)
+        self._lock = Lock()
 
     @property
     @deprecate_with_version('ArrayProxy.header deprecated', '2.2', '3.0')

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -139,7 +139,7 @@ class ArrayProxy(object):
         the open file object is closed if necessary.
         """
         if hasattr(self, '_opener') and not self._opener.closed:
-            self._opener.close()
+            self._opener.close_if_mine()
             self._opener = None
 
     def __getstate__(self):

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -186,13 +186,16 @@ class ArrayProxy(object):
         The value of ``keep_file_open`` that will be used by this
         ``ArrayProxy``.
         """
+        # if keep_file_open is True/False, we do what the user wants us to do
+        if isinstance(keep_file_open, bool):
+            return keep_file_open
+        if keep_file_open != 'auto':
+            raise ValueError(
+                'keep_file_open should be one of {\'auto\', True, False }')
 
         # file_like is a handle - keep_file_open is irrelevant
         if hasattr(file_like, 'read') and hasattr(file_like, 'seek'):
             return False
-        # if keep_file_open is True/False, we do what the user wants us to do
-        if keep_file_open != 'auto':
-            return bool(keep_file_open)
         # Otherwise, if file_like is gzipped, and we have_indexed_gzip, we set
         # keep_file_open to True, else we set it to False
         return HAVE_INDEXED_GZIP and file_like.endswith('gz')

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -135,21 +135,21 @@ class ArrayProxy(object):
         self._lock = Lock()
 
     def __del__(self):
-        '''If this ``ArrayProxy`` was created with ``keep_file_open=True``,
+        """If this ``ArrayProxy`` was created with ``keep_file_open=True``,
         the open file object is closed if necessary.
-        '''
+        """
         if hasattr(self, '_opener') and not self._opener.closed:
             self._opener.close()
             self._opener = None
 
     def __getstate__(self):
-        '''Returns the state of this ``ArrayProxy`` during pickling. '''
+        """Returns the state of this ``ArrayProxy`` during pickling. """
         state = self.__dict__.copy()
         state.pop('_lock', None)
         return state
 
     def __setstate__(self, state):
-        '''Sets the state of this ``ArrayProxy`` during unpickling. '''
+        """Sets the state of this ``ArrayProxy`` during unpickling. """
         self.__dict__.update(state)
         self._lock = Lock()
 
@@ -184,10 +184,18 @@ class ArrayProxy(object):
 
     @contextmanager
     def _get_fileobj(self):
-        '''Create and return a new ``ImageOpener``, or return an existing one.
-        one. The specific behaviour depends on the value of the
-        ``keep_file_open`` flag that was passed to ``__init__``.
-        '''
+        """Create and return a new ``ImageOpener``, or return an existing one.
+
+        The specific behaviour depends on the value of the ``keep_file_open``
+        flag that was passed to ``__init__``.
+
+
+        Yields
+        ------
+        ImageOpener
+            A newly created ``ImageOpener`` instance, or an existing one,
+            which provides access to the file.
+        """
         if self._keep_file_open:
             if not hasattr(self, '_opener'):
                 self._opener = ImageOpener(self.file_like)
@@ -197,10 +205,10 @@ class ArrayProxy(object):
                 yield opener
 
     def get_unscaled(self):
-        ''' Read of data from file
+        """ Read of data from file
 
         This is an optional part of the proxy API
-        '''
+        """
         with self._get_fileobj() as fileobj:
             raw_data = array_from_file(self._shape,
                                        self._dtype,
@@ -228,7 +236,7 @@ class ArrayProxy(object):
         return apply_read_scaling(raw_data, self._slope, self._inter)
 
     def reshape(self, shape):
-        ''' Return an ArrayProxy with a new shape, without modifying data '''
+        """ Return an ArrayProxy with a new shape, without modifying data """
         size = np.prod(self._shape)
 
         # Calculate new shape if not fully specified

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -34,7 +34,7 @@ from .deprecated import deprecate_with_version
 from .volumeutils import array_from_file, apply_read_scaling
 from .fileslice import fileslice
 from .keywordonly import kw_only_meth
-from .openers import ImageOpener
+from .openers import ImageOpener, HAVE_INDEXED_GZIP
 
 
 class ArrayProxy(object):
@@ -195,13 +195,7 @@ class ArrayProxy(object):
             return bool(keep_file_open)
         # Otherwise, if file_like is gzipped, and we have_indexed_gzip, we set
         # keep_file_open to True, else we set it to False
-        try:
-            import indexed_gzip
-            have_indexed_gzip = True
-        except ImportError:
-            have_indexed_gzip = False
-
-        return have_indexed_gzip and file_like.endswith('gz')
+        return HAVE_INDEXED_GZIP and file_like.endswith('gz')
 
     @property
     @deprecate_with_version('ArrayProxy.header deprecated', '2.2', '3.0')
@@ -259,7 +253,7 @@ class ArrayProxy(object):
 
         This is an optional part of the proxy API
         """
-        with self._get_fileobj() as fileobj:
+        with self._get_fileobj() as fileobj, self._lock:
             raw_data = array_from_file(self._shape,
                                        self._dtype,
                                        fileobj,

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -37,7 +37,6 @@ from .keywordonly import kw_only_meth
 from .openers import ImageOpener, HAVE_INDEXED_GZIP
 
 
-KEEP_FILE_OPEN_DEFAULT = False
 """This flag controls whether a new file handle is created every time an image
 is accessed through an ``ArrayProxy``, or a single file handle is created and
 used for the lifetime of the ``ArrayProxy``. It should be set to one of
@@ -53,6 +52,7 @@ If this is set to any other value, attempts to create an ``ArrayProxy`` without
 specifying the ``keep_file_open`` flag will result in a ``ValueError`` being
 raised.
 """
+KEEP_FILE_OPEN_DEFAULT = False
 
 
 class ArrayProxy(object):

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -37,6 +37,24 @@ from .keywordonly import kw_only_meth
 from .openers import ImageOpener, HAVE_INDEXED_GZIP
 
 
+KEEP_FILE_OPEN_DEFAULT = False
+"""This flag controls whether a new file handle is created every time an image
+is accessed through an ``ArrayProxy``, or a single file handle is created and
+used for the lifetime of the ``ArrayProxy``. It should be set to one of
+``True``, ``False``, or ``'auto'``.
+
+If ``True``, a single file handle is created and used. If ``False``, a new
+file handle is created every time the image is accessed. If ``'auto'``, and
+the optional ``indexed_gzip`` dependency is present, a single file handle is
+created and persisted. If ``indexed_gzip`` is not available, behaviour is the
+same as if ``keep_file_open is False``.
+
+If this is set to any other value, attempts to create an ``ArrayProxy`` without
+specifying the ``keep_file_open`` flag will result in a ``ValueError`` being
+raised.
+"""
+
+
 class ArrayProxy(object):
     """ Class to act as proxy for the array that can be read from a file
 
@@ -72,7 +90,7 @@ class ArrayProxy(object):
     _header = None
 
     @kw_only_meth(2)
-    def __init__(self, file_like, spec, mmap=True, keep_file_open='auto'):
+    def __init__(self, file_like, spec, mmap=True, keep_file_open=None):
         """Initialize array proxy instance
 
         Parameters
@@ -108,11 +126,12 @@ class ArrayProxy(object):
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_like`` is an
-            open file handle, this setting has no effect.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. If ``file_like`` is an open file
+            handle, this setting has no effect. The default value is set to
+            the value of ``KEEP_FILE_OPEN_DEFAULT``.
         """
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
@@ -186,6 +205,8 @@ class ArrayProxy(object):
         The value of ``keep_file_open`` that will be used by this
         ``ArrayProxy``.
         """
+        if keep_file_open is None:
+            keep_file_open = KEEP_FILE_OPEN_DEFAULT
         # if keep_file_open is True/False, we do what the user wants us to do
         if isinstance(keep_file_open, bool):
             return keep_file_open

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -72,7 +72,7 @@ class ArrayProxy(object):
     _header = None
 
     @kw_only_meth(2)
-    def __init__(self, file_like, spec, mmap=True, keep_file_open='indexed'):
+    def __init__(self, file_like, spec, mmap=True, keep_file_open='auto'):
         """Initialize array proxy instance
 
         Parameters
@@ -102,13 +102,13 @@ class ArrayProxy(object):
             True gives the same behavior as ``mmap='c'``.  If `file_like`
             cannot be memory-mapped, ignore `mmap` value and read array from
             file.
-        keep_file_open : { 'indexed', True, False }, optional, keyword only
+        keep_file_open : { 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
             same as if ``keep_file_open is False``. If ``file_like`` is an
@@ -177,7 +177,7 @@ class ArrayProxy(object):
 
         file_like : object
             File-like object or filename, as passed to ``__init__``.
-        keep_file_open : { 'indexed', True, False }
+        keep_file_open : { 'auto', True, False }
             Flag as passed to ``__init__``.
 
         Returns
@@ -191,7 +191,7 @@ class ArrayProxy(object):
         if hasattr(file_like, 'read') and hasattr(file_like, 'seek'):
             return False
         # if keep_file_open is True/False, we do what the user wants us to do
-        if keep_file_open != 'indexed':
+        if keep_file_open != 'auto':
             return bool(keep_file_open)
         # Otherwise, if file_like is gzipped, and we have_indexed_gzip, we set
         # keep_file_open to True, else we set it to False

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -120,7 +120,7 @@ class ArrayProxy(object):
             True gives the same behavior as ``mmap='c'``.  If `file_like`
             cannot be memory-mapped, ignore `mmap` value and read array from
             file.
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -130,8 +130,8 @@ class ArrayProxy(object):
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
             ``keep_file_open is False``. If ``file_like`` is an open file
-            handle, this setting has no effect. The default value is set to
-            the value of ``KEEP_FILE_OPEN_DEFAULT``.
+            handle, this setting has no effect. The default value (``None``)
+            will result in the value of ``KEEP_FILE_OPEN_DEFAULT`` being used.
         """
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
@@ -211,8 +211,8 @@ class ArrayProxy(object):
         if isinstance(keep_file_open, bool):
             return keep_file_open
         if keep_file_open != 'auto':
-            raise ValueError(
-                'keep_file_open should be one of {\'auto\', True, False }')
+            raise ValueError('keep_file_open should be one of {None, '
+                             '\'auto\', True, False}')
 
         # file_like is a handle - keep_file_open is irrelevant
         if hasattr(file_like, 'read') and hasattr(file_like, 'seek'):
@@ -256,7 +256,6 @@ class ArrayProxy(object):
 
         The specific behaviour depends on the value of the ``keep_file_open``
         flag that was passed to ``__init__``.
-
 
         Yields
         ------

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -1,7 +1,6 @@
 """ Utilities for getting array slices out of file-like objects
 """
 from __future__ import division
-from contextlib import contextmanager
 
 import operator
 from numbers import Integral
@@ -648,10 +647,12 @@ def read_segments(fileobj, segments, n_bytes, lock=None):
     """
     # Make a dummy lock-like thing to make the code below a bit nicer
     if lock is None:
-        @contextmanager
-        def dummy_lock():
-            yield
-        lock = dummy_lock
+        class DummyLock(object):
+            def __enter__(self):
+                pass
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return False
+        lock = DummyLock()
 
     if len(segments) == 0:
         if n_bytes != 0:

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -17,6 +17,21 @@ import numpy as np
 SKIP_THRESH = 2 ** 8
 
 
+
+class _NullLock(object):
+    """The ``_NullLock`` is an object which can be used in place of a
+    ``threading.Lock`` object, but doesn't actually do anything.
+
+    It is used by the ``read_segments`` function in the event that a
+    ``Lock`` is not provided by the caller.
+    """
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
 def is_fancy(sliceobj):
     """ Returns True if sliceobj is attempting fancy indexing
 
@@ -647,17 +662,9 @@ def read_segments(fileobj, segments, n_bytes, lock=None):
         object implementing buffer protocol, such as byte string or ndarray or
         mmap or ctypes ``c_char_array``
     """
-    # Make a dummy lock-like thing to make the code below a bit nicer
+    # Make a lock-like thing to make the code below a bit nicer
     if lock is None:
-
-        class DummyLock(object):
-            def __enter__(self):
-                pass
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                return False
-
-        lock = DummyLock()
+        lock = _NullLock()
 
     if len(segments) == 0:
         if n_bytes != 0:

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -637,7 +637,9 @@ def read_segments(fileobj, segments, n_bytes, lock=None):
     lock : threading.Lock
         If provided, used to ensure that paired calls to ``seek`` and ``read``
         cannot be interrupted by another thread accessing the same ``fileobj``.
-
+        Each thread which accesses the same file via ``read_segments`` must
+        share a lock in order to ensure that the file access is thread-safe.
+        A lock does not need to be provided for single-threaded access.
 
     Returns
     -------
@@ -647,11 +649,14 @@ def read_segments(fileobj, segments, n_bytes, lock=None):
     """
     # Make a dummy lock-like thing to make the code below a bit nicer
     if lock is None:
+
         class DummyLock(object):
             def __enter__(self):
                 pass
+
             def __exit__(self, exc_type, exc_val, exc_tb):
                 return False
+
         lock = DummyLock()
 
     if len(segments) == 0:

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -17,7 +17,6 @@ import numpy as np
 SKIP_THRESH = 2 ** 8
 
 
-
 class _NullLock(object):
     """The ``_NullLock`` is an object which can be used in place of a
     ``threading.Lock`` object, but doesn't actually do anything.

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -476,7 +476,7 @@ class MGHImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
         '''Load image from `file_map`
 
         Parameters
@@ -491,6 +491,17 @@ class MGHImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+        keep_file_open : { 'auto', True, False }, optional, keyword only
+            `keep_file_open` controls whether a new file handle is created
+            every time the image is accessed, or a single file handle is
+            created and used for the lifetime of this ``ArrayProxy``. If
+            ``True``, a single file handle is created and used. If ``False``,
+            a new file handle is created every time the image is accessed. If
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
+            dependency is present, a single file handle is created and
+            persisted. If ``indexed_gzip`` is not available, behaviour is the
+            same as if ``keep_file_open is False``. If ``file_map`` refers to
+            an open file handle, this setting has no effect.
         '''
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
@@ -500,7 +511,8 @@ class MGHImage(SpatialImage):
         affine = header.get_affine()
         hdr_copy = header.copy()
         # Pass original image fileobj / filename to array proxy
-        data = klass.ImageArrayProxy(img_fh.file_like, hdr_copy, mmap=mmap)
+        data = klass.ImageArrayProxy(img_fh.file_like, hdr_copy, mmap=mmap,
+                                     keep_file_open=keep_file_open)
         img = klass(data, affine, header, file_map=file_map)
         img._load_cache = {'header': hdr_copy,
                            'affine': affine.copy(),
@@ -509,7 +521,7 @@ class MGHImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True):
+    def from_filename(klass, filename, mmap=True, keep_file_open='auto'):
         ''' class method to create image from filename `filename`
 
         Parameters
@@ -523,6 +535,16 @@ class MGHImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+        keep_file_open : { 'auto', True, False }, optional, keyword only
+            `keep_file_open` controls whether a new file handle is created
+            every time the image is accessed, or a single file handle is
+            created and used for the lifetime of this ``ArrayProxy``. If
+            ``True``, a single file handle is created and used. If ``False``,
+            a new file handle is created every time the image is accessed. If
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
+            dependency is present, a single file handle is created and
+            persisted. If ``indexed_gzip`` is not available, behaviour is the
+            same as if ``keep_file_open is False``.
 
         Returns
         -------
@@ -531,7 +553,8 @@ class MGHImage(SpatialImage):
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
         file_map = klass.filespec_to_file_map(filename)
-        return klass.from_file_map(file_map, mmap=mmap)
+        return klass.from_file_map(file_map, mmap=mmap,
+                                   keep_file_open=keep_file_open)
 
     load = from_filename
 

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -491,7 +491,7 @@ class MGHImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -501,8 +501,9 @@ class MGHImage(SpatialImage):
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
             ``keep_file_open is False``. If ``file_map`` refers to an open
-            file handle, this setting has no effect. The default value is
-            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
+            file handle, this setting has no effect. The default value
+            (``None``) will result in the value of
+            ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT`` being used.
         '''
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
@@ -536,7 +537,7 @@ class MGHImage(SpatialImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -545,8 +546,9 @@ class MGHImage(SpatialImage):
             ``'auto'``, and the optional ``indexed_gzip`` dependency is
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
-            ``keep_file_open is False``. The default value is set to the value
-            of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
+            ``keep_file_open is False``. The default value (``None``) will
+            result in the value of
+            ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT`` being used.
 
         Returns
         -------

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -476,7 +476,7 @@ class MGHImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open=None):
         '''Load image from `file_map`
 
         Parameters
@@ -497,11 +497,12 @@ class MGHImage(SpatialImage):
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_map`` refers to
-            an open file handle, this setting has no effect.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. If ``file_map`` refers to an open
+            file handle, this setting has no effect. The default value is
+            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
         '''
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
@@ -521,8 +522,8 @@ class MGHImage(SpatialImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_filename(klass, filename, mmap=True, keep_file_open='auto'):
-        ''' class method to create image from filename `filename`
+    def from_filename(klass, filename, mmap=True, keep_file_open=None):
+        '''class method to create image from filename `filename`
 
         Parameters
         ----------
@@ -541,10 +542,11 @@ class MGHImage(SpatialImage):
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. The default value is set to the value
+            of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
 
         Returns
         -------

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -18,7 +18,7 @@ from os.path import splitext
 try:
     from indexed_gzip import SafeIndexedGzipFile
     HAVE_INDEXED_GZIP = True
-except:
+except ImportError:
     HAVE_INDEXED_GZIP = False
 
 

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -70,8 +70,8 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
         have_indexed_gzip = False
 
     # is this a file? if not we assume it is a string
-    is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write') and \
-              hasattr(fileish, 'mode')
+    is_file = (hasattr(fileish, 'read') and hasattr(fileish, 'write') and
+               hasattr(fileish, 'mode')
 
     # If we've been given a file object, we can't change its mode.
     if is_file:
@@ -79,7 +79,7 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
 
     # use indexed_gzip if possible for faster read access
     if mode == 'rb' and have_indexed_gzip:
-        kwargs = {'spacing' : 4194304, 'readbuf_size' : 1048576}
+        kwargs = {'spacing':4194304, 'readbuf_size':1048576}
         if hasattr(fileish, 'read') and hasattr(fileish, 'write'):
             gzip_file = SafeIndexedGzipFile(fid=fileish, **kwargs)
         else:

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -73,7 +73,7 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
     is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write') and \
               hasattr(fileish, 'mode')
     if is_file:
-        mode = file.mode
+        mode = fileish.mode
 
     # use indexed_gzip if possible for faster read access
     if mode == 'rb' and have_indexed_gzip:

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -14,6 +14,13 @@ import gzip
 import sys
 from os.path import splitext
 
+# is indexed_gzip present?
+try:
+    from indexed_gzip import SafeIndexedGzipFile
+    HAVE_INDEXED_GZIP = True
+except:
+    HAVE_INDEXED_GZIP = False
+
 
 # The largest memory chunk that gzip can use for reads
 GZIP_MAX_READ_CHUNK = 100 * 1024 * 1024  # 100Mb
@@ -62,13 +69,6 @@ class BufferedGzipFile(gzip.GzipFile):
 
 def _gzip_open(fileish, mode='rb', compresslevel=9):
 
-    # is indexed_gzip present?
-    try:
-        from indexed_gzip import SafeIndexedGzipFile
-        have_indexed_gzip = True
-    except:
-        have_indexed_gzip = False
-
     # is this a file? if not we assume it is a string
     is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write')
 
@@ -77,7 +77,7 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
         mode = fileish.mode
 
     # use indexed_gzip if possible for faster read access
-    if mode == 'rb' and have_indexed_gzip:
+    if mode == 'rb' and HAVE_INDEXED_GZIP:
         if is_file:
             gzip_file = SafeIndexedGzipFile(fid=fileish)
         else:

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -67,26 +67,16 @@ class BufferedGzipFile(gzip.GzipFile):
             return n_read
 
 
-def _gzip_open(fileish, mode='rb', compresslevel=9):
-
-    # is this a file? if not we assume it is a string
-    is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write')
-
-    # If we've been given a file object, we can't change its mode.
-    if is_file and hasattr(fileish, 'mode'):
-        mode = fileish.mode
+def _gzip_open(filename, mode='rb', compresslevel=9):
 
     # use indexed_gzip if possible for faster read access
     if mode == 'rb' and HAVE_INDEXED_GZIP:
-        if is_file:
-            gzip_file = SafeIndexedGzipFile(fid=fileish)
-        else:
-            gzip_file = SafeIndexedGzipFile(filename=fileish)
+        gzip_file = SafeIndexedGzipFile(filename)
 
     # Fall-back to built-in GzipFile (wrapped with the BufferedGzipFile class
     # defined above)
     else:
-        gzip_file = BufferedGzipFile(fileish, mode, compresslevel)
+        gzip_file = BufferedGzipFile(filename, mode, compresslevel)
 
     # Speedup for #209, for versions of python < 3.5. Open gzip files with
     # faster reads on large files using a larger read buffer. See

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -90,10 +90,10 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
     else:
         gzip_file = BufferedGzipFile(fileish, mode, compresslevel)
 
-    # Speedup for #209; attribute not present in in Python 3.5
-    # open gzip files with faster reads on large files using larger
-    # See https://github.com/nipy/nibabel/pull/210 for discussion
-    if hasattr(gzip_file, 'max_chunk_read'):
+    # Speedup for #209, for versions of python < 3.5. Open gzip files with
+    # faster reads on large files using a larger read buffer. See
+    # https://github.com/nipy/nibabel/pull/210 for discussion
+    if hasattr(gzip_file, 'max_read_chunk'):
         gzip_file.max_read_chunk = GZIP_MAX_READ_CHUNK
 
     return gzip_file

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -70,20 +70,18 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
         have_indexed_gzip = False
 
     # is this a file? if not we assume it is a string
-    is_file = (hasattr(fileish, 'read') and hasattr(fileish, 'write') and
-               hasattr(fileish, 'mode'))
+    is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write')
 
     # If we've been given a file object, we can't change its mode.
-    if is_file:
+    if is_file and hasattr(fileish, 'mode'):
         mode = fileish.mode
 
     # use indexed_gzip if possible for faster read access
     if mode == 'rb' and have_indexed_gzip:
-        kwargs = {'spacing':4194304, 'readbuf_size':1048576}
-        if hasattr(fileish, 'read') and hasattr(fileish, 'write'):
-            gzip_file = SafeIndexedGzipFile(fid=fileish, **kwargs)
+        if is_file:
+            gzip_file = SafeIndexedGzipFile(fid=fileish)
         else:
-            gzip_file = SafeIndexedGzipFile(filename=fileish, **kwargs)
+            gzip_file = SafeIndexedGzipFile(filename=fileish)
 
     # Fall-back to built-in GzipFile (wrapped with the BufferedGzipFile class
     # defined above)

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -71,7 +71,7 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
 
     # is this a file? if not we assume it is a string
     is_file = (hasattr(fileish, 'read') and hasattr(fileish, 'write') and
-               hasattr(fileish, 'mode')
+               hasattr(fileish, 'mode'))
 
     # If we've been given a file object, we can't change its mode.
     if is_file:

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -72,6 +72,8 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
     # is this a file? if not we assume it is a string
     is_file = hasattr(fileish, 'read') and hasattr(fileish, 'write') and \
               hasattr(fileish, 'mode')
+
+    # If we've been given a file object, we can't change its mode.
     if is_file:
         mode = fileish.mode
 
@@ -82,6 +84,9 @@ def _gzip_open(fileish, mode='rb', compresslevel=9):
             gzip_file = SafeIndexedGzipFile(fid=fileish, **kwargs)
         else:
             gzip_file = SafeIndexedGzipFile(filename=fileish, **kwargs)
+
+    # Fall-back to built-in GzipFile (wrapped with the BufferedGzipFile class
+    # defined above)
     else:
         gzip_file = BufferedGzipFile(fileish, mode, compresslevel)
 

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -270,8 +270,8 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_like`` is an
-            open file handle, this setting has no effect.
+            same as if ``keep_file_open is False``. If ``file_map`` refers to
+            an open file handle, this setting has no effect.
 
         Returns
         -------

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -261,7 +261,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'auto', True, False }, optional, keyword only
+        keep_file_open : { None, 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
@@ -271,8 +271,9 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             present, a single file handle is created and persisted. If
             ``indexed_gzip`` is not available, behaviour is the same as if
             ``keep_file_open is False``. If ``file_map`` refers to an open
-            file handle, this setting has no effect. The default value is
-            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
+            file handle, this setting has no effect. The default value
+            (``None``) will result in the value of
+            ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT`` being used.
 
         Returns
         -------

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -245,8 +245,8 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True):
-        ''' class method to create image from mapping in `file_map ``
+    def from_file_map(klass, file_map, mmap=True, keep_file_open=False):
+        '''class method to create image from mapping in `file_map ``
 
         Parameters
         ----------
@@ -261,13 +261,19 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
+        keep_file_open: If the file-ilke(s) is a file name, the default
+            behaviour is to open a new file handle every time the data is
+            accessed. If this flag is set to `True``, the file handle will be
+            opened on the first access, and kept open until this
+            ``ArrayProxy`` is garbage-collected.
 
         Returns
         -------
         img : Spm99AnalyzeImage instance
+
         '''
-        ret = super(Spm99AnalyzeImage, klass).from_file_map(file_map,
-                                                            mmap=mmap)
+        ret = super(Spm99AnalyzeImage, klass).from_file_map(
+            file_map, mmap=mmap, keep_file_open=keep_file_open)
         try:
             matf = file_map['mat'].get_prepare_fileobj()
         except IOError:

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -245,7 +245,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open=None):
         '''class method to create image from mapping in `file_map ``
 
         Parameters
@@ -267,11 +267,12 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'auto'`` (the default), and the optional ``indexed_gzip``
-            dependency is present, a single file handle is created and
-            persisted. If ``indexed_gzip`` is not available, behaviour is the
-            same as if ``keep_file_open is False``. If ``file_map`` refers to
-            an open file handle, this setting has no effect.
+            ``'auto'``, and the optional ``indexed_gzip`` dependency is
+            present, a single file handle is created and persisted. If
+            ``indexed_gzip`` is not available, behaviour is the same as if
+            ``keep_file_open is False``. If ``file_map`` refers to an open
+            file handle, this setting has no effect. The default value is
+            set to the value of ``nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT``.
 
         Returns
         -------

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -245,7 +245,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open=False):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open='indexed'):
         '''class method to create image from mapping in `file_map ``
 
         Parameters
@@ -261,11 +261,17 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open: If the file-ilke(s) is a file name, the default
-            behaviour is to open a new file handle every time the data is
-            accessed. If this flag is set to `True``, the file handle will be
-            opened on the first access, and kept open until this
-            ``ArrayProxy`` is garbage-collected.
+        keep_file_open : { 'indexed', True, False }, optional, keyword only
+            `keep_file_open` controls whether a new file handle is created
+            every time the image is accessed, or a single file handle is
+            created and used for the lifetime of this ``ArrayProxy``. If
+            ``True``, a single file handle is created and used. If ``False``,
+            a new file handle is created every time the image is accessed. If
+            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            dependency is present, a single file handle is created and
+            persisted. If ``indexed_gzip`` is not available, behaviour is the
+            same as if ``keep_file_open is False``. If ``file_like`` is an
+            open file handle, this setting has no effect.
 
         Returns
         -------

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -245,7 +245,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
 
     @classmethod
     @kw_only_meth(1)
-    def from_file_map(klass, file_map, mmap=True, keep_file_open='indexed'):
+    def from_file_map(klass, file_map, mmap=True, keep_file_open='auto'):
         '''class method to create image from mapping in `file_map ``
 
         Parameters
@@ -261,13 +261,13 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             `mmap` value of True gives the same behavior as ``mmap='c'``.  If
             image data file cannot be memory-mapped, ignore `mmap` value and
             read array from file.
-        keep_file_open : { 'indexed', True, False }, optional, keyword only
+        keep_file_open : { 'auto', True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
             created and used for the lifetime of this ``ArrayProxy``. If
             ``True``, a single file handle is created and used. If ``False``,
             a new file handle is created every time the image is accessed. If
-            ``'indexed'`` (the default), and the optional ``indexed_gzip``
+            ``'auto'`` (the default), and the optional ``indexed_gzip``
             dependency is present, a single file handle is created and
             persisted. If ``indexed_gzip`` is not available, behaviour is the
             same as if ``keep_file_open is False``. If ``file_like`` is an

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -402,21 +402,23 @@ def test_keep_file_open_default():
     # its default value
     dtype = np.float32
     data  = np.arange(1000, dtype=dtype).reshape((10, 10, 10))
-    voxels = np.random.randint(0, 10, (10, 3))
-    mockmod = mock.MagicMock()
     with InTemporaryDirectory():
         fname  = 'testdata.gz'
         with gzip.open(fname, 'wb') as fobj:
             fobj.write(data.tostring(order='F'))
     # If have_indexed_gzip, then keep_file_open should be True
-    with mock.patch.dict('sys.modules', {'indexed_gzip' : mockmod}), \
-         mock.patch('indexed_gzip.SafeIndexedGzipFile', gzip.GzipFile):
+    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP',    True), \
+         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+         mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
+                    create=True):
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
         assert proxy._keep_file_open
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')
         assert proxy._keep_file_open
     # If no have_indexed_gzip, then keep_file_open should be False
-    with mock.patch.dict('sys.modules', {'indexed_gzip' : None}):
+    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+         mock.patch('nibabel.openers.SafeIndexedGzipFile', None, create=True):
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
         assert not proxy._keep_file_open
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -419,19 +419,22 @@ def test_keep_file_open_auto():
         fname  = 'testdata.gz'
         with gzip.open(fname, 'wb') as fobj:
             fobj.write(data.tostring(order='F'))
-    # If have_indexed_gzip, then keep_file_open should be True
-    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP',    True), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
-                    create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')
-        assert proxy._keep_file_open
-    # If no have_indexed_gzip, then keep_file_open should be False
-    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', None, create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')
-        assert not proxy._keep_file_open
+        # If have_indexed_gzip, then keep_file_open should be True
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP',    True), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert proxy._keep_file_open
+        # If no have_indexed_gzip, then keep_file_open should be False
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', None,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert not proxy._keep_file_open
 
 
 def test_keep_file_open_default():
@@ -443,55 +446,62 @@ def test_keep_file_open_default():
         fname  = 'testdata.gz'
         with gzip.open(fname, 'wb') as fobj:
             fobj.write(data.tostring(order='F'))
-    # The default value of KEEP_FILE_OPEN_DEFAULT should cause keep_file_open
-    # to be False, regardless of whether or not indexed_gzip is present
-    assert KEEP_FILE_OPEN_DEFAULT is False
-    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', None, create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert not proxy._keep_file_open
-    with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
-                    create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert not proxy._keep_file_open
-    # KEEP_FILE_OPEN_DEFAULT=True should cause keep_file_open to be True,
-    # regardless of whether or not indexed_gzip is present
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', True), \
-         mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
-                    create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert proxy._keep_file_open
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', True), \
-         mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', None, create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert proxy._keep_file_open
-    # KEEP_FILE_OPEN_DEFAULT=auto should cause keep_file_open to be True
-    # or False, depending on whether indeed_gzip is present,
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'auto'), \
-         mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
-                    create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert proxy._keep_file_open
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'auto'), \
-         mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', None, create=True):
-        proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-        assert not proxy._keep_file_open
-    # KEEP_FILE_OPEN_DEFAULT=any other value should cuse an error to be raised
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'badvalue'):
-        assert_raises(ValueError,  ArrayProxy, fname, ((10, 10, 10), dtype))
-    with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', None):
-        assert_raises(ValueError,  ArrayProxy, fname, ((10, 10, 10), dtype))
+        # The default value of KEEP_FILE_OPEN_DEFAULT should cause
+        # keep_file_open to be False, regardless of whether or not indexed_gzip
+        # is present
+        assert KEEP_FILE_OPEN_DEFAULT is False
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', None,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert not proxy._keep_file_open
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert not proxy._keep_file_open
+        # KEEP_FILE_OPEN_DEFAULT=True should cause keep_file_open to be True,
+        # regardless of whether or not indexed_gzip is present
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', True), \
+             mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert proxy._keep_file_open
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', True), \
+             mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', None,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert proxy._keep_file_open
+        # KEEP_FILE_OPEN_DEFAULT=auto should cause keep_file_open to be True
+        # or False, depending on whether indeed_gzip is present,
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'auto'), \
+             mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', gzip.GzipFile,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert proxy._keep_file_open
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'auto'), \
+             mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', None,
+                        create=True):
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+            assert not proxy._keep_file_open
+        # KEEP_FILE_OPEN_DEFAULT=any other value should cuse an error to be
+        # raised
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', 'badval'):
+            assert_raises(ValueError,  ArrayProxy, fname, ((10, 10, 10),
+                                                           dtype))
+        with mock.patch('nibabel.arrayproxy.KEEP_FILE_OPEN_DEFAULT', None):
+            assert_raises(ValueError,  ArrayProxy, fname, ((10, 10, 10),
+                                                           dtype))
 
 
 def test_pickle_lock():

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -413,9 +413,13 @@ def test_keep_file_open_default():
          mock.patch('indexed_gzip.SafeIndexedGzipFile', gzip.GzipFile):
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
         assert proxy._keep_file_open
+        proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')
+        assert proxy._keep_file_open
     # If no have_indexed_gzip, then keep_file_open should be False
     with mock.patch.dict('sys.modules', {'indexed_gzip' : None}):
         proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+        assert not proxy._keep_file_open
+        proxy = ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='auto')
         assert not proxy._keep_file_open
 
 def test_pickle_lock():

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -353,7 +353,7 @@ def test_keep_file_open():
             proxy_no_kfp = ArrayProxy(fname, ((10, 10, 10), dtype))
             proxy_kfp = ArrayProxy(fname, ((10, 10, 10), dtype),
                                    keep_file_open=True)
-            voxels = np.random.randint(0, 10, (10, 3), dtype=np.uint32)
+            voxels = np.random.randint(0, 10, (10, 3))
             for i in range(voxels.shape[0]):
                 x , y, z = [int(c) for c in voxels[i, :]]
                 assert proxy_no_kfp[x, y, z] == x * 100 + y * 10 + z

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -694,7 +694,7 @@ def test_read_segments():
 def test_read_segments_lock():
     # Test read_segment locking with multiple threads
     fobj = BytesIO()
-    arr = np.random.randint(0, 256, 1000, dtype=np.uint8)
+    arr = np.array(np.random.randint(0, 256, 1000), dtype=np.uint8)
     fobj.write(arr.tostring())
 
     # Encourage the interpreter to switch threads between a seek/read pair

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -8,6 +8,8 @@ from io import BytesIO
 from itertools import product
 from functools import partial
 from distutils.version import LooseVersion
+from threading import Thread, Lock
+import time
 
 import numpy as np
 
@@ -687,6 +689,60 @@ def test_read_segments():
     assert_raises(ValueError, read_segments, fobj, [], 1)
     assert_raises(ValueError, read_segments, fobj, [(0, 200)], 199)
     assert_raises(Exception, read_segments, fobj, [(0, 100), (100, 200)], 199)
+
+
+def test_read_segments_lock():
+    # Test read_segment locking with multiple threads
+    fobj = BytesIO()
+    arr = np.random.randint(0, 256, 1000, dtype=np.uint8)
+    fobj.write(arr.tostring())
+
+    # Encourage the interpreter to switch threads between a seek/read pair
+    def yielding_read(*args, **kwargs):
+        time.sleep(0.001)
+        return fobj._real_read(*args, **kwargs)
+
+    fobj._real_read = fobj.read
+    fobj.read = yielding_read
+
+    # Generate some random array segments to read from the file
+    def random_segments(nsegs):
+        segs = []
+        nbytes = 0
+
+        for i in range(nsegs):
+            seglo = np.random.randint(0, 998)
+            seghi = np.random.randint(seglo + 1, 1000)
+            seglen = seghi - seglo
+            nbytes += seglen
+            segs.append([seglo, seglen])
+
+        return segs, nbytes
+
+    # Get the data that should be returned for the given segments
+    def get_expected(segs):
+        segs = [arr[off:off + length] for off, length in segs]
+        return np.concatenate(segs)
+
+    # Read from the file, check the result. We do this task simultaneously in
+    # many threads. Each thread that passes adds 1 to numpassed[0]
+    numpassed = [0]
+    lock = Lock()
+
+    def runtest():
+        seg, nbytes = random_segments(1)
+        expected = get_expected(seg)
+        _check_bytes(read_segments(fobj, seg, nbytes, lock), expected)
+
+        seg, nbytes = random_segments(10)
+        expected = get_expected(seg)
+        _check_bytes(read_segments(fobj, seg, nbytes, lock), expected)
+        numpassed[0] += 1
+
+    threads = [Thread(target=runtest) for i in range(100)]
+    [t.start() for t in threads]
+    [t.join() for t in threads]
+    assert numpassed[0] == len(threads)
 
 
 def _check_slicer(sliceobj, arr, fobj, offset, order,

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -737,7 +737,9 @@ def test_read_segments_lock():
         seg, nbytes = random_segments(10)
         expected = get_expected(seg)
         _check_bytes(read_segments(fobj, seg, nbytes, lock), expected)
-        numpassed[0] += 1
+
+        with lock:
+            numpassed[0] += 1
 
     threads = [Thread(target=runtest) for i in range(100)]
     [t.start() for t in threads]

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -17,10 +17,10 @@ from ..openers import Opener, ImageOpener
 from ..tmpdirs import InTemporaryDirectory
 from ..volumeutils import BinOpener
 
+import mock
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_not_equal, assert_raises)
 from ..testing import error_warnings
-import mock
 
 
 class Lunk(object):

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -114,13 +114,18 @@ def test_Opener_gzip_type():
             f.write(data.encode())
 
         # test with indexd_gzip not present
-        with mock.patch.dict('sys.modules', {'indexed_gzip' : None}):
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', False), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', None,
+                        create=True):
             assert isinstance(Opener(fname, mode='rb').fobj, GzipFile)
             assert isinstance(Opener(fname, mode='wb').fobj, GzipFile)
 
         # test with indexd_gzip present
-        with mock.patch.dict('sys.modules', {'indexed_gzip' : mockmod}), \
-             mock.patch('indexed_gzip.SafeIndexedGzipFile', MockIGZFile):
+        with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', True), \
+             mock.patch('nibabel.openers.SafeIndexedGzipFile', MockIGZFile,
+                        create=True):
             assert isinstance(Opener(fname, mode='rb').fobj, MockIGZFile)
             assert isinstance(Opener(fname, mode='wb').fobj, GzipFile)
 

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -103,7 +103,7 @@ def test_Opener_gzip_type():
     fname = 'test.gz'
     mockmod = mock.MagicMock()
 
-    class MockClass(object):
+    class MockIGZFile(object):
         def __init__(self, *args, **kwargs):
             pass
 
@@ -120,8 +120,8 @@ def test_Opener_gzip_type():
 
         # test with indexd_gzip present
         with mock.patch.dict('sys.modules', {'indexed_gzip' : mockmod}), \
-             mock.patch('indexed_gzip.SafeIndexedGzipFile', MockClass):
-            assert isinstance(Opener(fname, mode='rb').fobj, MockClass)
+             mock.patch('indexed_gzip.SafeIndexedGzipFile', MockIGZFile):
+            assert isinstance(Opener(fname, mode='rb').fobj, MockIGZFile)
             assert isinstance(Opener(fname, mode='wb').fobj, GzipFile)
 
 

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -232,7 +232,11 @@ def test_compressed_ext_case():
             if lext != ext:  # extension should not be recognized -> file
                 assert_true(isinstance(fobj.fobj, file_class))
             elif lext == 'gz':
-                assert_true(isinstance(fobj.fobj, GzipFile))
+                try:
+                    from indexed_gzip import IndexedGzipFile
+                except ImportError:
+                    IndexedGzipFile = GzipFile
+                assert_true(isinstance(fobj.fobj, (GzipFile, IndexedGzipFile)))
             else:
                 assert_true(isinstance(fobj.fobj, BZ2File))
 


### PR DESCRIPTION
Howdy all,

I've been [sitting on this one](https://mail.python.org/pipermail/neuroimaging/2016-March/000822.html) for a while. This PR proposes to conditionally use [`indexed_gzip`](https://github.com/pauldmccarthy/indexed_gzip) instead of `gzip` to allow for faster random access to `.gz` files. The default behaviour of `nibabel` is unchanged by this PR - to take advantage of `indexed_gzip`, one needs to load an image with a new flag, like so:

```python
img = nib.load('large_gzipped_image.nii.gz', keep_file_open=True)
```

This PR also proposes changes to `ArrayProxy` and `fileslice.read_segments` which makes paired calls to `seek` and `read` thread-safe - see [here](https://mail.python.org/pipermail/neuroimaging/2017-February/001321.html) for a discussion surrounding this change.

**Changes**

1. The `ArrayProxy` has been modified so that it will optionally create and use a single `ImageOpener` for its lifetime, rather than creating/destroying an `ImageOpener` every time the image data is accessed. This is controlled via the `keep_file_open` flag.

2. The `fileslice.read_segments` function optionally accepts a `threading.Lock` so that paired calls to the `seek`/`read` functions can be protected against changes to the running thread.

3. The `openers._gzip_open` function has been changed to conditionally use `indexed_gzip` when available.

4. (Unrelated) There was a bug in `_gzip_open` which was causing the `max_read_chunk` fix to have no effect. This has been fixed.

**Outstanding issues**

 - `indexed_gzip` is not available for windows platforms. I don't have a windows machine to test on, so would need somebody to help out in making it work on windows. See pauldmccarthy/indexed_gzip#1. Note that this PR in its initial state does not break `nibabel` on windows, as the use of `indexed_gzip` is conditional upon its presence.

 - `indexed_gzip` does not support writing. If a file is opened in write mode, the built-in `GzipFile` class is used. I am not against adding write-support into `indexed_gzip`, but to date have not considered it a necessity (and don't know how much time it would take!).

 - The `MGHFormat` class uses the `ArrayProxy`, but I have not updated it to use the `keep_file_open` flag, so it does not benefit from `indexed_gzip`. Adding this would be trivial, but I thought I'd just start by proposing changes to NIFTI/ANALYZE access.

 - The `PARRECImage` class implements its own `ArrayProxy`, so does not benefit from `indexed_gzip`. The `PARRECArrayProxy` class would need to be updated similarly, or some refactorings made so that it uses the standard `ArrayProxy`. I've not looked too closely at the `PARRECArrayProxy`, but on the surface it seems to be quite similar to the `ArrayProxy` class, so this should not be too difficult.

 - `indexed_gzip` is currently available as a binary wheel for macos, but only a source package for other platforms. Hence cython and a C compiler must be available for it to be installed. Is this a concern? I can look into generating linux builds if you think it is needed.

**Other notes**

 - I have not updated `fileslice._simple_fileslice` to accept a `Lock`, because it is not used by anything (apart from unit tests)

 - I decided against using `pread` for the thread-safe fix (as discussed in the mailing list thread) because the built-in `GzipFile` class doesn't have a `pread` method.

 - I have run the `nibabel` unit tests locally, both with and without `indexed_gzip`. It may be desirable to build both of these scenarios into the standard `nibabel` CI test suite.
