### PR TITLE
Clarification to docs regarding initial sform/qform code values

### DIFF
--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -281,6 +281,61 @@ the sform: ``get_qform()``, ``set_qform()``.
 The qform also has a corresponding ``qform_code`` with the same interpretation
 as the `sform_code`.
 
+Default sform and qform codes
+=============================
+
+If you create a new image, e.g.:
+
+>>> data = np.random.random((20, 20, 20))
+>>> xform = np.eye(4) * 2
+>>> img = nib.nifti1.Nifti1Image(data, xform)
+
+The sform and qform codes will be initialised to 2 (aligned) and 0 (unknown)
+respectively:
+
+>>> img.get_sform(coded=True)
+(array([[ 2.,  0.,  0.,  0.],
+        [ 0.,  2.,  0.,  0.],
+        [ 0.,  0.,  2.,  0.],
+        [ 0.,  0.,  0.,  1.]]), array(2, dtype=int16))
+>>> img.get_qform(coded=True)
+(None, 0)
+
+This is based on the assumption that the affine you specify for a newly
+created image will align the image to some known coordinate system. According
+to the `NIfTI specification <nifti1>`_, the qform is intended to encode a
+transformation into scanner coordinates - for a programmatically created
+image, we have no way of knowing what the scanner coordinate system is;
+furthermore, the qform cannot be used to store an arbitrary affine transform,
+as it is unable to encode shears. So the provided affine will be stored in the
+sform, and the qform will be left uninitialised.
+
+If you create a new image and specify an existing header, e.g.:
+
+>>> example_ni1 = os.path.join(data_path, 'example4d.nii.gz')
+>>> n1_img = nib.load(example_ni1)
+>>> new_header = header=n1_img.header.copy()
+>>> new_data = np.random.random(n1_img.shape[:3])
+>>> new_img = nib.nifti1.Nifti1Image(data, None, header=new_header)
+
+Then the newly created image will inherit the same sform and qform codes that
+are in the provided header. However, if you create a new image with both an
+affine and a header specified, e.g.:
+
+>>> xform = np.eye(4)
+>>> new_img = nib.nifti1.Nifti1Image(data, xform, header=new_header)
+
+Then the sform and qform codes will *only* be preserved if the provided affine
+is the same as the affine in the provided header. If the affines do not match,
+the sform and qform codes will be set to their default values of 2 and 0
+respectively. This is done on the basis that, if you are changing the affine,
+you are likely to be changing the space to which the affine is pointing. So
+the original sform and qform codes can no longer be assumed to be valid.
+
+If you wish to set the sform and qform affines and/or codes to some other
+value, you can always set them after creation using the ``set_sform`` and
+``set_qform`` methods, as described above.
+
 The fall-back header affine
 ===========================
 

--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -353,14 +353,14 @@ If you create a new image and specify an existing header, e.g.:
 >>> new_data = np.random.random(n1_img.shape[:3])
 >>> new_img = nib.nifti1.Nifti1Image(data, None, header=new_header)
 
-Then the newly created image will inherit the same sform and qform codes that
+then the newly created image will inherit the same sform and qform codes that
 are in the provided header. However, if you create a new image with both an
 affine and a header specified, e.g.:
 
 >>> xform = np.eye(4)
 >>> new_img = nib.nifti1.Nifti1Image(data, xform, header=new_header)
 
-Then the sform and qform codes will *only* be preserved if the provided affine
+then the sform and qform codes will *only* be preserved if the provided affine
 is the same as the affine in the provided header. If the affines do not match,
 the sform and qform codes will be set to their default values of 2 and 0
 respectively. This is done on the basis that, if you are changing the affine,

--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -328,7 +328,7 @@ If you create a new image, e.g.:
 The sform and qform codes will be initialised to 2 (aligned) and 0 (unknown)
 respectively:
 
