### PR TITLE
Fix freesurfer `read_annot`, and enhance `write_annot`

### DIFF
--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -518,7 +518,7 @@ def write_annot(filepath, labels, ctab, names, fill_ctab=True):
             np.array([num]).astype(dtype).tofile(fobj)
 
         def write_string(s):
-            s = s.encode() + b'\00'
+            s = (s if isinstance(s, bytes) else s.encode()) + b'\x00'
             write(len(s))
             write(s, dtype='|S%d' % len(s))
 

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -89,9 +89,8 @@ def _pack_rgba(rgba):
     out : ndarray, shape (n, )
         Annotation values for each colour.
     """
-    # ctab :: n x 4
     bitshifts = 2 ** np.array([[0], [8], [16], [24]], dtype=rgba.dtype)
-    return rgba.dot(bitshifts).squeeze()
+    return rgba.dot(bitshifts)
 
 
 def read_geometry(filepath, read_metadata=False, read_stamp=False):
@@ -402,7 +401,7 @@ def read_annot(filepath, orig_ids=False):
                 ctab[idx, :4] = np.fromfile(fobj, dt, 4)
 
     # generate annotation values for each LUT entry
-    ctab[:, 4] = _pack_rgba(ctab[:, :4])
+    ctab[:, [4]] = _pack_rgba(ctab[:, :4])
 
     # make sure names are strings, not bytes
     names = [n.decode('ascii') for n in names]
@@ -450,8 +449,7 @@ def write_annot(filepath, labels, ctab, names, fill_ctab=True):
 
         # Generate annotation values for each ctab entry
         if fill_ctab:
-            ctab = np.hstack((ctab[:, :4],
-                              _pack_rgba(ctab[:, :4]).reshape(-1, 1)))
+            ctab = np.hstack((ctab[:, :4], _pack_rgba(ctab[:, :4])))
         elif not np.array_equal(ctab[:, 4], _pack_rgba(ctab[:, :4])):
             warnings.warn('Annotation values in {} will be incorrect'.format(
                 filepath))

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -389,6 +389,9 @@ def read_annot(filepath, orig_ids=False):
                               ctab[i, 2] * (2 ** 16) +
                               ctab[i, 3] * (2 ** 24))
 
+    # make sure names are strings, not bytes
+    names = [n.decode('ascii') for n in names]
+
     labels = labels.astype(np.int32)
 
     if not orig_ids:

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -85,17 +85,17 @@ def _pack_rgba(rgba):
     """Pack an RGBA sequence into a single integer.
 
     Used by :func:`read_annot` and :func:`write_annot` to generate
-    "annotation values" for a Freesuerfer ``.annot`` file.
+    "annotation values" for a Freesurfer ``.annot`` file.
 
     Parameters
     ----------
     rgba : ndarray, shape (n, 4)
-        RGBA colours
+        RGBA colors
 
     Returns
     -------
     out : ndarray, shape (n, 1)
