### PR TITLE
MRG: refactoring for pydicom 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ cache:
     - $HOME/.cache/pip
 env:
     global:
-        - DEPENDS="six numpy scipy matplotlib h5py pillow"
+        - DEPENDS="six numpy scipy matplotlib h5py pillow pydicom"
         - OPTIONAL_DEPENDS=""
-        - PYDICOM=1
         - INSTALL_TYPE="setup"
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
         - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
@@ -34,7 +33,7 @@ matrix:
     # Absolute minimum dependencies
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.7.1" PYDICOM=0
+        - DEPENDS="numpy==1.7.1"
     # Absolute minimum dependencies plus oldest MPL
     # Check these against:
     # nibabel/info.py
@@ -42,7 +41,7 @@ matrix:
     # requirements.txt
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.7.1 matplotlib==1.3.1" PYDICOM=0
+        - DEPENDS="numpy==1.7.1 matplotlib==1.3.1"
     # Minimum pydicom dependency
     - python: 2.7
       env:
@@ -51,12 +50,12 @@ matrix:
     - python: 2.7
       env:
         - DEPENDS="numpy==1.7.1"
-    # pydicom 1.0 (currently unreleased)
-    - python: 2.7
+    # pydicom master branch
+    - python: 3.5
       env:
-        - PYDICOM="v1.0"
-    # test 2.7 against pre-release builds of everything
-    - python: 2.7
+        - DEPENDS="numpy git+https://github.com/pydicom/pydicom.git@master"
+    # test 3.5 against pre-release builds of everything
+    - python: 3.5
       env:
         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     # test 3.5 against pre-release builds of everything
@@ -102,14 +101,6 @@ before_install:
     - pip install -U pip wheel  # needed at one point
     - retry pip install nose flake8 mock  # always
     - pip install $EXTRA_PIP_FLAGS $DEPENDS $OPTIONAL_DEPENDS
-    # pydicom <= 0.9.8 doesn't install on python 3
-    - if [ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]; then
-        if [ "$PYDICOM" == "1" ]; then
-            pip install pydicom;
-        elif [ "$PYDICOM" == "v1.0" ]; then
-            pip install git+https://github.com/darcymason/pydicom.git@43f278444d5cb2e4648135d3edcd430c363c6975;
-        fi
-      fi
     - if [ "${COVERAGE}" == "1" ]; then
       pip install coverage;
       pip install coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
     # Minimum pydicom dependency
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.7.1 pydicom==0.9.7 pillow==2.6"
+        - DEPENDS="numpy==1.7.1 pydicom==0.9.9 pillow==2.6"
     # test against numpy 1.7
     - python: 2.7
       env:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -90,7 +90,7 @@ Requirements
 *  NumPy_ 1.7.1 or greater
 *  Six_ 1.3 or greater
 *  SciPy_ (optional, for full SPM-ANALYZE support)
-*  PyDICOM_ 0.9.7 or greater (optional, for DICOM support)
+*  PyDICOM_ 0.9.9 or greater (optional, for DICOM support)
 *  `Python Imaging Library`_ (optional, for PNG conversion in DICOMFS)
 *  nose_ 0.11 or greater (optional, to run the tests)
 *  mock_ (optional, to run the tests)

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -187,7 +187,7 @@ the top of the release notes.  Click on the badge for more information.
 # requirements.txt
 # .travis.yml
 NUMPY_MIN_VERSION = '1.7.1'
-PYDICOM_MIN_VERSION = '0.9.7'
+PYDICOM_MIN_VERSION = '0.9.9'
 SIX_MIN_VERSION = '1.3'
 
 # Main setup parameters

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -21,7 +21,7 @@ from . import csareader as csar
 from .dwiparams import B2q, nearest_pos_semi_def, q2bg
 from ..openers import ImageOpener
 from ..onetime import setattr_on_read as one_time
-from ..pydicom_compat import pydicom
+from ..pydicom_compat import tag_for_keyword
 
 
 class WrapperError(Exception):
@@ -517,7 +517,7 @@ class MultiframeWrapper(Wrapper):
         # Determine if one of the dimension indices refers to the stack id
         dim_seq = [dim.DimensionIndexPointer
                    for dim in self.get('DimensionIndexSequence')]
-        stackid_tag = pydicom.datadict.tag_for_name('StackID')
+        stackid_tag = tag_for_keyword('StackID')
         # remove the stack id axis if present
         if stackid_tag in dim_seq:
             stackid_dim_idx = dim_seq.index(stackid_tag)

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -9,7 +9,8 @@ from copy import copy
 
 import numpy as np
 
-from nibabel.pydicom_compat import have_dicom, pydicom, read_file, dicom_test
+from nibabel.pydicom_compat import (have_dicom, pydicom, read_file, dicom_test,
+                                    tag_for_keyword)
 
 from .. import dicomwrappers as didw
 from .. import dicomreaders as didr
@@ -416,8 +417,8 @@ def fake_shape_dependents(div_seq, sid_seq=None, sid_dim=None):
     dim_idx_seq = [DimIdxSeqElem()] * num_of_frames
     # add an entry for StackID into the DimensionIndexSequence
     if sid_dim is not None:
-        sid_tag = pydicom.datadict.tag_for_name('StackID')
-        fcs_tag = pydicom.datadict.tag_for_name('FrameContentSequence')
+        sid_tag = tag_for_keyword('StackID')
+        fcs_tag = tag_for_keyword('FrameContentSequence')
         dim_idx_seq[sid_dim] = DimIdxSeqElem(sid_tag, fcs_tag)
     # create the PerFrameFunctionalGroupsSequence
     frames = [PerFrmFuncGrpSeqElem(div, sid)

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -10,17 +10,18 @@ without error, and always defines:
 * pydicom : pydicom module or dicom module or None of not importable;
 * read_file : ``read_file`` function if pydicom or dicom module is importable
   else None;
+* tag_for_keyword : ``tag_for_keyword`` function if pydicom or dicom module
+  is importable else None;
 * dicom_test : test decorator that skips test if dicom not available.
 """
 
-# Module does (apparently) unused imports; stop flake8 complaining
+# Module has (apparently) unused imports; stop flake8 complaining
 # flake8: noqa
 
 import numpy as np
 
 have_dicom = True
-read_file = None
-pydicom = None
+pydicom = read_file = tag_for_keyword = None
 
 try:
     import dicom as pydicom
@@ -37,6 +38,14 @@ except ImportError:
         import pydicom.values
 else:  # dicom module available
     read_file = pydicom.read_file
+
+if have_dicom:
+    try:
+        # Versions >= 1.0
+        tag_for_keyword = pydicom.datadict.tag_for_keyword
+    except AttributeError:
+        # Versions < 1.0 - also has more search options.
+        tag_for_keyword = pydicom.datadict.tag_for_name
 
 
 # test decorator that skips test if dicom not available.


### PR DESCRIPTION
Make tests pass against pydicom 1.0.

Refactor CI to test pydicom master, as suggested by pydicom folks.

Update minimum pydicom dependency to 0.9.9 (previous versions no longer install).