->>> img.get_sform(coded=True)
+>>> img.get_sform(coded=True) # doctest: +NORMALIZE_WHITESPACE
 (array([[ 2.,  0.,  0.,  0.],
         [ 0.,  2.,  0.,  0.],
         [ 0.,  0.,  2.,  0.],

--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -281,6 +281,41 @@ the sform: ``get_qform()``, ``set_qform()``.
 The qform also has a corresponding ``qform_code`` with the same interpretation
 as the `sform_code`.
 
+The fall-back header affine
+===========================
+
+This is the affine of last resort, constructed only from the ``pixdim`` voxel
+sizes.  The `NIfTI specification <nifti1>`_ says that this should set the
+first voxel in the image as [0, 0, 0] in world coordinates, but we nibabblers
+follow SPM_ in preferring to set the central voxel to have [0, 0, 0] world
+coordinate. The NIfTI spec also implies that the image should be assumed to be
+in RAS+ *voxel* orientation for this affine (see :doc:`coordinate_systems`).
+Again like SPM, we prefer to assume LAS+ voxel orientation by default.
+
+You can always get the fall-back affine with ``get_base_affine()``:
+
+>>> n1_header.get_base_affine()
+array([[  -2. ,    0. ,    0. ,  127. ],
+       [   0. ,    2. ,    0. ,  -95. ],
+       [   0. ,    0. ,    2.2,  -25.3],
+       [   0. ,    0. ,    0. ,    1. ]])
+
+.. _choosing-image-affine:
+
+Choosing the image affine
+=========================
+
+Given there are three possible affines defined in the NIfTI header, nibabel
+has to chose which of these to use for the image ``affine``.
+
+The algorithm is defined in the ``get_best_affine()`` method.  It is:
+
+#. If ``sform_code`` != 0 ('unknown') use the sform affine; else
+#. If ``qform_code`` != 0 ('unknown') use the qform affine; else
+#. Use the fall-back affine.
+
+.. _default-sform-qform-codes:
+
 Default sform and qform codes
 =============================
 
@@ -335,39 +370,6 @@ the original sform and qform codes can no longer be assumed to be valid.
 If you wish to set the sform and qform affines and/or codes to some other
 value, you can always set them after creation using the ``set_sform`` and
 ``set_qform`` methods, as described above.
-
-The fall-back header affine
-===========================
-
-This is the affine of last resort, constructed only from the ``pixdim`` voxel
-sizes.  The `NIfTI specification <nifti1>`_ says that this should set the
-first voxel in the image as [0, 0, 0] in world coordinates, but we nibabblers
-follow SPM_ in preferring to set the central voxel to have [0, 0, 0] world
-coordinate. The NIfTI spec also implies that the image should be assumed to be
-in RAS+ *voxel* orientation for this affine (see :doc:`coordinate_systems`).
-Again like SPM, we prefer to assume LAS+ voxel orientation by default.
-
-You can always get the fall-back affine with ``get_base_affine()``:
-
->>> n1_header.get_base_affine()
-array([[  -2. ,    0. ,    0. ,  127. ],
-       [   0. ,    2. ,    0. ,  -95. ],
-       [   0. ,    0. ,    2.2,  -25.3],
-       [   0. ,    0. ,    0. ,    1. ]])
-
-.. _choosing-image-affine:
-
-Choosing the image affine
-=========================
-
-Given there are three possible affines defined in the NIfTI header, nibabel
-has to chose which of these to use for the image ``affine``.
-
-The algorithm is defined in the ``get_best_affine()`` method.  It is:
-
-#. If ``sform_code`` != 0 ('unknown') use the sform affine; else
-#. If ``qform_code`` != 0 ('unknown') use the qform affine; else
-#. Use the fall-back affine.
 
 ************
 Data scaling

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1768,7 +1768,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
     Notes
     -----
 
-    If both a ``header`` and an ``affine`` are specified, andq the ``affine``
+    If both a ``header`` and an ``affine`` are specified, and the ``affine``
     does not match the affine that is in the ``header``, the ``affine`` will
     be used, but the ``sform_code`` and ``qform_code`` fields in the header
     will be re-initialised to their default values. This is performed on the

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1773,8 +1773,8 @@ class Nifti1Pair(analyze.AnalyzeImage):
               you are changing the affine, you are likely to be changing the
               space to which the affine is pointing.  The :meth:`set_sform`
               and :meth:`set_qform` methods can be used to update the codes
-              after an image has been created - see those methods for more
-              details.  .
+              after an image has been created - see those methods, and
+              the :ref:`manual <default-sform-qform-codes>` for more details.
     '''
 
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1768,12 +1768,12 @@ class Nifti1Pair(analyze.AnalyzeImage):
     Notes
     -----
 
-    If both a ``header`` and an ``affine`` are specified, and the ``affine``
-    does not match the affine that is in the ``header``, the ``affine`` will
-    be used, but the ``sform_code`` and ``qform_code`` fields in the header
-    will be re-initialised to their default values. This is performed on the
-    basis that, if you are changing the affine, you are likely to be changing
-    the space to which the affine is pointing.  The :meth:`set_sform` and
+    If both a `header` and an `affine` are specified, and the `affine` does
+    not match the affine that is in the `header`, the `affine` will be used,
+    but the ``sform_code`` and ``qform_code`` fields in the header will be
+    re-initialised to their default values. This is performed on the basis
+    that, if you are changing the affine, you are likely to be changing the
+    space to which the affine is pointing.  The :meth:`set_sform` and
     :meth:`set_qform` methods can be used to update the codes after an image
     has been created - see those methods, and the :ref:`manual
     <default-sform-qform-codes>` for more details.  '''

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1765,17 +1765,18 @@ class Nifti1Pair(analyze.AnalyzeImage):
             self._affine2header()
     # Copy docstring
     __init__.__doc__ = analyze.AnalyzeImage.__init__.__doc__ + '''
-    .. note:: If both a ``header`` and an ``affine`` are specified, and the
-              ``affine`` does not match the affine that is in the ``header``,
-              the ``affine`` will be used, but the ``sform_code`` and
-              ``qform_code`` fields in the header will be re-initialised to
-              their default values. This is performed on the basis that, if
-              you are changing the affine, you are likely to be changing the
-              space to which the affine is pointing.  The :meth:`set_sform`
-              and :meth:`set_qform` methods can be used to update the codes
-              after an image has been created - see those methods, and
-              the :ref:`manual <default-sform-qform-codes>` for more details.
-    '''
+    Notes
+    -----
+
+    If both a ``header`` and an ``affine`` are specified, andq the ``affine``
+    does not match the affine that is in the ``header``, the ``affine`` will
+    be used, but the ``sform_code`` and ``qform_code`` fields in the header
+    will be re-initialised to their default values. This is performed on the
+    basis that, if you are changing the affine, you are likely to be changing
+    the space to which the affine is pointing.  The :meth:`set_sform` and
+    :meth:`set_qform` methods can be used to update the codes after an image
+    has been created - see those methods, and the :ref:`manual
+    <default-sform-qform-codes>` for more details.  '''
 
 
     def update_header(self):

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1764,7 +1764,19 @@ class Nifti1Pair(analyze.AnalyzeImage):
         if header is None and affine is not None:
             self._affine2header()
     # Copy docstring
-    __init__.doc = analyze.AnalyzeImage.__init__.__doc__
+    __init__.__doc__ = analyze.AnalyzeImage.__init__.__doc__ + '''
+    .. note:: If both a ``header`` and an ``affine`` are specified, and the
+              ``affine`` does not match the affine that is in the ``header``,
+              the ``affine`` will be used, but the ``sform_code`` and
+              ``qform_code`` fields in the header will be re-initialised to
+              their default values.. This is performed on the basis that, if
+              you are changing the affine, you are likely to be changing the
+              space to which the affine is pointing.  The :meth:`set_sform`
+              and :meth:`set_qform` methods can be used to update the codes
+              after an image has been created - see those methods for more
+              details.  .
+    '''
+
 
     def update_header(self):
         ''' Harmonize header with image data and affine

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1769,7 +1769,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
               ``affine`` does not match the affine that is in the ``header``,
               the ``affine`` will be used, but the ``sform_code`` and
               ``qform_code`` fields in the header will be re-initialised to
-              their default values.. This is performed on the basis that, if
+              their default values. This is performed on the basis that, if
               you are changing the affine, you are likely to be changing the
               space to which the affine is pointing.  The :meth:`set_sform`
               and :meth:`set_qform` methods can be used to update the codes


### PR DESCRIPTION
[see #574 for background]

This PR adds a little bit of documentation to the `Nifti1Pair` class, and to the nibabel user documentation page on working with NIfTI images, clarifying how the `sform_code` and `qform_code` fields are initialised under different circumstances.