### PR TITLE
BF: if voxel order in header is lowercase, .trk can't load

### DIFF
--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -350,9 +350,8 @@ def axcodes2ornt(axcodes, labels=None):
            [ 2.,  1.]])
     """
 
-    axcodes = tuple(c.upper() for c in axcodes)
-
     if labels is None:
+        axcodes = tuple(c.upper() for c in axcodes)
         labels = list(zip('LPI', 'RAS'))
     n_axes = len(axcodes)
     ornt = np.ones((n_axes, 2), dtype=np.int8) * np.nan

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -349,9 +349,8 @@ def axcodes2ornt(axcodes, labels=None):
            [ 0., -1.],
            [ 2.,  1.]])
     """
-
     if labels is None:
-        axcodes = tuple(c.upper() for c in axcodes)
+        axcodes = tuple(c.upper() if c is not None else None for c in axcodes)
         labels = list(zip('LPI', 'RAS'))
     n_axes = len(axcodes)
     ornt = np.ones((n_axes, 2), dtype=np.int8) * np.nan

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -349,7 +349,12 @@ def axcodes2ornt(axcodes, labels=None):
            [ 0., -1.],
            [ 2.,  1.]])
     """
-    axcodes = axcodes.upper()
+
+    upper_str = []
+    for c in axcodes:
+        upper_str.append(c.upper())
+    axcodes = tuple(upper_str)
+
     if labels is None:
         labels = list(zip('LPI', 'RAS'))
     n_axes = len(axcodes)

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -349,6 +349,7 @@ def axcodes2ornt(axcodes, labels=None):
            [ 0., -1.],
            [ 2.,  1.]])
     """
+    axcodes = axcodes.upper()
     if labels is None:
         labels = list(zip('LPI', 'RAS'))
     n_axes = len(axcodes)

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -350,10 +350,7 @@ def axcodes2ornt(axcodes, labels=None):
            [ 2.,  1.]])
     """
 
-    upper_str = []
-    for c in axcodes:
-        upper_str.append(c.upper())
-    axcodes = tuple(upper_str)
+    axcodes = tuple(c.upper() for c in axcodes)
 
     if labels is None:
         labels = list(zip('LPI', 'RAS'))

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -17,7 +17,7 @@ from ..tractogram import Tractogram
 from ..tractogram_file import HeaderError, HeaderWarning
 
 from .. import trk as trk_module
-from ..trk import TrkFile, encode_value_in_name, decode_value_from_name
+from ..trk import TrkFile, encode_value_in_name, decode_value_from_name, get_affine_trackvis_to_rasmm
 from ..header import Field
 
 DATA = {}
@@ -110,6 +110,17 @@ class TestTRK(unittest.TestCase):
         return trk_struct, trk_bytes
 
     def test_load_file_with_wrong_information(self):
+        # Simulate a TRK file where `voxel_order` is lowercase.
+        trk_struct1, trk_bytes1 = self.trk_with_bytes()
+        trk_struct1[Field.VOXEL_ORDER] = b'LAS'
+        trk1 = TrkFile.load(BytesIO(trk_bytes1))
+        trk_struct2, trk_bytes2 = self.trk_with_bytes()
+        trk_struct2[Field.VOXEL_ORDER] = b'las'
+        trk2 = TrkFile.load(BytesIO(trk_bytes2))
+        trk1_aff2rasmm = get_affine_trackvis_to_rasmm(trk1.header)
+        trk2_aff2rasmm = get_affine_trackvis_to_rasmm(trk2.header)
+        assert_array_equal(trk1_aff2rasmm,trk2_aff2rasmm)
+
         # Simulate a TRK file where `count` was not provided.
         trk_struct, trk_bytes = self.trk_with_bytes()
         trk_struct[Field.NB_STREAMLINES] = 0

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -106,7 +106,7 @@ def get_affine_trackvis_to_rasmm(header):
     if hasattr(vox_order, 'item'):  # structured array
         vox_order = header[Field.VOXEL_ORDER].item()
     affine_ornt = "".join(aff2axcodes(header[Field.VOXEL_TO_RASMM]))
-    header_ornt = axcodes2ornt(vox_order.decode('latin1'))
+    header_ornt = axcodes2ornt(vox_order.decode('latin1').upper())
     affine_ornt = axcodes2ornt(affine_ornt)
     ornt = nib.orientations.ornt_transform(header_ornt, affine_ornt)
     M = nib.orientations.inv_ornt_aff(ornt, header[Field.DIMENSIONS])

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -106,7 +106,7 @@ def get_affine_trackvis_to_rasmm(header):
     if hasattr(vox_order, 'item'):  # structured array
         vox_order = header[Field.VOXEL_ORDER].item()
     affine_ornt = "".join(aff2axcodes(header[Field.VOXEL_TO_RASMM]))
-    header_ornt = axcodes2ornt(vox_order.decode('latin1').upper())
+    header_ornt = axcodes2ornt(vox_order.decode('latin1'))
     affine_ornt = axcodes2ornt(affine_ornt)
     ornt = nib.orientations.ornt_transform(header_ornt, affine_ornt)
     M = nib.orientations.inv_ornt_aff(ornt, header[Field.DIMENSIONS])

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -313,6 +313,11 @@ def test_axcodes2ornt():
                         [2, 1]]
                        )
 
+    # test that format of axcode works for tuples and upper/lower case
+    lia_ornt = [[0, -1], [2, -1], [1, 1]]
+    for lia_axcodes in ('LIA', 'lia', ('L', 'I', 'A'), ('l', 'i', 'a')):
+        assert_array_equal(axcodes2ornt(lia_axcodes), lia_ornt)
+
 
 def test_aff2axcodes():
     assert_equal(aff2axcodes(np.eye(4)), tuple('RAS'))


### PR DESCRIPTION
If the voxel_order field of the header is lowercase in a track file (this is the case when I re-save streamlines using trackvis on my mac: Trackvis Version 0.6.1 (Build 2017.01.17) Public), it will not load using the new nib.streamlines.load because axcodes2ornt returns nan's when given a lower case voxel order.