### PR TITLE
[Fix] buffer_size on ArraySequence

### DIFF
--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -37,7 +37,7 @@ class _BuildCache(object):
         self.common_shape = common_shape
         n_in_row = reduce(mul, common_shape, 1)
         bytes_per_row = n_in_row * dtype.itemsize
-        self.rows_per_buf = self.bytes_per_buf / bytes_per_row
+        self.rows_per_buf = int(np.ceil(self.bytes_per_buf / bytes_per_row))
 
     def update_seq(self, arr_seq):
         arr_seq._offsets = np.array(self.offsets)

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -37,7 +37,7 @@ class _BuildCache(object):
         self.common_shape = common_shape
         n_in_row = reduce(mul, common_shape, 1)
         bytes_per_row = n_in_row * dtype.itemsize
-        self.rows_per_buf = bytes_per_row / self.bytes_per_buf
+        self.rows_per_buf = self.bytes_per_buf / bytes_per_row
 
     def update_seq(self, arr_seq):
         arr_seq._offsets = np.array(self.offsets)

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -37,7 +37,7 @@ class _BuildCache(object):
         self.common_shape = common_shape
         n_in_row = reduce(mul, common_shape, 1)
         bytes_per_row = n_in_row * dtype.itemsize
-        self.rows_per_buf = int(np.ceil(self.bytes_per_buf / bytes_per_row))
+        self.rows_per_buf = max(1, self.bytes_per_buf // bytes_per_row)
 
     def update_seq(self, arr_seq):
         arr_seq._offsets = np.array(self.offsets)
@@ -185,6 +185,7 @@ class ArraySequence(object):
             return
         self._build_cache.update_seq(self)
         self._build_cache = None
+        self.shrink_data()
 
     def _resize_data_to(self, n_rows, build_cache):
         """ Resize data array if required """

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -329,4 +329,3 @@ def test_concatenate():
     new_seq = concatenate(seqs, axis=0)
     assert_true(len(new_seq), seq.common_shape[0] * len(seq))
     assert_array_equal(new_seq._data, seq._data.T.reshape((-1, 1)))
-    

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -97,8 +97,8 @@ class TestArraySequence(unittest.TestCase):
         seq_with_buffer = ArraySequence(gen_2, buffer_size=256)
 
         # Check buffer size effect
-        assert_true(seq_with_buffer.data.shape[0] > seq.data.shape[0])
-        assert_equal(seq_with_buffer.common_shape, seq.common_shape)
+        assert_equal(seq_with_buffer.data.shape, seq.data.shape)
+        assert_true(seq_with_buffer._buffer_size > seq._buffer_size)
 
         # Check generator result
         check_arr_seq(seq, SEQ_DATA['data'])
@@ -328,4 +328,5 @@ def test_concatenate():
     seqs = [seq[:, [i]] for i in range(seq.common_shape[0])]
     new_seq = concatenate(seqs, axis=0)
     assert_true(len(new_seq), seq.common_shape[0] * len(seq))
-    assert_array_equal(new_seq._data, seq._data.T.reshape((-1, 0)))
+    assert_array_equal(new_seq._data, seq._data.T.reshape((-1, 1)))
+    

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import tempfile
+import itertools
 import numpy as np
 
 from nose.tools import assert_equal, assert_raises, assert_true
@@ -91,11 +92,20 @@ class TestArraySequence(unittest.TestCase):
                       SEQ_DATA['data'])
 
     def test_creating_arraysequence_from_generator(self):
-        gen = (e for e in SEQ_DATA['data'])
-        check_arr_seq(ArraySequence(gen), SEQ_DATA['data'])
+        gen_1, gen_2 = itertools.tee((e for e in SEQ_DATA['data']))
+        seq = ArraySequence(gen_1)
+        seq_with_buffer = ArraySequence(gen_2, buffer_size=256)
+
+        # Check buffer size effect
+        assert_true(seq_with_buffer.data.shape[0] > seq.data.shape[0])
+        assert_equal(seq_with_buffer.common_shape, seq.common_shape)
+
+        # Check generator result
+        check_arr_seq(seq, SEQ_DATA['data'])
+        check_arr_seq(seq_with_buffer, SEQ_DATA['data'])
 
         # Already consumed generator
-        check_empty_arr_seq(ArraySequence(gen))
+        check_empty_arr_seq(ArraySequence(gen_1))
 
     def test_creating_arraysequence_from_arraysequence(self):
         seq = ArraySequence(SEQ_DATA['data'])

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -328,4 +328,4 @@ def test_concatenate():
     seqs = [seq[:, [i]] for i in range(seq.common_shape[0])]
     new_seq = concatenate(seqs, axis=0)
     assert_true(len(new_seq), seq.common_shape[0] * len(seq))
-    assert_array_equal(new_seq._data, seq._data.T.reshape((-1, 1)))
+    assert_array_equal(new_seq._data, seq._data.T.reshape((-1, 0)))


### PR DESCRIPTION
Hi, 

When you initialize `ArraySequence` with a big generator on Windows,  this operation is really really slow. (6 hours for 560583 streamlines...).  Unfortunately, setting up the `buffer_size` does not have any effect. 

So the goal of this PR is to fix this issue. Now, this operation takes me 46sec.

@MarcCote, @Garyfallidis, Can you look at this PR? Thanks!
