### PR TITLE
MRG: defer use of ufunc / memmap test until testing

### DIFF
--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -32,7 +32,7 @@ from six.moves import zip_longest
 data_path = abspath(pjoin(dirname(__file__), '..', 'tests', 'data'))
 
 
-from .np_features import VIRAL_MEMMAP
+from .np_features import memmap_after_ufunc
 
 def assert_dt_equal(a, b):
     """ Assert two numpy dtype specifiers are equal

--- a/nibabel/testing/np_features.py
+++ b/nibabel/testing/np_features.py
@@ -4,16 +4,20 @@
 import numpy as np
 
 
-def _memmap_after_ufunc():
+def memmap_after_ufunc():
     """ Return True if ufuncs on memmap arrays always return memmap arrays
 
     This should be True for numpy < 1.12, False otherwise.
+
+    Memoize after first call.  We do this to avoid having to call this when
+    importing nibabel.testing, because we cannot depend on the source file
+    being present - see gh-571.
     """
+    if memmap_after_ufunc.result is not None:
+        return memmap_after_ufunc.result
     with open(__file__, 'rb') as fobj:
         mm_arr = np.memmap(fobj, mode='r', shape=(10,), dtype=np.uint8)
-        mm_preserved = isinstance(mm_arr + 1, np.memmap)
-    return mm_preserved
+        memmap_after_ufunc.result = isinstance(mm_arr + 1, np.memmap)
+    return memmap_after_ufunc.result
 
-
-# True if ufunc on memmap always returns a memmap
-VIRAL_MEMMAP = _memmap_after_ufunc()
+memmap_after_ufunc.result = None

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -30,7 +30,7 @@ import mock
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_not_equal, assert_raises)
-from nibabel.testing import VIRAL_MEMMAP
+from nibabel.testing import memmap_after_ufunc
 
 from .test_fileslice import slicer_samples
 from .test_openers import patch_indexed_gzip
@@ -298,6 +298,8 @@ def check_mmap(hdr, offset, proxy_class,
     # Whether scaled array memory backed by memory map (regardless of what
     # numpy says).
     scaled_really_mmap = unscaled_really_mmap and not has_scaling
+    # Whether ufunc on memmap return memmap
+    viral_memmap = memmap_after_ufunc()
     with InTemporaryDirectory():
         with open(fname, 'wb') as fobj:
             fobj.write(b' ' * offset)
@@ -324,9 +326,9 @@ def check_mmap(hdr, offset, proxy_class,
                 assert_false(back_is_mmap)
             else:
                 assert_equal(unscaled_is_mmap,
-                             VIRAL_MEMMAP or unscaled_really_mmap)
+                             viral_memmap or unscaled_really_mmap)
                 assert_equal(back_is_mmap,
-                             VIRAL_MEMMAP or scaled_really_mmap)
+                             viral_memmap or scaled_really_mmap)
                 if scaled_really_mmap:
                     assert_equal(back_data.mode, expected_mode)
             del prox, back_data

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -25,7 +25,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from .test_helpers import bytesio_round_trip
 from ..testing import (clear_and_catch_warnings, suppress_warnings,
-                       VIRAL_MEMMAP)
+                       memmap_after_ufunc)
 from ..tmpdirs import InTemporaryDirectory
 from .. import load as top_load
 
@@ -464,6 +464,7 @@ class MmapImageMixin(object):
     def test_load_mmap(self):
         # Test memory mapping when loading images
         img_klass = self.image_class
+        viral_memmap = memmap_after_ufunc()
         with InTemporaryDirectory():
             img, fname, has_scaling = self.get_disk_image()
             file_map = img.file_map.copy()
@@ -485,7 +486,7 @@ class MmapImageMixin(object):
                     # numpies returned a memmap object, even though the array
                     # has no mmap memory backing.  See:
                     # https://github.com/numpy/numpy/pull/7406
-                    if has_scaling and not VIRAL_MEMMAP:
+                    if has_scaling and not viral_memmap:
                         expected_mode = None
                     kwargs = {}
                     if mmap is not None:


### PR DESCRIPTION
Avoid doing the ufunc / memmap test until we need it.

Might fix gh-571.