### PR TITLE
BF: fix doctest failure with pre-release numpy

### DIFF
--- a/nibabel/nicom/dwiparams.py
+++ b/nibabel/nicom/dwiparams.py
@@ -21,7 +21,7 @@ The B matrix ``B`` is a symmetric positive semi-definite matrix.  If
 '''
 import numpy as np
 import numpy.linalg as npl
-from ..testing import setup_test  # flake8: noqa F401
+from ..testing import setup_test as setup_module # flake8: noqa F401
 
 
 def B2q(B, tol=None):

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -218,4 +218,4 @@ def setup_test():
     """
     from distutils.version import LooseVersion
     if LooseVersion(np.__version__) >= LooseVersion('1.14'):
-        np.set_printoptions(sign='legacy')
+        np.set_printoptions(legacy="1.13")


### PR DESCRIPTION
Numpy output printing has changed in upcoming 1.14 - trigger legacy
printing for doctests.

Chris - I had to do `from nibabel.testing import setup_test as setup_module` to
make this work. Is this also true for the other imports of this function?