### PR TITLE
MAINT: Use SSH address to use key-based auth

### DIFF
--- a/tools/upload-gh-pages.sh
+++ b/tools/upload-gh-pages.sh
@@ -23,7 +23,7 @@ ORGANIZATION=$3
 if [ -z "$ORGANIZATION" ]; then
     ORGANIZATION=nipy
 fi
-upstream_repo="https://github.com/$ORGANIZATION/$PROJECT"
+upstream_repo="git@github.com:$ORGANIZATION/$PROJECT"
 cd $HTML_DIR
 git init
 git checkout -b gh-pages


### PR DESCRIPTION
I've had issues pushing updated docs to the HTTPS URL. Anybody that has HTTPS write access should have SSH, so this seems safe.