### PR TITLE
FIX: Fix for NumPy deprecation

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -255,7 +255,7 @@ class MGHHeader(LabeledWrapStruct):
         .. _mghformat: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat#line-82
         '''
         # Do not return time zoom (TR) if 3D image
-        tzoom = (self['tr'],)[:int(self._ndims() > 3)]
+        tzoom = (self['tr'],) if self._ndims() > 3 else ()
         return tuple(self._structarr['delta']) + tzoom
 
     def set_zooms(self, zooms):

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -255,7 +255,7 @@ class MGHHeader(LabeledWrapStruct):
         .. _mghformat: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat#line-82
         '''
         # Do not return time zoom (TR) if 3D image
-        tzoom = (self['tr'],)[:self._ndims() > 3]
+        tzoom = (self['tr'],)[:int(self._ndims() > 3)]
         return tuple(self._structarr['delta']) + tzoom
 
     def set_zooms(self, zooms):


### PR DESCRIPTION
Fixes this warning:
```
  /home/larsoner/custombuilds/nibabel/nibabel/freesurfer/mghformat.py:258: DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
    tzoom = (self['tr'],)[:self._ndims() > 3]
```