### PR TITLE
2.2.0 release prep

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -53,6 +53,8 @@ Enhancements
 * Improve error handling for ``img.__getitem__`` (pr/533) (Ariel Rokem)
 * Delegate reorientation to SpatialImage classes (pr/544) (Mark Hymers, CM,
   reviewed by MB)
+* Enable using ``indexed_gzip`` to reduce memory usage when reading from
+  gzipped NIfTI and MGH files (pr/552) (Paul McCarthy, reviewed by MB, CM)
 
 Bug fixes
 ---------

--- a/Changelog
+++ b/Changelog
@@ -65,6 +65,7 @@ Bug fixes
 Maintenance
 -----------
 
+* Fix documentation errors (pr/517, pr/536) (Fernando Perez, Venky Reddy)
 * Documentation update (pr/514) (Ivan Gonzalez)
 * Update testing to use pre-release builds of dependencies (pr/509) (MB)
 * Better warnings when nibabel not on path (pr/503) (MB)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -52,7 +52,7 @@ contributed code and discussion (in rough order of appearance):
 * Basile Pinsard
 * `Satrajit Ghosh`_
 * `Nolan Nichols`_
-* Nguyen, Ly
+* Ly Nguyen
 * Philippe Gervais
 * Demian Wassermann
 * Justin Lecher
@@ -78,6 +78,7 @@ contributed code and discussion (in rough order of appearance):
 * Fernando Pérez García
 * Venky Reddy
 * Mark Hymers
+* Jasper J.F. van den Bosch
 
 License reprise
 ===============

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -212,10 +212,12 @@ def test_annot():
 @freesurfer_test
 def test_label():
     """Test IO of .label"""
-    label_path = pjoin(data_path, "label", "lh.BA1.label")
+    label_path = pjoin(data_path, "label", "lh.cortex.label")
     label = read_label(label_path)
     # XXX : test more
-    assert_true(np.all(label > 0))
+    assert_true(label.min() >= 0)
+    assert_true(label.max() <= 163841)
+    assert_true(label.shape[0] <= 163842)
 
     labels, scalars = read_label(label_path, True)
     assert_true(np.all(labels == label))

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -19,8 +19,8 @@ from distutils.version import StrictVersion
 _version_major = 2
 _version_minor = 2
 _version_micro = 0
-_version_extra = 'dev'
-# _version_extra = ''
+# _version_extra = 'dev'
+_version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,


### PR DESCRIPTION
Minor version increment. Fixed a FreeSurfer test that depended on FreeSurfer < v6.0.0.

Closes #540

Open issues/PRs that could go in quickly
--------
* [ ] #524 
* [ ] #550
* [ ] #554
* [x] #562
* [ ] Follow-up edits to https://github.com/nipy/nibabel/pull/552#issuecomment-331950557?

Pre-release checklist
--------
* [x] Review the open list of [nibabel issues](https://github.com/nipy/nibabel/issues). Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release. Label them!
* [x] Review and update the release notes. Review and update the [Changelog file](https://github.com/nipy/nibabel/blob/master/Changelog).
* [x] Look at [`doc/source/index.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/index.rst) and add any authors not yet acknowledged.
* [x] Use the opportunity to update the [`.mailmap file`](https://github.com/nipy/nibabel/blob/master/.mailmap) if there are any duplicate authors listed from `git shortlog -nse`.
* [x] Check the copyright year in [doc/source/conf.py](https://github.com/nipy/nibabel/blob/master/doc/source/conf.py)
* [x] Refresh the [README.rst](https://github.com/nipy/nibabel/blob/master/README.rst) text from the `LONG_DESCRIPTION` in [`info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) by running `make refresh-readme`.
* [x] Check the dependencies listed in [`nibabel/info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) (e.g. `NUMPY_MIN_VERSION`) and in [`doc/source/installation.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/installation.rst) and in [`requirements.txt`](https://github.com/nipy/nibabel/blob/master/requirements.txt) and [`.travis.yml`](https://github.com/nipy/nibabel/blob/master/.travis.yml). They should at least match. Do they still hold? Make sure nibabel on travis is testing the minimum dependencies specifically.
* [ ] [`nibabel-release-checks`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11)
  * [ ] [`make sdist-tests` errors](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_7/logs/stdio)
  * [x] [`make check-version-info`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_9/logs/stdio)
  * [x] [`make check-files`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_8/logs/stdio)
  * [ ] [`make -C doc doctest`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_14/logs/stdio)
  * [x] [`python -m compileall .`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_6/logs/stdio)
  * [x] [`make source-release`](https://nipy.bic.berkeley.edu/builders/nibabel-release-checks/builds/11/steps/shell_10/logs/stdio)
* [x] Make sure all tests pass (from the nibabel root directory): `nosetests --with-doctest nibabel`
* [x] Edit [`nibabel/info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py)) to set `_version_extra` to `''`; commit
* [x] Build bots
  * [x] [nibabel-py2.7-osx-10.10](https://nipy.bic.berkeley.edu/builders/nibabel-py2.7-osx-10.10/builds/137/steps/shell_6/logs/stdio)
  * [x] [nibabel-bdist32-27](https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-27/builds/180/steps/shell_8/logs/stdio)
  * [x] [nibabel-bdist32-33](https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-33/builds/161/steps/shell_8/logs/stdio)
  * [x] [nibabel-bdist32-34](https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-34/builds/167/steps/shell_8/logs/stdio)
  * [x] [nibabel-bdist32-35](https://nipy.bic.berkeley.edu/builders/nibabel-bdist32-35/builds/89/steps/shell_8/logs/stdio)
  * [x] [nibabel-bdist64-27](https://nipy.bic.berkeley.edu/builders/nibabel-bdist64-27/builds/133/steps/shell_8/logs/stdio)

Adapted from http://nipy.org/nibabel/devel/make_release.html#release-checklist