-        Annotation values for each colour.
+        Annotation values for each color.
     """
     bitshifts = 2 ** np.array([[0], [8], [16], [24]], dtype=rgba.dtype)
     return rgba.dot(bitshifts)
@@ -328,14 +328,14 @@ def read_annot(filepath, orig_ids=False):
 
     An ``.annot`` file contains a sequence of vertices with a label (also known
     as an "annotation value") associated with each vertex, and then a sequence
-    of colours corresponding to each label.
+    of colors corresponding to each label.
 
     Annotation file format versions 1 and 2 are supported, corresponding to
     the "old-style" and "new-style" color table layout.
 
     See:
-    https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
-    https://github.com/freesurfer/freesurfer/blob/dev/matlab/read_annotation.m
+     * https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
+     * https://github.com/freesurfer/freesurfer/blob/dev/matlab/read_annotation.m
 
     Parameters
     ----------
@@ -366,13 +366,13 @@ def read_annot(filepath, orig_ids=False):
         data = np.fromfile(fobj, dt, vnum * 2).reshape(vnum, 2)
         labels = data[:, 1]
 
-        # is there a colour table?
+        # is there a color table?
         ctab_exists = np.fromfile(fobj, dt, 1)[0]
         if not ctab_exists:
             raise Exception('Color table not found in annotation file')
 
         # in old-format files, the next field will contain the number of
-        # entries in the colour table. In new-format files, this must be
+        # entries in the color table. In new-format files, this must be
         # equal to -2
         n_entries = np.fromfile(fobj, dt, 1)[0]
 
@@ -395,18 +395,18 @@ def read_annot(filepath, orig_ids=False):
 
 
 def _read_annot_ctab_old_format(fobj, n_entries):
-    """Read in an old-style Freesurfer colour table from `fobj`.
+    """Read in an old-style Freesurfer color table from `fobj`.
 
     This function is used by :func:`read_annot`.
 
     Parameters
     ----------
 
-    fobj : file-like
+    fobj : file
         Open file handle to a Freesurfer `.annot` file, with seek point
-        at the beginning of the colour table data.
+        at the beginning of the color table data.
     n_entries : int
-        Number of entries in the colour table.
+        Number of entries in the color table.
 
     Returns
     -------
@@ -436,18 +436,18 @@ def _read_annot_ctab_old_format(fobj, n_entries):
 
 
 def _read_annot_ctab_new_format(fobj, ctab_version):
-    """Read in a new-style Freesurfer colour table from `fobj`.
+    """Read in a new-style Freesurfer color table from `fobj`.
 
     This function is used by :func:`read_annot`.
 
     Parameters
     ----------
 
-    fobj : file-like
+    fobj : file
         Open file handle to a Freesurfer `.annot` file, with seek point
-        at the beginning of the colour table data.
+        at the beginning of the color table data.
     ctab_version : int
-        Colour table format version - must be equal to 2
+        Color table format version - must be equal to 2
 
     Returns
     -------
@@ -487,8 +487,8 @@ def write_annot(filepath, labels, ctab, names, fill_ctab=True):
     """Write out a "new-style" Freesurfer annotation file.
 
     See:
-    https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
-    https://github.com/freesurfer/freesurfer/blob/dev/matlab/write_annotation.m
+     * https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
+     * https://github.com/freesurfer/freesurfer/blob/dev/matlab/write_annotation.m
 
     Parameters
     ----------

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -357,9 +357,8 @@ def read_annot(filepath, orig_ids=False):
         to any label and orig_ids=False, its id will be set to -1.
     ctab : ndarray, shape (n_labels, 5)
         RGBA + label id colortable array.
-    names : list of str
+    names : list of str (python 2), list of bytes (python 3)
         The names of the labels. The length of the list is n_labels.
-
     """
     with open(filepath, "rb") as fobj:
         dt = _ANNOT_DT
@@ -390,9 +389,6 @@ def read_annot(filepath, orig_ids=False):
 
     # generate annotation values for each LUT entry
     ctab[:, [4]] = _pack_rgba(ctab[:, :4])
-
-    # make sure names are strings, not bytes
-    names = [n.decode('ascii') for n in names]
 
     if not orig_ids:
         ord = np.argsort(ctab[:, -1])
@@ -522,6 +518,7 @@ def write_annot(filepath, labels, ctab, names, fill_ctab=True):
             np.array([num]).astype(dtype).tofile(fobj)
 
         def write_string(s):
+            s = s.encode() + b'\00'
             write(len(s))
             write(s, dtype='|S%d' % len(s))
 

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -450,7 +450,7 @@ def write_annot(filepath, labels, ctab, names, fill_ctab=True):
         # Generate annotation values for each ctab entry
         if fill_ctab:
             ctab = np.hstack((ctab[:, :4], _pack_rgba(ctab[:, :4])))
-        elif not np.array_equal(ctab[:, 4], _pack_rgba(ctab[:, :4])):
+        elif not np.array_equal(ctab[:, [4]], _pack_rgba(ctab[:, :4])):
             warnings.warn('Annotation values in {} will be incorrect'.format(
                 filepath))
 

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -402,7 +402,7 @@ def _read_annot_ctab_old_format(fobj, n_entries):
     Parameters
     ----------
 
-    fobj : file
+    fobj : file-like
         Open file handle to a Freesurfer `.annot` file, with seek point
         at the beginning of the color table data.
     n_entries : int
@@ -416,8 +416,9 @@ def _read_annot_ctab_old_format(fobj, n_entries):
     names : list of str
         The names of the labels. The length of the list is n_entries.
     """
