### PR TITLE
BF: preserve error output if not valid klass in `nibabel.save()`

### DIFF
--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -133,10 +133,10 @@ def save(img, filename):
                 converted = klass.from_image(img)
                 break
             except Exception as e:
-                continue
+                err = e
         # ... and if none of them work, raise an error.
         if converted is None:
-            raise e
+            raise err
 
     # Here, we either have a klass or a converted image.
     if converted is None:

--- a/nibabel/tests/test_image_load_save.py
+++ b/nibabel/tests/test_image_load_save.py
@@ -30,7 +30,7 @@ from ..optpkg import optional_package
 from ..spatialimages import SpatialImage
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import assert_true, assert_equal
+from nose.tools import assert_true, assert_equal, assert_raises
 
 _, have_scipy, _ = optional_package('scipy')  # No scipy=>no SPM-format writing
 DATA_PATH = pjoin(dirname(__file__), 'data')
@@ -322,3 +322,14 @@ def test_guessed_image_type():
     assert_equal(nils.guessed_image_type(
         pjoin(DATA_PATH, 'analyze.hdr')),
         Spm2AnalyzeImage)
+
+
+def test_fail_save():
+    with InTemporaryDirectory():
+        dataobj = np.ones((10, 10, 10), dtype=np.float16)
+        affine = np.eye(4, dtype=np.float32)
+        img = SpatialImage(dataobj, affine)
+        # Fails because float16 is not supported.
+        with assert_raises(AttributeError):
+            nils.save(img, 'foo.nii.gz')
+        del img

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -10,8 +10,7 @@ import numpy as np
 from .. import (Spm99AnalyzeImage, Spm2AnalyzeImage,
                 Nifti1Pair, Nifti1Image,
                 Nifti2Pair, Nifti2Image)
-from ..spatialimages import SpatialImage
-from ..loadsave import load, read_img_data, save
+from ..loadsave import load, read_img_data
 from ..filebasedimages import ImageFileError
 from ..tmpdirs import InTemporaryDirectory, TemporaryDirectory
 
@@ -136,33 +135,3 @@ def test_read_img_data_nifti():
             assert_array_equal(exp_offset, read_img_data(img_back))
             # Delete stuff that might hold onto file references
             del img, img_back, data_back
-
-
-def test_save():
-    with InTemporaryDirectory():
-        dataobj = np.ones((10, 10, 10), dtype=np.float16)
-        affine = np.eye(4, dtype=np.float32)
-        img = SpatialImage(dataobj, affine)
-
-        # The `save` method can raise one of many types of errors, but they are
-        # all subclasses of Exception. This attempt will fail because float16
-        # is not supported.
-        with assert_raises(Exception):
-            save(img, 'foo.nii.gz')
-
-        # Test the saving of several types of images.
-        dataobj = np.ones((10, 10, 10), dtype=np.float32)
-        img = SpatialImage(dataobj, affine)
-        for ext in {'hdr', 'img', 'nii', 'nii.gz', 'mgz'}:
-            this_filepath = "foo." + ext
-            save(img, this_filepath)
-            img_loaded = load(this_filepath)
-            assert_array_equal(np.asarray(img_loaded.dataobj), dataobj)
-            assert_array_equal(np.asarray(img_loaded.affine), affine)
-
-        # Test not being able to work out file type.
-        with assert_raises(ImageFileError):
-            save(img, 'foo.noexists')
-
-        # Delete stuff that might hold onto file references
-        del img, img_loaded


### PR DESCRIPTION
This PR proposes a fix for an `UnboundLocalError` in `nibabel.save`, specifically in the lines

https://github.com/nipy/nibabel/blob/e48b746af1841aed2ff862d1eea8471f35265b2c/nibabel/loadsave.py#L131-L139

The scope of variable `e` in `except Exception as e` is the `except block` in python3. Trying to raise it out of the `except` block will raise an error. I haven't been able to test this myself yet, so it's possible something else must be changed. I can add a test for this as well.

I initially came upon this error when trying to save a float16 nifti:

```python
import nibabel as nb
import numpy as np

dataobj = np.ones((10, 10, 10), dtype=np.float16)
affine = np.eye(4)
img = nb.spatialimages.SpatialImage(dataobj, affine)
nb.save(img, 'foo.nii.gz')
```

Here are minimal examples of this behavior:

```python
try:
    foo
except Exception as e:
    pass
raise e  # e is not defined
```

```python
try:
    foo
except Exception as e:
    err = e
raise err  # foo is not defined (expected)
```

Interestingly...
```python
try:
    foo
except Exception as e:
    e = e
raise e  # e is not defined
```