### PR TITLE
DOCTEST: Use legacy float array printing for now

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -67,6 +67,7 @@ from . import trackvis
 from . import mriutils
 from . import streamlines
 from . import viewers
+from .testing import setup_test
 
 # Note test requirement for "mock".  Requirement for "nose" tested by numpy.
 try:

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -1,6 +1,12 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Utility routines for working with points and affine transforms
+
+.. testsetup::
+
+>>> from distutils.version import LooseVersion
+>>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+...     np.set_printoptions(sign='legacy')
 """
 
 import numpy as np

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -1,17 +1,12 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Utility routines for working with points and affine transforms
-
-.. testsetup::
-
-    from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-        np.set_printoptions(sign='legacy')
 """
 
 import numpy as np
 
 from six.moves import reduce
+from .testing import setup_test
 
 
 class AffineError(ValueError):

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from six.moves import reduce
-from .testing import setup_test
+from .testing import setup_test  # flake8: noqa F401
 
 
 class AffineError(ValueError):

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -4,9 +4,9 @@
 
 .. testsetup::
 
->>> from distutils.version import LooseVersion
->>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-...     np.set_printoptions(sign='legacy')
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')
 """
 
 import numpy as np

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -2,6 +2,12 @@
 
 Most routines work round some numpy oddities in floating point precision and
 casting.  Others work round numpy casting to and from python ints
+
+.. testsetup::
+
+>>> from distutils.version import LooseVersion
+>>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+...     np.set_printoptions(sign='legacy')
 """
 
 from numbers import Integral

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -5,9 +5,9 @@ casting.  Others work round numpy casting to and from python ints
 
 .. testsetup::
 
->>> from distutils.version import LooseVersion
->>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-...     np.set_printoptions(sign='legacy')
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')
 """
 
 from numbers import Integral

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -2,18 +2,13 @@
 
 Most routines work round some numpy oddities in floating point precision and
 casting.  Others work round numpy casting to and from python ints
-
-.. testsetup::
-
-    from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-        np.set_printoptions(sign='legacy')
 """
 
 from numbers import Integral
 from platform import processor, machine
 
 import numpy as np
+from .testing import setup_test
 
 
 class CastingError(Exception):

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -8,7 +8,7 @@ from numbers import Integral
 from platform import processor, machine
 
 import numpy as np
-from .testing import setup_test
+from .testing import setup_test  # flake8: noqa F401
 
 
 class CastingError(Exception):

--- a/nibabel/nicom/dwiparams.py
+++ b/nibabel/nicom/dwiparams.py
@@ -18,6 +18,11 @@ The B matrix ``B`` is a symmetric positive semi-definite matrix.  If
 
    B ~ (q_est . q_est.T) / norm(q_est)
 
+.. testsetup::
+
+>>> from distutils.version import LooseVersion
+>>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+...     np.set_printoptions(sign='legacy')
 '''
 import numpy as np
 import numpy.linalg as npl

--- a/nibabel/nicom/dwiparams.py
+++ b/nibabel/nicom/dwiparams.py
@@ -20,9 +20,9 @@ The B matrix ``B`` is a symmetric positive semi-definite matrix.  If
 
 .. testsetup::
 
->>> from distutils.version import LooseVersion
->>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-...     np.set_printoptions(sign='legacy')
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')
 '''
 import numpy as np
 import numpy.linalg as npl

--- a/nibabel/nicom/dwiparams.py
+++ b/nibabel/nicom/dwiparams.py
@@ -18,14 +18,10 @@ The B matrix ``B`` is a symmetric positive semi-definite matrix.  If
 
    B ~ (q_est . q_est.T) / norm(q_est)
 
-.. testsetup::
-
-    from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-        np.set_printoptions(sign='legacy')
 '''
 import numpy as np
 import numpy.linalg as npl
+from ..testing import setup_test
 
 
 def B2q(B, tol=None):

--- a/nibabel/nicom/dwiparams.py
+++ b/nibabel/nicom/dwiparams.py
@@ -21,7 +21,7 @@ The B matrix ``B`` is a symmetric positive semi-definite matrix.  If
 '''
 import numpy as np
 import numpy.linalg as npl