-    dt = _ANNOT_DT
+    assert hasattr(fobj, 'read')
 
+    dt = _ANNOT_DT
     # orig_tab string length + string
     length = np.fromfile(fobj, dt, 1)[0]
     orig_tab = np.fromfile(fobj, '>c', length)
@@ -443,7 +444,7 @@ def _read_annot_ctab_new_format(fobj, ctab_version):
     Parameters
     ----------
 
-    fobj : file
+    fobj : file-like
         Open file handle to a Freesurfer `.annot` file, with seek point
         at the beginning of the color table data.
     ctab_version : int
@@ -457,6 +458,8 @@ def _read_annot_ctab_new_format(fobj, ctab_version):
     names : list of str
         The names of the labels. The length of the list is n_labels.
     """
+    assert hasattr(fobj, 'read')
+
     dt = _ANNOT_DT
     # This code works with a file version == 2, nothing else
     if ctab_version != 2:

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -383,11 +383,11 @@ def read_annot(filepath, orig_ids=False):
                 name = np.fromfile(fobj, "|S%d" % name_length, 1)[0]
                 names.append(name)
                 # RGBA
-                ctab[i, :4] = np.fromfile(fobj, dt, 4)
-                ctab[i, 4] = (ctab[i, 0] +
-                              ctab[i, 1] * (2 ** 8) +
-                              ctab[i, 2] * (2 ** 16) +
-                              ctab[i, 3] * (2 ** 24))
+                ctab[idx, :4] = np.fromfile(fobj, dt, 4)
+                ctab[idx, 4] = (ctab[idx, 0] +
+                                ctab[idx, 1] * (2 ** 8) +
+                                ctab[idx, 2] * (2 ** 16) +
+                                ctab[idx, 3] * (2 ** 24))
 
     # make sure names are strings, not bytes
     names = [n.decode('ascii') for n in names]

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -85,17 +85,15 @@ def _pack_rgba(rgba):
     """Pack an RGBA sequence into a single integer.
 
     Used by :func:`read_annot` and :func:`write_annot` to generate
-    "annotation values" for a Freesuerfer `.annot` file.
+    "annotation values" for a Freesuerfer ``.annot`` file.
 
     Parameters
     ----------
-
     rgba : ndarray, shape (n, 4)
         RGBA colours
 
     Returns
     -------
