### PR TITLE
ENH:  Take advantage of IndexedGzipFile drop_handles flag

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -34,7 +34,7 @@ from .deprecated import deprecate_with_version
 from .volumeutils import array_from_file, apply_read_scaling
 from .fileslice import fileslice
 from .keywordonly import kw_only_meth
-from .openers import ImageOpener, HAVE_INDEXED_GZIP
+from . import openers
 
 
 """This flag controls whether a new file handle is created every time an image
@@ -214,7 +214,7 @@ class ArrayProxy(object):
         if hasattr(file_like, 'read') and hasattr(file_like, 'seek'):
             return False
         # don't have indexed_gzip - auto -> False
-        if keep_file_open == 'auto' and not (HAVE_INDEXED_GZIP and
+        if keep_file_open == 'auto' and not (openers.HAVE_INDEXED_GZIP and
                                              file_like.endswith('.gz')):
             return False
         return keep_file_open
@@ -263,11 +263,11 @@ class ArrayProxy(object):
         """
         if self._keep_file_open:
             if not hasattr(self, '_opener'):
-                self._opener = ImageOpener(
+                self._opener = openers.ImageOpener(
                     self.file_like, keep_open=self._keep_file_open)
             yield self._opener
         else:
-            with ImageOpener(self.file_like) as opener:
+            with openers.ImageOpener(self.file_like) as opener:
                 yield opener
 
     def get_unscaled(self):

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -51,8 +51,12 @@ behaviour is the same as if ``keep_file_open is False``.
 If this is set to any other value, attempts to create an ``ArrayProxy`` without
 specifying the ``keep_file_open`` flag will result in a ``ValueError`` being
 raised.
+
+.. warning:: Setting this flag to a value of ``'auto'`` will become deprecated
+             behaviour in version 2.4.0. Support for ``'auto'`` will be removed
+             in version 3.0.0.
 """
-KEEP_FILE_OPEN_DEFAULT = 'auto'
+KEEP_FILE_OPEN_DEFAULT = False
 
 
 class ArrayProxy(object):

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -43,10 +43,10 @@ used for the lifetime of the ``ArrayProxy``. It should be set to one of
 ``True``, ``False``, or ``'auto'``.
 
 If ``True``, a single file handle is created and used. If ``False``, a new
-file handle is created every time the image is accessed. If ``'auto'``, and
-the optional ``indexed_gzip`` dependency is present, a single file handle is
-created and persisted. If ``indexed_gzip`` is not available, behaviour is the
-same as if ``keep_file_open is False``.
+file handle is created every time the image is accessed. For gzip files, if
+``'auto'``, and the optional ``indexed_gzip`` dependency is present, a single
+file handle is created and persisted. If ``indexed_gzip`` is not available,
+behaviour is the same as if ``keep_file_open is False``.
 
 If this is set to any other value, attempts to create an ``ArrayProxy`` without
 specifying the ``keep_file_open`` flag will result in a ``ValueError`` being
@@ -186,7 +186,7 @@ class ArrayProxy(object):
         The return value is derived from these rules:
 
           - If ``file_like`` is a file(-like) object, ``False`` is returned.
-            Otherwise, ``file_like`` is assumed to be a file name
+            Otherwise, ``file_like`` is assumed to be a file name.
           - If ``keep_file_open`` is ``auto``, and ``indexed_gzip`` is
             not available, ``False`` is returned.
           - Otherwise, the value of ``keep_file_open`` is returned unchanged.
@@ -214,7 +214,8 @@ class ArrayProxy(object):
         if hasattr(file_like, 'read') and hasattr(file_like, 'seek'):
             return False
         # don't have indexed_gzip - auto -> False
-        if keep_file_open == 'auto' and not HAVE_INDEXED_GZIP:
+        if keep_file_open == 'auto' and not (HAVE_INDEXED_GZIP and
+                                             file_like.endswith('.gz')):
             return False
         return keep_file_open
 
@@ -260,7 +261,7 @@ class ArrayProxy(object):
             A newly created ``ImageOpener`` instance, or an existing one,
             which provides access to the file.
         """
-        if bool(self._keep_file_open):
+        if self._keep_file_open:
             if not hasattr(self, '_opener'):
                 self._opener = ImageOpener(
                     self.file_like, keep_open=self._keep_file_open)

--- a/nibabel/benchmarks/bench_array_to_file.py
+++ b/nibabel/benchmarks/bench_array_to_file.py
@@ -16,6 +16,7 @@ Run this benchmark with:
 from __future__ import division, print_function
 
 import sys
+from io import BytesIO  # NOQA
 
 import numpy as np
 

--- a/nibabel/benchmarks/bench_arrayproxy_slicing.py
+++ b/nibabel/benchmarks/bench_arrayproxy_slicing.py
@@ -15,7 +15,6 @@ Run this benchmark with:
 """
 
 from timeit import timeit
-import contextlib
 import gc
 import itertools as it
 import numpy as np

--- a/nibabel/benchmarks/bench_arrayproxy_slicing.py
+++ b/nibabel/benchmarks/bench_arrayproxy_slicing.py
@@ -62,8 +62,7 @@ else:
 @contextlib.contextmanager
 def patch_indexed_gzip(have_igzip):
 
-    atts = ['nibabel.openers.HAVE_INDEXED_GZIP',
-            'nibabel.arrayproxy.HAVE_INDEXED_GZIP']
+    atts = ['nibabel.openers.HAVE_INDEXED_GZIP']
 
     with mock.patch(atts[0], have_igzip), mock.patch(atts[1], have_igzip):
         yield

--- a/nibabel/benchmarks/bench_arrayproxy_slicing.py
+++ b/nibabel/benchmarks/bench_arrayproxy_slicing.py
@@ -51,7 +51,7 @@ SLICEOBJS = [
     ('?', '?', '?', ':'),
 ]
 
-KEEP_OPENS = [False, True]
+KEEP_OPENS = [False, True, 'auto']
 
 if HAVE_INDEXED_GZIP:
     HAVE_IGZIP = [False, True]

--- a/nibabel/benchmarks/bench_arrayproxy_slicing.py
+++ b/nibabel/benchmarks/bench_arrayproxy_slicing.py
@@ -59,15 +59,6 @@ else:
     HAVE_IGZIP = [False]
 
 
-@contextlib.contextmanager
-def patch_indexed_gzip(have_igzip):
-
-    atts = ['nibabel.openers.HAVE_INDEXED_GZIP']
-
-    with mock.patch(atts[0], have_igzip), mock.patch(atts[1], have_igzip):
-        yield
-
-
 def bench_arrayproxy_slicing():
 
     print_git_title('\nArrayProxy gzip slicing')
@@ -153,14 +144,15 @@ def bench_arrayproxy_slicing():
             # load uncompressed and compressed versions of the image
             img = nib.load(testfile, keep_file_open=keep_open)
 
-            with patch_indexed_gzip(have_igzip):
+            with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', have_igzip):
                 imggz = nib.load(testfilegz, keep_file_open=keep_open)
 
             def basefunc():
                 img.dataobj[fix_sliceobj(sliceobj)]
 
             def testfunc():
-                with patch_indexed_gzip(have_igzip):
+                with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP',
+                                have_igzip):
                     imggz.dataobj[fix_sliceobj(sliceobj)]
 
             # make sure nothing is floating around from the previous test

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -89,9 +89,9 @@ def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
     # use indexed_gzip if possible for faster read access.  If keep_open ==
     # True, we tell IndexedGzipFile to keep the file handle open. Otherwise
     # the IndexedGzipFile will close/open the file on each read.
-    if HAVE_INDEXED_GZIP and keep_open in (True, 'auto') and mode == 'rb':
+    if HAVE_INDEXED_GZIP and mode == 'rb':
         gzip_file = IndexedGzipFile(
-            filename, drop_handles=keep_open == 'auto')
+            filename, drop_handles=keep_open is not True)
 
     # Fall-back to built-in GzipFile (wrapped with the BufferedGzipFile class
     # defined above)

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -90,8 +90,7 @@ def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
     # True, we tell IndexedGzipFile to keep the file handle open. Otherwise
     # the IndexedGzipFile will close/open the file on each read.
     if HAVE_INDEXED_GZIP and mode == 'rb':
-        gzip_file = IndexedGzipFile(
-            filename, drop_handles=keep_open is not True)
+        gzip_file = IndexedGzipFile(filename, drop_handles=not keep_open)
 
     # Fall-back to built-in GzipFile (wrapped with the BufferedGzipFile class
     # defined above)

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -23,17 +23,11 @@ try:
 
     HAVE_INDEXED_GZIP = True
 
-    # < 0.6 - no good
-    if StrictVersion(version) < StrictVersion('0.6.0'):
+    # < 0.7 - no good
+    if StrictVersion(version) < StrictVersion('0.7.0'):
         warnings.warn('indexed_gzip is present, but too old '
-                      '(>= 0.6.0 required): {})'.format(version))
+                      '(>= 0.7.0 required): {})'.format(version))
         HAVE_INDEXED_GZIP = False
-    # < 0.7 - does not support drop_handles
-    elif StrictVersion(version) < StrictVersion('0.7.0'):
-        class IndexedGzipFile(igzip.SafeIndexedGzipFile):
-            def __init__(self, *args, **kwargs):
-                kwargs.pop('drop_handles', None)
-                super(IndexedGzipFile, self).__init__(*args, **kwargs)
     # >= 0.8 SafeIndexedGzipFile renamed to IndexedGzipFile
     elif StrictVersion(version) < StrictVersion('0.8.0'):
         IndexedGzipFile = igzip.SafeIndexedGzipFile

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -369,7 +369,7 @@ def test_keep_file_open_true_false_invalid():
         # Test that ArrayProxy(keep_file_open=True) only creates one file
         # handle, and that ArrayProxy(keep_file_open=False) creates a file
         # handle on every data access.
-        with mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+        with mock.patch('nibabel.openers.ImageOpener', CountingImageOpener):
             proxy_no_kfp = ArrayProxy(fname, ((10, 10, 10), dtype),
                                       keep_file_open=False)
             assert not proxy_no_kfp._keep_file_open
@@ -418,7 +418,7 @@ def test_keep_file_open_auto():
         # If have_indexed_gzip, then the arrayproxy should create one
         # ImageOpener
         with patch_indexed_gzip(True), \
-             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+             mock.patch('nibabel.openers.ImageOpener', CountingImageOpener):
             CountingImageOpener.num_openers = 0
             proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
                                keep_file_open='auto')
@@ -426,7 +426,7 @@ def test_keep_file_open_auto():
             assert _count_ImageOpeners(proxy, data, voxels) == 1
         # If no have_indexed_gzip, then keep_file_open should be False
         with patch_indexed_gzip(False), \
-             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+             mock.patch('nibabel.openers.ImageOpener', CountingImageOpener):
             CountingImageOpener.num_openers = 0
             proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
                                keep_file_open='auto')
@@ -438,14 +438,14 @@ def test_keep_file_open_auto():
             fobj.write(data.tostring(order='F'))
         # regardless of whether indexed_gzip is present or not
         with patch_indexed_gzip(True), \
-             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+             mock.patch('nibabel.openers.ImageOpener', CountingImageOpener):
             CountingImageOpener.num_openers = 0
             proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
                                keep_file_open='auto')
             assert proxy._keep_file_open is False
             assert _count_ImageOpeners(proxy, data, voxels) == 10
         with patch_indexed_gzip(False), \
-             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+             mock.patch('nibabel.openers.ImageOpener', CountingImageOpener):
             CountingImageOpener.num_openers = 0
             proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
                                keep_file_open='auto')

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -20,8 +20,7 @@ from ..tmpdirs import InTemporaryDirectory
 
 import numpy as np
 
-from ..arrayproxy import (ArrayProxy, KEEP_FILE_OPEN_DEFAULT, is_proxy,
-                          reshape_dataobj)
+from ..arrayproxy import (ArrayProxy, is_proxy, reshape_dataobj)
 from ..openers import ImageOpener
 from ..nifti1 import Nifti1Header
 
@@ -342,13 +341,18 @@ def check_mmap(hdr, offset, proxy_class,
 # An image opener class which counts how many instances of itself have been
 # created
 class CountingImageOpener(ImageOpener):
-
     num_openers = 0
-
     def __init__(self, *args, **kwargs):
-
         super(CountingImageOpener, self).__init__(*args, **kwargs)
         CountingImageOpener.num_openers += 1
+
+
+def _count_ImageOpeners(proxy, data, voxels):
+    CountingImageOpener.num_openers = 0
+    for i in range(voxels.shape[0]):
+        x, y, z = [int(c) for c in voxels[i, :]]
+        assert proxy[x, y, z] == x * 100 + y * 10 + z
+    return CountingImageOpener.num_openers
 
 
 def test_keep_file_open_true_false_invalid():
@@ -369,18 +373,11 @@ def test_keep_file_open_true_false_invalid():
             proxy_no_kfp = ArrayProxy(fname, ((10, 10, 10), dtype),
                                       keep_file_open=False)
             assert not proxy_no_kfp._keep_file_open
-            for i in range(voxels.shape[0]):
-                x , y, z = [int(c) for c in voxels[i, :]]
-                assert proxy_no_kfp[x, y, z] == x * 100 + y * 10 + z
-                assert CountingImageOpener.num_openers == i + 1
-            CountingImageOpener.num_openers = 0
+            assert _count_ImageOpeners(proxy_no_kfp, data, voxels) == 10
             proxy_kfp = ArrayProxy(fname, ((10, 10, 10), dtype),
                                    keep_file_open=True)
             assert proxy_kfp._keep_file_open
-            for i in range(voxels.shape[0]):
-                x , y, z = [int(c) for c in voxels[i, :]]
-                assert proxy_kfp[x, y, z] == x * 100 + y * 10 + z
-                assert CountingImageOpener.num_openers == 1
+            assert _count_ImageOpeners(proxy_kfp, data, voxels) == 1
             del proxy_kfp
             del proxy_no_kfp
         # Test that the keep_file_open flag has no effect if an open file
@@ -389,10 +386,9 @@ def test_keep_file_open_true_false_invalid():
             for kfo in (True, False, 'auto'):
                 proxy = ArrayProxy(fobj, ((10, 10, 10), dtype),
                                    keep_file_open=kfo)
-                if kfo == 'auto':
-                    kfo = False
-                assert proxy._keep_file_open is kfo
+                assert proxy._keep_file_open is False
                 for i in range(voxels.shape[0]):
+                    x, y, z = [int(c) for c in voxels[i, :]]
                     assert proxy[x, y, z] == x * 100 + y * 10 + z
                     assert not fobj.closed
                 del proxy
@@ -400,15 +396,42 @@ def test_keep_file_open_true_false_invalid():
         assert fobj.closed
         # Test invalid values of keep_file_open
         with assert_raises(ValueError):
-            ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open=0)
-        with assert_raises(ValueError):
-            ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open=1)
-        with assert_raises(ValueError):
             ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open=55)
         with assert_raises(ValueError):
             ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='autob')
         with assert_raises(ValueError):
             ArrayProxy(fname, ((10, 10, 10), dtype), keep_file_open='cauto')
+
+
+def test_keep_file_open_auto():
+    # Test the behaviour of the keep_file_open __init__ flag, when it is set to
+    # 'auto'.
+    # if indexed_gzip is present, the ArrayProxy should persist its ImageOpener.
+    # Otherwise the ArrayProxy should drop openers.
+    dtype = np.float32
+    data = np.arange(1000, dtype=dtype).reshape((10, 10, 10))
+    voxels = np.random.randint(0, 10, (10, 3))
+    with InTemporaryDirectory():
+        fname  = 'testdata.gz'
+        with gzip.open(fname, 'wb') as fobj:
+            fobj.write(data.tostring(order='F'))
+        # If have_indexed_gzip, then the arrayproxy should create one
+        # ImageOpener
+        with patch_indexed_gzip(True), \
+             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+            CountingImageOpener.num_openers = 0
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert proxy._keep_file_open == 'auto'
+            assert _count_ImageOpeners(proxy, data, voxels) == 1
+        # If no have_indexed_gzip, then keep_file_open should be False
+        with patch_indexed_gzip(False), \
+             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+            CountingImageOpener.num_openers = 0
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert proxy._keep_file_open is False
+            assert _count_ImageOpeners(proxy, data, voxels) == 10
 
 
 @contextlib.contextmanager
@@ -418,62 +441,42 @@ def patch_keep_file_open_default(value):
         yield
 
 
-def test_keep_file_open_auto():
-    # Test the behaviour of the keep_file_open __init__ flag, when it is set to
-    # 'auto'
-    dtype = np.float32
-    data  = np.arange(1000, dtype=dtype).reshape((10, 10, 10))
-    with InTemporaryDirectory():
-        fname  = 'testdata.gz'
-        with gzip.open(fname, 'wb') as fobj:
-            fobj.write(data.tostring(order='F'))
-        # If have_indexed_gzip, then keep_file_open should be True
-        with patch_indexed_gzip(True):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
-                               keep_file_open='auto')
-            assert proxy._keep_file_open
-        # If no have_indexed_gzip, then keep_file_open should be False
-        with patch_indexed_gzip(False):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
-                               keep_file_open='auto')
-            assert not proxy._keep_file_open
-
-
 def test_keep_file_open_default():
     # Test the behaviour of the keep_file_open __init__ flag, when the
     # arrayproxy.KEEP_FILE_OPEN_DEFAULT value is changed
     dtype = np.float32
-    data  = np.arange(1000, dtype=dtype).reshape((10, 10, 10))
+    data = np.arange(1000, dtype=dtype).reshape((10, 10, 10))
     with InTemporaryDirectory():
         fname  = 'testdata.gz'
         with gzip.open(fname, 'wb') as fobj:
             fobj.write(data.tostring(order='F'))
-        # The default value of KEEP_FILE_OPEN_DEFAULT should cause
-        # keep_file_open to be False, regardless of whether or not indexed_gzip
-        # is present
-        assert KEEP_FILE_OPEN_DEFAULT is False
-        with patch_indexed_gzip(False):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert not proxy._keep_file_open
-        with patch_indexed_gzip(True):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert not proxy._keep_file_open
-        # KEEP_FILE_OPEN_DEFAULT=True should cause keep_file_open to be True,
-        # regardless of whether or not indexed_gzip is present
-        with patch_keep_file_open_default(True), patch_indexed_gzip(True):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert proxy._keep_file_open
-        with patch_keep_file_open_default(True), patch_indexed_gzip(False):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert proxy._keep_file_open
-        # KEEP_FILE_OPEN_DEFAULT=auto should cause keep_file_open to be True
-        # or False, depending on whether indeed_gzip is present,
-        with patch_keep_file_open_default('auto'), patch_indexed_gzip(True):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert proxy._keep_file_open
-        with patch_keep_file_open_default('auto'), patch_indexed_gzip(False):
-            proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
-            assert not proxy._keep_file_open
+        # If KEEP_FILE_OPEN_DEFAULT is False, ArrayProxy instances should
+        # interpret keep_file_open as False
+        with patch_keep_file_open_default(False):
+            with patch_indexed_gzip(False):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open is False
+            with patch_indexed_gzip(True):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open is False
+        # If KEEP_FILE_OPEN_DEFAULT is True, ArrayProxy instances should
+        # interpret keep_file_open as True
+        with patch_keep_file_open_default(True):
+            with patch_indexed_gzip(False):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open is True
+            with patch_indexed_gzip(True):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open is True
+        # If KEEP_FILE_OPEN_DEFAULT is auto, ArrayProxy instances should
+        # interpret it as auto if indexed_gzip is present, False otherwise.
+        with patch_keep_file_open_default('auto'):
+            with patch_indexed_gzip(False):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open is False
+            with patch_indexed_gzip(True):
+                proxy = ArrayProxy(fname, ((10, 10, 10), dtype))
+                assert proxy._keep_file_open == 'auto'
         # KEEP_FILE_OPEN_DEFAULT=any other value should cuse an error to be
         # raised
         with patch_keep_file_open_default('badvalue'):

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -432,6 +432,25 @@ def test_keep_file_open_auto():
                                keep_file_open='auto')
             assert proxy._keep_file_open is False
             assert _count_ImageOpeners(proxy, data, voxels) == 10
+        # If not a gzip file,  keep_file_open should be False
+        fname  = 'testdata'
+        with open(fname, 'wb') as fobj:
+            fobj.write(data.tostring(order='F'))
+        # regardless of whether indexed_gzip is present or not
+        with patch_indexed_gzip(True), \
+             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+            CountingImageOpener.num_openers = 0
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert proxy._keep_file_open is False
+            assert _count_ImageOpeners(proxy, data, voxels) == 10
+        with patch_indexed_gzip(False), \
+             mock.patch('nibabel.arrayproxy.ImageOpener', CountingImageOpener):
+            CountingImageOpener.num_openers = 0
+            proxy = ArrayProxy(fname, ((10, 10, 10), dtype),
+                               keep_file_open='auto')
+            assert proxy._keep_file_open is False
+            assert _count_ImageOpeners(proxy, data, voxels) == 10
 
 
 @contextlib.contextmanager

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -108,12 +108,11 @@ def patch_indexed_gzip(state):
     # Make it look like we do (state==True) or do not (state==False) have
     # the indexed gzip module.
     if state:
-        values = (True, True, MockIndexedGzipFile)
+        values = (True, MockIndexedGzipFile)
     else:
-        values = (False, False, GzipFile)
+        values = (False, GzipFile)
     with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', values[0]), \
-         mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', values[1]), \
-         mock.patch('nibabel.openers.IndexedGzipFile', values[2],
+         mock.patch('nibabel.openers.IndexedGzipFile', values[1],
                     create=True):
         yield
 

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -137,13 +137,13 @@ def test_Opener_gzip_type():
             (False, {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
             (False, {'mode' : 'wb', 'keep_open' : True},   GzipFile),
             (False, {'mode' : 'wb', 'keep_open' : False},  GzipFile),
-            (False, {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
+            (False, {'mode' : 'wb', 'keep_open' : 'auto'}, GzipFile),
             (True,  {'mode' : 'rb', 'keep_open' : True},   MockIndexedGzipFile),
             (True,  {'mode' : 'rb', 'keep_open' : False},  GzipFile),
             (True,  {'mode' : 'rb', 'keep_open' : 'auto'}, MockIndexedGzipFile),
             (True,  {'mode' : 'wb', 'keep_open' : True},   GzipFile),
             (True,  {'mode' : 'wb', 'keep_open' : False},  GzipFile),
-            (True,  {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
+            (True,  {'mode' : 'wb', 'keep_open' : 'auto'}, GzipFile),
         ]
 
         for test in tests:

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -97,9 +97,10 @@ def test_BinOpener():
                       BinOpener, 'test.txt', 'r')
 
 
-class MockIndexedGzipFile(object):
+class MockIndexedGzipFile(GzipFile):
     def __init__(self, *args, **kwargs):
-        pass
+        kwargs.pop('drop_handles', False)
+        super(MockIndexedGzipFile, self).__init__(*args, **kwargs)
 
 
 @contextlib.contextmanager
@@ -112,7 +113,7 @@ def patch_indexed_gzip(state):
         values = (False, False, GzipFile)
     with mock.patch('nibabel.openers.HAVE_INDEXED_GZIP', values[0]), \
          mock.patch('nibabel.arrayproxy.HAVE_INDEXED_GZIP', values[1]), \
-         mock.patch('nibabel.openers.SafeIndexedGzipFile', values[2],
+         mock.patch('nibabel.openers.IndexedGzipFile', values[2],
                     create=True):
         yield
 

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -133,14 +133,18 @@ def test_Opener_gzip_type():
         # Each test is specified by a tuple containing:
         #   (indexed_gzip present, Opener kwargs, expected file type)
         tests = [
-            (False, {'mode' : 'rb', 'keep_open' : True},  GzipFile),
-            (False, {'mode' : 'rb', 'keep_open' : False}, GzipFile),
-            (False, {'mode' : 'wb', 'keep_open' : True},  GzipFile),
-            (False, {'mode' : 'wb', 'keep_open' : False}, GzipFile),
-            (True,  {'mode' : 'rb', 'keep_open' : True},  MockIndexedGzipFile),
-            (True,  {'mode' : 'rb', 'keep_open' : False}, GzipFile),
-            (True,  {'mode' : 'wb', 'keep_open' : True},  GzipFile),
-            (True,  {'mode' : 'wb', 'keep_open' : False}, GzipFile),
+            (False, {'mode' : 'rb', 'keep_open' : True},   GzipFile),
+            (False, {'mode' : 'rb', 'keep_open' : False},  GzipFile),
+            (False, {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
+            (False, {'mode' : 'wb', 'keep_open' : True},   GzipFile),
+            (False, {'mode' : 'wb', 'keep_open' : False},  GzipFile),
+            (False, {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
+            (True,  {'mode' : 'rb', 'keep_open' : True},   MockIndexedGzipFile),
+            (True,  {'mode' : 'rb', 'keep_open' : False},  GzipFile),
+            (True,  {'mode' : 'rb', 'keep_open' : 'auto'}, MockIndexedGzipFile),
+            (True,  {'mode' : 'wb', 'keep_open' : True},   GzipFile),
+            (True,  {'mode' : 'wb', 'keep_open' : False},  GzipFile),
+            (True,  {'mode' : 'rb', 'keep_open' : 'auto'}, GzipFile),
         ]
 
         for test in tests:


### PR DESCRIPTION
This is an attempt to address #573. 

 - Deprecate the `keep_file_open` parameter
 - Always use `indexed_gzip` if it is present (this can be disabled by overwriting the `nibabel.openers.HAVE_INDEXED_GZIP` flag)
 - Change `ArrayProxy` so that, if `indexed_gzip` is present, and it is given a `.gz` file, it creates and uses a single `ImageOpener`. Otherwise it creates a new `ImageOpener` on every access.
