### PR TITLE
[WIP] ENH: Relax default threshold for negative w2 in fillpositive

### DIFF
--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -96,7 +96,8 @@ def fillpositive(xyz, w2_thresh=None):
     # Calculate w
     w2 = 1.0 - np.dot(xyz, xyz)
     if w2 < 0:
-        if w2 < w2_thresh:
+        # if w2 is negative and is not very very close to zero
+        if w2 < w2_thresh and not np.isclose(w2, 0, rtol=1e-05, atol=1e-05):
             raise ValueError('w2 should be positive, but is %e' % w2)
         w = 0
     else:


### PR DESCRIPTION
I have added the condition `and not np.isclose(w2, 0, rtol=1e-05, atol=1e-05)` because I had some problems to load data as the w2 value was a very very very small negative value close to zero (precision error).

This fixed it for me. Does it make sense? 