-
     out : ndarray, shape (n, 1)
         Annotation values for each colour.
     """
@@ -326,16 +324,14 @@ def write_morph_data(file_like, values, fnum=0):
 
 
 def read_annot(filepath, orig_ids=False):
-    """Read in a Freesurfer annotation from a `.annot` file.
+    """Read in a Freesurfer annotation from a ``.annot`` file.
 
-    An `.annot` file contains a sequence of vertices with a label (also known
+    An ``.annot`` file contains a sequence of vertices with a label (also known
     as an "annotation value") associated with each vertex, and then a sequence
     of colours corresponding to each label.
 
-    The colour table itself may be stored in either an "old-style" format, or
-    a "new-style" format - the :func:`_read_annot_ctab_old_format` and
-    :func:`_read_annot_ctab_new_format` functions are respectively used to
-    read in the colour table.
+    Annotation file format versions 1 and 2 are supported, corresponding to
+    the "old-style" and "new-style" color table layout.
 
     See:
     https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation
@@ -488,7 +484,7 @@ def _read_annot_ctab_new_format(fobj, ctab_version):
 
 
 def write_annot(filepath, labels, ctab, names, fill_ctab=True):
-    """Write out a Freesurfer annotation file.
+    """Write out a "new-style" Freesurfer annotation file.
 
     See:
     https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -212,7 +212,7 @@ def test_annot():
 
 
 def test_read_write_annot():
-    """Test generating .annot fiole and reading it back."""
+    """Test generating .annot file and reading it back."""
     # This annot file will store a LUT for a mesh made of 10 vertices, with
     # 3 colours in the LUT.
     nvertices = 10
@@ -242,6 +242,7 @@ def test_read_write_annot():
     with InTemporaryDirectory():
         write_annot(annot_path, labels, rgbal, names, fill_ctab=False)
         labels2, rgbal2, names2 = read_annot(annot_path)
+        names2 = [n.decode('ascii') for n in names2]
         assert np.all(np.isclose(rgbal2, rgbal))
         assert np.all(np.isclose(labels2, labels))
         assert names2 == names
@@ -261,6 +262,7 @@ def test_write_annot_fill_ctab():
     with InTemporaryDirectory():
         write_annot(annot_path, labels, rgba, names, fill_ctab=True)
         labels2, rgbal2, names2 = read_annot(annot_path)
+        names2 = [n.decode('ascii') for n in names2]
         assert np.all(np.isclose(rgbal2[:, :4], rgba))
         assert np.all(np.isclose(labels2, labels))
         assert names2 == names
@@ -276,6 +278,7 @@ def test_write_annot_fill_ctab():
             any('Annotation values in {} will be incorrect'.format(
                 annot_path) == str(ww.message) for ww in w))
         labels2, rgbal2, names2 = read_annot(annot_path, orig_ids=True)
+        names2 = [n.decode('ascii') for n in names2]
         assert np.all(np.isclose(rgbal2[:, :4], rgba))
         assert np.all(np.isclose(labels2, badannot[labels].squeeze()))
         assert names2 == names
@@ -292,6 +295,7 @@ def test_write_annot_fill_ctab():
             not any('Annotation values in {} will be incorrect'.format(
                 annot_path) == str(ww.message) for ww in w))
         labels2, rgbal2, names2 = read_annot(annot_path)
+        names2 = [n.decode('ascii') for n in names2]
         assert np.all(np.isclose(rgbal2[:, :4], rgba))
         assert np.all(np.isclose(labels2, labels))
         assert names2 == names
@@ -315,11 +319,11 @@ def test_read_annot_old_format():
         fbytes += struct.pack(dt, rgba.shape[0])
         # length of orig_tab string
         fbytes += struct.pack(dt, 5)
-        fbytes += b'abcd\00'
+        fbytes += b'abcd\x00'
         for i in range(rgba.shape[0]):
             # length of entry name (+1 for terminating byte)
             fbytes += struct.pack(dt, len(names[i]) + 1)
-            fbytes += names[i].encode('ascii') + b'\00'
+            fbytes += names[i].encode('ascii') + b'\x00'
             fbytes += bytes(rgba[i, :].astype(dt).tostring())
         with open(fpath, 'wb') as f:
             f.write(fbytes)
@@ -335,6 +339,7 @@ def test_read_annot_old_format():
         gen_old_annot_file('blah.annot', nverts, labels, rgba, names)
         # read it back
         rlabels, rrgba, rnames = read_annot('blah.annot')
+        rnames = [n.decode('ascii') for n in rnames]
         assert np.all(np.isclose(labels, rlabels))
         assert np.all(np.isclose(rgba, rrgba[:, :4]))
         assert names == rnames

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -301,14 +301,14 @@ def test_read_annot_old_format():
     """Test reading an old-style .annot file."""
     def gen_old_annot_file(fpath, nverts, labels, rgba, names):
         dt = '>i'
-        vdata = np.zeros((nverts, 2))
+        vdata = np.zeros((nverts, 2), dtype=dt)
         vdata[:, 0] = np.arange(nverts)
         vdata[:, [1]] = _pack_rgba(rgba[labels, :])
         fbytes = b''
         # number of vertices
         fbytes += struct.pack(dt, nverts)
         # vertices + annotation values
-        fbytes += vdata.astype(dt).tobytes()
+        fbytes += bytes(vdata.astype(dt).tostring())
         # is there a colour table?
         fbytes += struct.pack(dt, 1)
         # number of entries in colour table
@@ -320,7 +320,7 @@ def test_read_annot_old_format():
             # length of entry name (+1 for terminating byte)
             fbytes += struct.pack(dt, len(names[i]) + 1)
             fbytes += names[i].encode('ascii') + b'\00'
-            fbytes += rgba[i, :].astype(dt).tobytes()
+            fbytes += bytes(rgba[i, :].astype(dt))
         with open(fpath, 'wb') as f:
             f.write(fbytes)
     with InTemporaryDirectory():
@@ -328,7 +328,7 @@ def test_read_annot_old_format():
         nlabels = 3
         names = ['Label {}'.format(l) for l in range(nlabels)]
         labels = np.concatenate((
-            np.arange(nlabels), np.random.randint(0, 3, nverts - nlabels)))
+            np.arange(nlabels), np.random.randint(0, nlabels, nverts - nlabels)))
         np.random.shuffle(labels)
         rgba = np.random.randint(0, 255, (nlabels, 4))
         # write an old .annot file

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -209,7 +209,7 @@ def test_annot():
         assert_equal(names, names2)
 
 
-def test_annot_readback():
+def test_read_write_annot():
 
     # This annot file will store a LUT for a mesh made of 10 vertices, with
     # 3 colours in the LUT.
@@ -245,9 +245,31 @@ def test_annot_readback():
     annot_path = 'c.annot'
 
     with InTemporaryDirectory():
-        write_annot(annot_path, labels, rgbal, names)
+        write_annot(annot_path, labels, rgbal, names, fill_ctab=False)
         labels2, rgbal2, names2 = read_annot(annot_path)
         assert np.all(np.isclose(rgbal2, rgbal))
+        assert np.all(np.isclose(labels2, labels))
+        assert names2 == names
+
+
+def test_write_annot_fill_ctab():
+
+    nvertices = 10
+    nlabels = 3
+    names = ['label {}'.format(l) for l in range(1, nlabels + 1)]
+    labels = list(range(nlabels)) + \
+             list(np.random.randint(0, nlabels, nvertices - nlabels))
+    labels = np.array(labels, dtype=np.int32)
+    np.random.shuffle(labels)
+    rgbal = np.random.randint(0, 255, (nlabels, 4), dtype=np.int32)
+    annot_path = 'c.annot'
+
+    with InTemporaryDirectory():
+        write_annot(annot_path, labels, rgbal, names, fill_ctab=True)
+        labels2, rgbal2, names2 = read_annot(annot_path)
+        assert np.all(np.isclose(rgbal2[:, :4], rgbal))
+        assert np.all(np.isclose(labels2, labels))
+        assert names2 == names
 
 
 @freesurfer_test

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -320,7 +320,7 @@ def test_read_annot_old_format():
             # length of entry name (+1 for terminating byte)
             fbytes += struct.pack(dt, len(names[i]) + 1)
             fbytes += names[i].encode('ascii') + b'\00'
-            fbytes += bytes(rgba[i, :].astype(dt))
+            fbytes += bytes(rgba[i, :].astype(dt).tostring())
         with open(fpath, 'wb') as f:
             f.write(fbytes)
     with InTemporaryDirectory():

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -261,7 +261,7 @@ def test_write_annot_fill_ctab():
              list(np.random.randint(0, nlabels, nvertices - nlabels))
     labels = np.array(labels, dtype=np.int32)
     np.random.shuffle(labels)
-    rgbal = np.random.randint(0, 255, (nlabels, 4), dtype=np.int32)
+    rgbal = np.array(np.random.randint(0, 255, (nlabels, 4)), dtype=np.int32)
     annot_path = 'c.annot'
 
     with InTemporaryDirectory():


### PR DESCRIPTION
This PR comprises two sections, related to the `nibabel.freesurfer.io.read_annot` and `write_annot` functions. The first involves changes to `read_annot`, to fix some bugs, and the second involves enhancements to `write_annot`, to make saving `.annot` files a little easier.


Bug fixes to `read_annot`
-------------------------


After a few hours of having my mind bent by the [craziness of the Freesurfer `.annot` file format](https://surfer.nmr.mgh.harvard.edu/fswiki/LabelsClutsAnnotationFiles#Annotation), I discovered a few bugs in the `nibabel.freesurfer.io.read_annot` function. The following simple test case will trigger the buggy behaviour:


```python
import numpy as np
from nibabel.freesurfer import read_annot, write_annot
from nibabel.tmpdirs import InTemporaryDirectory

def test_annot_readback():

    # This annot file will store a LUT for a mesh made of 10 vertices, with
    # 3 colours in the LUT.
    nvertices = 10
    nlabels = 3

    names = ['label {}'.format(l) for l in range(1, nlabels + 1)]

    # randomly generate a label for each vertex, making sure
    # that at least one of each label value is present. Label
    # values are in the range (0, nlabels-1) - they are used
    # as indices into the lookup table (generated below).
    labels = list(range(nlabels)) + \
             list(np.random.randint(0, nlabels, nvertices - nlabels))
    labels = np.array(labels, dtype=np.int32)
    np.random.shuffle(labels)

    # Generate some random colours for the LUT
    rgbal = np.zeros((nlabels, 5), dtype=np.int32)
    rgbal[:, :4] = np.random.randint(0, 255, (nlabels, 4))

    # But make sure we have at least one large alpha, to make sure that when
    # it is packed into a signed 32 bit int, it results in a negative value
    # for the annotation value.
    rgbal[0, 3] = 255

    # Generate the annotation values for each LUT entry
    rgbal[:, 4] = (rgbal[:, 0] +
                   rgbal[:, 1] * (2 ** 8) +
                   rgbal[:, 2] * (2 ** 16) +
                   rgbal[:, 3] * (2 ** 24))

    annot_path = 'c.annot'

    with InTemporaryDirectory():
        write_annot(annot_path, labels, rgbal, names)
        labels2, rgbal2, names2 = read_annot(annot_path)
        assert np.all(np.isclose(rgbal2, rgbal))
```


This fails against the current implementation of `read_annot` because:

 - The annotation value for new-format `.annot` files is being incorrectly generated - the alpha value is not being included.
 - All alpha values are being overwritten with 255 for some unknown reason
 - `np.int` is used rather than `np.int32`, when generating the annotation values. When the top bit is 1, an `int32` will roll around to a negative value (as it should in this instanace), but the use of `np.int` causes such a value to be interpreted as a large positive integer.

I'm guessing that these errors are a throwback from the development period for this code.


Enhancements to `write_annot`
-----------------------------


The Freesurfer `.annot` file format is mildly insane and awkward to use. Alongside each vertex ID is stored the ABRG colour, packed into a signed 32 bit integer. So in order to identify the LUT entry that corresponds to a given vertex, you have to actually scan through the LUT until you find the matching colour<sup>*</sup>.


The `read_annot` function does this for us, so it's no big deal. But, if you want to generate an `.annot` file (as I did, just to write a couple of unit tests for my own code), you have to do the reverse, and generate the "annotation values" for every vertex. This procedure is shown in the above example.


So I'm proposing a small change to `write_annot`, to get it to do this for us, and that this is the new default behaviour - it accepts a new `fill_ctab` parameter, which defaults to `True`. So instead of having to do:

```python
rgbal = np.zeros((nlabels, 5), dtype=np.int32)
rgbal[:, :4] = np.random.randint(0, 255, (nlabels, 5))
rgbal[:,  4] = (rgbal[:, 0] +
                rgbal[:, 1] * (2 ** 8) +
                rgbal[:, 2] * (2 ** 16) +
                rgbal[:, 3] * (2 ** 24))

write_annot(annot_path, labels, rgbal, names)
```


With this PR, you can now do the following (and I am proposing that `fill_ctab` defaults to `True`):


```python
rgbal = np.random.randint(0, 255, (nlabels, 4), dtype=np.int32)
write_annot(annot_path, labels, rgbal, names, fill_ctab=True)
```


<sup>*</sup> Although this only allows you to get the corresponding structure name, so you don't need to bother if all you want is the colour.