### PR TITLE
Force sform/qform codes to be ints, rather than numpy types.

### DIFF
--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -237,7 +237,7 @@ You can get the affine and the code using the ``coded=True`` argument to
 (array([[  -2.  ,    0.  ,    0.  ,  117.86],
        [  -0.  ,    1.97,   -0.36,  -35.72],
        [   0.  ,    0.32,    2.17,   -7.25],
-       [   0.  ,    0.  ,    0.  ,    1.  ]]), array(1, dtype=int16))
+       [   0.  ,    0.  ,    0.  ,    1.  ]]), 1)
 
 You can set the sform with the ``set_sform()`` method of the header and
 the image.
@@ -256,7 +256,7 @@ Set the affine and code using the ``code`` parameter to ``set_sform()``:
 (array([[ 3.,  0.,  0.,  0.],
        [ 0.,  4.,  0.,  0.],
        [ 0.,  0.,  5.,  0.],
-       [ 0.,  0.,  0.,  1.]]), array(4, dtype=int16))
+       [ 0.,  0.,  0.,  1.]]), 4)
 
 The qform affine
 ================
@@ -276,7 +276,7 @@ the sform: ``get_qform()``, ``set_qform()``.
 (array([[  -2.  ,    0.  ,    0.  ,  117.86],
        [  -0.  ,    1.97,   -0.36,  -35.72],
        [   0.  ,    0.32,    2.17,   -7.25],
-       [   0.  ,    0.  ,    0.  ,    1.  ]]), array(1, dtype=int16))
+       [   0.  ,    0.  ,    0.  ,    1.  ]]), 1)
 
 The qform also has a corresponding ``qform_code`` with the same interpretation
 as the `sform_code`.
@@ -332,7 +332,7 @@ respectively:
 (array([[ 2.,  0.,  0.,  0.],
         [ 0.,  2.,  0.,  0.],
         [ 0.,  0.,  2.,  0.],
-        [ 0.,  0.,  0.,  1.]]), array(2, dtype=int16))
+        [ 0.,  0.,  0.,  1.]]), 2)
 >>> img.get_qform(coded=True)
 (None, 0)
 

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -251,7 +251,7 @@ class MGHHeader(LabeledWrapStruct):
         -------
         z : tuple
            tuple of header zoom values
-           
+
         .. _mghformat: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat#line-82
         '''
         # Do not return time zoom (TR) if 3D image

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -911,7 +911,7 @@ class Nifti1Header(SpmAnalyzeHeader):
             Qform code. Only returned if `coded` is True.
         """
         hdr = self._structarr
-        code = hdr['qform_code']
+        code = int(hdr['qform_code'])
         if code == 0 and coded:
             return None, 0
         quat = self.get_qform_quaternion()
@@ -1054,7 +1054,7 @@ class Nifti1Header(SpmAnalyzeHeader):
             Sform code. Only returned if `coded` is True.
         """
         hdr = self._structarr
-        code = hdr['sform_code']
+        code = int(hdr['sform_code'])
         if code == 0 and coded:
             return None, 0
         out = np.eye(4)

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -12,6 +12,8 @@ import os
 import warnings
 import struct
 
+import six
+
 import numpy as np
 
 from nibabel import nifti1 as nifti1
@@ -595,7 +597,7 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         assert_raises(HeaderDataError, ehdr.set_intent, 999, (1,),
                       allow_unknown=True)
         assert_raises(HeaderDataError, ehdr.set_intent, 999, (1,2),
-                      allow_unknown=True) 
+                      allow_unknown=True)
 
     def test_set_slice_times(self):
         hdr = self.header_class()
@@ -899,6 +901,23 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
         new_affine = np.eye(4)
         img.set_sform(new_affine, 2)
         assert_array_almost_equal(img.affine, new_affine)
+
+    def test_sqform_code_type(self):
+        # make sure get_s/qform returns codes as integers
+        img = self.image_class(np.zeros((2, 3, 4)), None)
+        assert isinstance(img.get_sform(coded=True)[1], six.integer_types)
+        assert isinstance(img.get_qform(coded=True)[1], six.integer_types)
+        img.set_sform(None, 3)
+        img.set_qform(None, 3)
+        assert isinstance(img.get_sform(coded=True)[1], six.integer_types)
+        assert isinstance(img.get_qform(coded=True)[1], six.integer_types)
+        img.set_sform(None, 2.0)
+        img.set_qform(None, 4.0)
+        assert isinstance(img.get_sform(coded=True)[1], six.integer_types)
+        assert isinstance(img.get_qform(coded=True)[1], six.integer_types)
+        img.set_sform(None, img.get_sform(coded=True)[1])
+        img.set_qform(None, img.get_qform(coded=True)[1])
+
 
     def test_hdr_diff(self):
         # Check an offset beyond data does not raise an error


### PR DESCRIPTION
This PR contains a tiny fix to bring the behaviour of the `Nifti1Header.set_sform` and `set_qform` methods in line with their documentaion. 

These methods currently return the codes as a `numpy` array with one element, but the codes should be returned with type `int`.  As an example, the following code causes an error:

```
(fsleyes3.5) ws148:fsleyes paulmc$ ipython
Python 3.5.3 (v3.5.3:1880cb95a742, Jan 16 2017, 08:49:46)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.1.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import nibabel as nib
   ...:
   ...: img = nib.load('MNI152_T1_2mm.nii.gz')
   ...:
   ...: img.set_sform(None, img.get_sform(True)[1])
   ...: img.set_qform(None, img.get_qform(True)[1])
   ...:
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-2e90a9e2e037> in <module>()
      3 img = nib.load('MNI152_T1_2mm.nii.gz')
      4
----> 5 img.set_sform(None, img.get_sform(True)[1])
      6 img.set_qform(None, img.get_qform(True)[1])
      7

~/Projects/Public/nibabel/nibabel/nifti1.py in set_sform(self, affine, code, **kwargs)
   1964         if kwargs:
   1965             raise TypeError('Unexpected keyword argument(s) %s' % kwargs)
-> 1966         self._header.set_sform(affine, code)
   1967         if update_affine:
   1968             if self._affine is None:

~/Projects/Public/nibabel/nibabel/nifti1.py in set_sform(self, affine, code)
   1119                 code = old_code
   1120         else:  # code set
-> 1121             code = self._field_recoders['sform_code'][code]
   1122         hdr['sform_code'] = code
   1123         if affine is None:

~/Projects/Public/nibabel/nibabel/volumeutils.py in __getitem__(self, key)
    161         2
    162         '''
--> 163         return self.field1[key]
    164
    165     def __contains__(self, key):

TypeError: unhashable type: 'numpy.ndarray'

In [2]:
``` 

