### PR TITLE
MAINT: Remove conda from Appveyor script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,60 +1,34 @@
 # vim ft=yaml
 # CI on Windows via appveyor
-# This file was based on Olivier Grisel's python-appveyor-demo
 
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python27-conda32"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-conda32"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-conda64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35-conda64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35-conda32"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python27
+    - PYTHON: C:\Python27-x64
+    - PYTHON: C:\Python34
+    - PYTHON: C:\Python34-x64
+    - PYTHON: C:\Python35
+    - PYTHON: C:\Python35-x64
+    - PYTHON: C:\Python36
+    - PYTHON: C:\Python36-x64
 
 install:
-  # Install miniconda Python
-  - "powershell ./tools/install_python.ps1"
-
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-
-  # Set up a conda environment:
-  - conda config --set always_yes yes
-  - conda update -q conda
-  - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION%
-  - activate test-environment
-
-  # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   # Install the dependencies of the project.
-  - "conda install --yes --quiet numpy scipy matplotlib nose h5py mock"
-  - "pip install pydicom"
-  - "python setup.py install"
-  - "SET NIBABEL_DATA_DIR=%CD%\\nibabel-data"
+  - pip install numpy scipy matplotlib nose h5py mock
+  - pip install pydicom
+  - pip install .
+  - SET NIBABEL_DATA_DIR=%CD%\nibabel-data
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Change into an innocuous directory and find tests from installation
-  - "mkdir for_testing"
-  - "cd for_testing"
-  - "nosetests --with-doctest nibabel"
+  - mkdir for_testing
+  - cd for_testing
+  - nosetests --with-doctest nibabel


### PR DESCRIPTION
We can get away without conda, now wheels are available.

Simplify file otherwise, by removing unnecessary quotes and backslashes.