### PR TITLE
Better handle pathological filenames

### DIFF
--- a/nibabel/filename_parser.py
+++ b/nibabel/filename_parser.py
@@ -264,9 +264,14 @@ def splitext_addext(filename,
     for ext in addexts:
         if endswith(filename, ext):
             extpos = -len(ext)
-            addext = filename[extpos:]
-            filename = filename[:extpos]
+            filename, addext = filename[:extpos], filename[extpos:]
             break
     else:
         addext = ''
-    return os.path.splitext(filename) + (addext,)
+    # os.path.splitext() behaves unexpectedly when filename starts with '.'
+    extpos = filename.rfind('.')
+    if extpos < 0 or filename.strip('.') == '':
+        root, ext = filename, ''
+    else:
+        root, ext = filename[:extpos], filename[extpos:]
+    return (root, ext, addext)

--- a/nibabel/tests/test_filename_parser.py
+++ b/nibabel/tests/test_filename_parser.py
@@ -159,3 +159,14 @@ def test_splitext_addext():
     # case sensitive
     res = splitext_addext('fname.ext.FOO', ('.foo', '.bar'), True)
     assert_equal(res, ('fname.ext', '.FOO', ''))
+    # edge cases
+    res = splitext_addext('.nii')
+    assert_equal(res, ('', '.nii', ''))
+    res = splitext_addext('...nii')
+    assert_equal(res, ('..', '.nii', ''))
+    res = splitext_addext('.')
+    assert_equal(res, ('.', '', ''))
+    res = splitext_addext('..')
+    assert_equal(res, ('..', '', ''))
+    res = splitext_addext('...')
+    assert_equal(res, ('...', '', ''))


### PR DESCRIPTION
_os.path.splitext()_ does not provide the behavior we need to properly
recognize edge cases such as `.nii` as image files.

Fixes #620