-from ..testing import setup_test
+from ..testing import setup_test  # flake8: noqa F401
 
 
 def B2q(B, tol=None):

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -9,6 +9,12 @@
 ''' Read / write access to NIfTI1 image format
 
 NIfTI1 format defined at http://nifti.nimh.nih.gov/nifti-1/
+
+.. testsetup::
+
+>>> from distutils.version import LooseVersion
+>>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+...     np.set_printoptions(sign='legacy')
 '''
 from __future__ import division, print_function
 import warnings

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -9,12 +9,6 @@
 ''' Read / write access to NIfTI1 image format
 
 NIfTI1 format defined at http://nifti.nimh.nih.gov/nifti-1/
-
-.. testsetup::
-
-    from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-        np.set_printoptions(sign='legacy')
 '''
 from __future__ import division, print_function
 import warnings
@@ -33,6 +27,7 @@ from . import analyze  # module import
 from .spm99analyze import SpmAnalyzeHeader
 from .casting import have_binary128
 from .pydicom_compat import have_dicom, pydicom as pdcm
+from .testing import setup_test
 
 # nifti1 flat header definition for Analyze-like first 348 bytes
 # first number in comments indicates offset in file header in bytes

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -27,7 +27,7 @@ from . import analyze  # module import
 from .spm99analyze import SpmAnalyzeHeader
 from .casting import have_binary128
 from .pydicom_compat import have_dicom, pydicom as pdcm
-from .testing import setup_test
+from .testing import setup_test  # flake8: noqa F401
 
 # nifti1 flat header definition for Analyze-like first 348 bytes
 # first number in comments indicates offset in file header in bytes

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -12,9 +12,9 @@ NIfTI1 format defined at http://nifti.nimh.nih.gov/nifti-1/
 
 .. testsetup::
 
->>> from distutils.version import LooseVersion
->>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-...     np.set_printoptions(sign='legacy')
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')
 '''
 from __future__ import division, print_function
 import warnings

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -23,6 +23,12 @@ they are applied on the left of the vector.  For example:
 >>> M = quat2mat(q) # from this module
 >>> vec = np.array([1, 2, 3]).reshape((3,1)) # column vector
 >>> tvec = np.dot(M, vec)
+
+.. testsetup::
+
+>>> from distutils.version import LooseVersion
+>>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+...     np.set_printoptions(sign='legacy')
 '''
 
 import math

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -27,7 +27,7 @@ they are applied on the left of the vector.  For example:
 
 import math
 import numpy as np
-from .testing import setup_test
+from .testing import setup_test  # flake8: noqa F401
 
 MAX_FLOAT = np.maximum_sctype(np.float)
 FLOAT_EPS = np.finfo(np.float).eps

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -26,9 +26,9 @@ they are applied on the left of the vector.  For example:
 
 .. testsetup::
 
->>> from distutils.version import LooseVersion
->>> if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-...     np.set_printoptions(sign='legacy')
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')
 '''
 
 import math

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -23,16 +23,11 @@ they are applied on the left of the vector.  For example:
 >>> M = quat2mat(q) # from this module
 >>> vec = np.array([1, 2, 3]).reshape((3,1)) # column vector
 >>> tvec = np.dot(M, vec)
-
-.. testsetup::
-
-    from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
-        np.set_printoptions(sign='legacy')
 '''
 
 import math
 import numpy as np
+from .testing import setup_test
 
 MAX_FLOAT = np.maximum_sctype(np.float)
 FLOAT_EPS = np.finfo(np.float).eps

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -209,3 +209,13 @@ def assert_arr_dict_equal(dict1, dict2):
     for key, value1 in dict1.items():
         value2 = dict2[key]
         assert_array_equal(value1, value2)
+
+
+def setup_test():
+    """ Set numpy print options to "legacy" for new versions of numpy
+
+    If imported into a file, nosetest will run this before any doctests.
+    """
+    from distutils.version import LooseVersion
+    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+        np.set_printoptions(sign='legacy')

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -217,5 +217,5 @@ def setup_test():
     If imported into a file, nosetest will run this before any doctests.
     """
     from distutils.version import LooseVersion
-    if LooseVersion(np.__version__) > LooseVersion('1.13.1'):
+    if LooseVersion(np.__version__) >= LooseVersion('1.14'):
         np.set_printoptions(sign='legacy')


### PR DESCRIPTION
In numpy's pre-release, float arrays now have different printing strategies. Adding `#doctest: +NORMALIZE_WHITESPACE` doesn't resolve the issue, so for the moment we need to use their option to revert printing behavior to keep doctests from breaking.

Using `.. testsetup::` should avoid visual changes to the docs.

Introduced in https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718