### PR TITLE
Stop adding extraneous metadata padding

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -334,7 +334,8 @@ class Nifti1Extension(object):
         size = len(self._mangle(self._content))
         size += 8
         # extensions size has to be a multiple of 16 bytes
-        size += 16 - (size % 16)
+        if size % 16 != 0:
+            size += 16 - (size % 16)
         return size
 
     def __repr__(self):

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1075,6 +1075,9 @@ def test_extension_basics():
     assert_true(ext.get_sizeondisk() == 16)
     assert_true(ext.get_content() == raw)
     assert_true(ext.get_code() == 6)
+    # Test that extensions already aligned to 16 bytes are not padded
+    ext = Nifti1Extension('comment', b'x' * 24)
+    assert_true(ext.get_sizeondisk() == 32)
 
 
 def test_ext_eq():


### PR DESCRIPTION
If the metadata field is already aligned to a 16-byte boundary then
don't add additional padding.  This allows the user to create a
16-byte aligned extension padded with 0x20 that can be read by the [Jim
software](http://www.xinapse.com/) (which doesn't like finding 0x00 in the metadata chunk).