### PR TITLE
BF: be resilient to optional module non-ImportError exceptions upon import

### DIFF
--- a/nibabel/optpkg.py
+++ b/nibabel/optpkg.py
@@ -97,12 +97,11 @@ def optional_package(name, trip_msg=None, min_version=None):
     exc = None
     try:
         pkg = __import__(name, fromlist=fromlist)
-    except ImportError as exc:
-        pass
-    except Exception as exc:  # it failed to import for some other reason
+    except Exception as exc_:
+        # Could fail due to some ImportError or for some other reason
         # e.g. h5py might have been checking file system to support UTF-8
         # etc.  We should not blow if they blow
-        pass
+        exc = exc_  # So it is accessible outside of the code block
     else:  # import worked
         # top level module
         if check_version(pkg):

--- a/nibabel/optpkg.py
+++ b/nibabel/optpkg.py
@@ -94,9 +94,14 @@ def optional_package(name, trip_msg=None, min_version=None):
     # fromlist=[''] results in submodule being returned, rather than the top
     # level module.  See help(__import__)
     fromlist = [''] if '.' in name else []
+    exc = None
     try:
         pkg = __import__(name, fromlist=fromlist)
-    except ImportError:
+    except ImportError as exc:
+        pass
+    except Exception as exc:  # it failed to import for some other reason
+        # e.g. h5py might have been checking file system to support UTF-8
+        # etc.  We should not blow if they blow
         pass
     else:  # import worked
         # top level module
@@ -111,8 +116,8 @@ def optional_package(name, trip_msg=None, min_version=None):
                             (name, min_version))
     if trip_msg is None:
         trip_msg = ('We need package %s for these functions, but '
-                    '``import %s`` raised an ImportError'
-                    % (name, name))
+                    '``import %s`` raised %s'
+                    % (name, name, exc))
     pkg = TripWire(trip_msg)
 
     def setup_module():

--- a/nibabel/py3k.py
+++ b/nibabel/py3k.py
@@ -41,6 +41,7 @@ if sys.version_info[0] >= 3:
     ints2bytes = lambda seq: bytes(seq)
     ZEROB = bytes([0])
     FileNotFoundError = FileNotFoundError
+    import builtins
 else:
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
@@ -65,6 +66,8 @@ else:
 
     class FileNotFoundError(IOError):
         pass
+
+    import __builtin__ as builtins
 
 
 def getexception():

--- a/nibabel/py3k.py
+++ b/nibabel/py3k.py
@@ -67,7 +67,7 @@ else:
     class FileNotFoundError(IOError):
         pass
 
-    import __builtin__ as builtins
+    import __builtin__ as builtins  # flake8: noqa F401
 
 
 def getexception():

--- a/nibabel/tests/test_optpkg.py
+++ b/nibabel/tests/test_optpkg.py
@@ -1,6 +1,7 @@
 """ Testing optpkg module
 """
 
+import mock
 import types
 import sys
 from distutils.version import LooseVersion
@@ -36,6 +37,12 @@ def test_basic():
     assert_good('os.path')
     # We never have package _not_a_package
     assert_bad('_not_a_package')
+    def raise_Exception(*args, **kwargs):
+        raise Exception(
+            "non ImportError could be thrown by some malfunctioning module "
+            "upon import, and optional_package should catch it too")
+    with mock.patch('__builtin__.__import__', side_effect=raise_Exception):
+        assert_bad('nottriedbefore')
 
 
 def test_versions():

--- a/nibabel/tests/test_optpkg.py
+++ b/nibabel/tests/test_optpkg.py
@@ -11,6 +11,7 @@ from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal)
 
 
+from nibabel.py3k import builtins
 from nibabel.optpkg import optional_package
 from nibabel.tripwire import TripWire, TripWireError
 
@@ -41,7 +42,7 @@ def test_basic():
         raise Exception(
             "non ImportError could be thrown by some malfunctioning module "
             "upon import, and optional_package should catch it too")
-    with mock.patch('__builtin__.__import__', side_effect=raise_Exception):
+    with mock.patch.object(builtins, '__import__', side_effect=raise_Exception):
         assert_bad('nottriedbefore')
 
 


### PR DESCRIPTION
ATM h5py is giving a grief while trying to work on a filesystem without
utf-8 encoding support in filenames.