### PR TITLE
ENH: Add SerializableImage class with to/from_bytes methods

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -65,6 +65,7 @@ from .nifti2 import Nifti2Header, Nifti2Image, Nifti2Pair
 from .minc1 import Minc1Image
 from .minc2 import Minc2Image
 from .cifti2 import Cifti2Header, Cifti2Image
+from .gifti import GiftiImage
 # Deprecated backwards compatiblity for MINC1
 from .deprecated import ModuleProxy as _ModuleProxy
 minc = _ModuleProxy('nibabel.minc')

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -511,3 +511,9 @@ class FileBasedImage(object):
         if sniff is None or len(sniff[0]) < klass._meta_sniff_len:
             return False, sniff
         return klass.header_class.may_contain_header(sniff[0]), sniff
+
+    def serialize(self):
+        bio = io.BytesIO()
+        file_map = self.make_file_map({'image': bio, 'header': bio})
+        self.to_file_map(file_map)
+        return bio.getvalue()

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -561,7 +561,10 @@ class SerializableImage(FileBasedImage):
 
     Images that consist of separate header and data files (e.g., Analyze
     images) currently do not support this interface.
+    For multi-file images, ``to_bytes()`` and ``from_bytes()`` must be
+    overridden, and any encoding details should be documented.
     '''
+
     @classmethod
     def from_bytes(klass, bytestring):
         """ Construct image from a byte string

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -513,6 +513,18 @@ class FileBasedImage(object):
         return klass.header_class.may_contain_header(sniff[0]), sniff
 
     def serialize(self):
+        """ Return a ``bytes`` object with the contents of the file that would
+        be written if the image were saved.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        bytes
+            Serialized image
+        """
         bio = io.BytesIO()
         file_map = self.make_file_map({'image': bio, 'header': bio})
         self.to_file_map(file_map)

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -573,6 +573,8 @@ class SerializableImage(FileBasedImage):
         bstring : bytes
             Byte string containing the on-disk representation of an image
         """
+        if len(klass.files_types) > 1:
+            raise NotImplementedError("from_bytes is undefined for multi-file images")
         bio = io.BytesIO(bytestring)
         file_map = klass.make_file_map({'image': bio, 'header': bio})
         return klass.from_file_map(file_map)
@@ -590,6 +592,8 @@ class SerializableImage(FileBasedImage):
         bytes
             Serialized image
         """
+        if len(self.__class__.files_types) > 1:
+            raise NotImplementedError("to_bytes() is undefined for multi-file images")
         bio = io.BytesIO()
         file_map = self.make_file_map({'image': bio, 'header': bio})
         self.to_file_map(file_map)

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -261,6 +261,21 @@ class FileBasedImage(object):
         return klass.from_file_map(file_map)
 
     @classmethod
+    def from_bytes(klass, bstring):
+        """ Construct image from a byte string
+
+        Class method
+
+        Parameters
+        ----------
+        bstring : bytes
+            Byte string containing the on-disk representation of an image
+        """
+        bio = io.BytesIO(bstring)
+        file_map = self.make_file_map({'image': bio, 'header': bio})
+        return klass.from_file_map(file_map)
+
+    @classmethod
     def from_file_map(klass, file_map):
         raise NotImplementedError
 
@@ -333,6 +348,24 @@ class FileBasedImage(object):
         '''
         self.file_map = self.filespec_to_file_map(filename)
         self.to_file_map()
+
+    def to_bytes(self):
+        """ Return a ``bytes`` object with the contents of the file that would
+        be written if the image were saved.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        bytes
+            Serialized image
+        """
+        bio = io.BytesIO()
+        file_map = self.make_file_map({'image': bio, 'header': bio})
+        self.to_file_map(file_map)
+        return bio.getvalue()
 
     @deprecate_with_version('to_filespec method is deprecated.\n'
                             'Please use the "to_filename" method instead.',
@@ -512,21 +545,3 @@ class FileBasedImage(object):
         if sniff is None or len(sniff[0]) < klass._meta_sniff_len:
             return False, sniff
         return klass.header_class.may_contain_header(sniff[0]), sniff
-
-    def serialize(self):
-        """ Return a ``bytes`` object with the contents of the file that would
-        be written if the image were saved.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        bytes
-            Serialized image
-        """
-        bio = io.BytesIO()
-        file_map = self.make_file_map({'image': bio, 'header': bio})
-        self.to_file_map(file_map)
-        return bio.getvalue()

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -79,8 +79,8 @@ class FileBasedImage(object):
 
     methods:
 
-       * .get_header() (deprecated, use header property instead)
-       * .to_filename(fname) - writes data to filename(s) derived from
+       * get_header() (deprecated, use header property instead)
+       * to_filename(fname) - writes data to filename(s) derived from
          ``fname``, where the derivation may differ between formats.
        * to_file_map() - save image to files with which the image is already
          associated.
@@ -524,20 +524,26 @@ class SerializableImage(FileBasedImage):
 
     methods:
 
-       * .to_bytes() - serialize image to byte string
+       * to_bytes() - serialize image to byte string
 
     classmethods:
 
        * from_bytes(bytestring) - make instance by deserializing a byte string
 
-    The following properties should hold:
+    Loading from byte strings should provide round-trip equivalence:
 
-      * ``klass.from_bytes(bstr).to_bytes() == bstr``
-      * if ``img = orig.__class__.from_bytes(orig.to_bytes())``, then
-        ``img.header == orig.header`` and ``img.get_data() == orig.get_data()``
+    .. code:: python
+
+        img_a = klass.from_bytes(bstr)
+        img_b = klass.from_bytes(img_a.to_bytes())
+
+        np.allclose(img_a.get_fdata(), img_b.get_fdata())
+        np.allclose(img_a.affine, img_b.affine)
 
     Further, for images that are single files on disk, the following methods of loading
     the image must be equivalent:
+
+    .. code:: python
 
         img = klass.from_filename(fname)
 
@@ -546,15 +552,15 @@ class SerializableImage(FileBasedImage):
 
     And the following methods of saving a file must be equivalent:
 
+    .. code:: python
+
         img.to_filename(fname)
 
         with open(fname, 'wb') as fobj:
             fobj.write(img.to_bytes())
 
-    Images that consist of separate header and data files will generally
-    place the header with the data, but if the header is not of fixed
-    size and does not define its own size, a new format may need to be
-    defined.
+    Images that consist of separate header and data files (e.g., Analyze
+    images) currently do not support this interface.
     '''
     @classmethod
     def from_bytes(klass, bytestring):

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -8,6 +8,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 ''' Common interface for any image format--volume or surface, binary or xml.'''
 
+import io
 from copy import deepcopy
 from six import string_types
 from .fileholders import FileHolder

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -567,7 +567,7 @@ class SerializableImage(FileBasedImage):
         bstring : bytes
             Byte string containing the on-disk representation of an image
         """
-        bio = io.BytesIO(bstring)
+        bio = io.BytesIO(bytestring)
         file_map = klass.make_file_map({'image': bio, 'header': bio})
         return klass.from_file_map(file_map)
 

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -16,6 +16,7 @@ import numpy as np
 from ..affines import voxel_sizes, from_matvec
 from ..volumeutils import (array_to_file, array_from_file, endian_codes,
                            Recoder)
+from ..filebasedimages import SerializableImage
 from ..spatialimages import HeaderDataError, SpatialImage
 from ..fileholders import FileHolder
 from ..arrayproxy import ArrayProxy, reshape_dataobj
@@ -503,7 +504,7 @@ class MGHHeader(LabeledWrapStruct):
             super(MGHHeader, self).__setitem__(item, value)
 
 
-class MGHImage(SpatialImage):
+class MGHImage(SpatialImage, SerializableImage):
     """ Class for MGH format image
     """
     header_class = MGHHeader

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -18,7 +18,7 @@ import sys
 import numpy as np
 
 from .. import xmlutils as xml
-from ..filebasedimages import FileBasedImage
+from ..filebasedimages import SerializableImage
 from ..nifti1 import data_type_codes, xform_codes, intent_codes
 from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes, KIND2FMT)
@@ -534,7 +534,7 @@ class GiftiDataArray(xml.XmlSerializable):
         return self.meta.metadata
 
 
-class GiftiImage(xml.XmlSerializable, FileBasedImage):
+class GiftiImage(xml.XmlSerializable, SerializableImage):
     """ GIFTI image object
 
     The Gifti spec suggests using the following suffixes to your
@@ -723,6 +723,9 @@ class GiftiImage(xml.XmlSerializable, FileBasedImage):
         return b"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE GIFTI SYSTEM "http://www.nitrc.org/frs/download.php/115/gifti.dtd">
 """ + xml.XmlSerializable.to_xml(self, enc)
+
+    # Avoid the indirection of going through to_file_map
+    to_bytes = to_xml
 
     def to_file_map(self, file_map=None):
         """ Save the current image to the specified file_map

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -19,6 +19,7 @@ import numpy as np
 import numpy.linalg as npl
 
 from .py3k import asstr
+from .filebasedimages import SerializableImage
 from .volumeutils import Recoder, make_dt_codes, endian_codes
 from .spatialimages import HeaderDataError, ImageFileError
 from .batteryrunners import Report
@@ -1758,7 +1759,7 @@ class Nifti1PairHeader(Nifti1Header):
     is_single = False
 
 
-class Nifti1Pair(analyze.AnalyzeImage):
+class Nifti1Pair(analyze.AnalyzeImage, SerializableImage):
     """ Class for NIfTI1 format image, header pair
     """
     header_class = Nifti1PairHeader

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1759,7 +1759,7 @@ class Nifti1PairHeader(Nifti1Header):
     is_single = False
 
 
-class Nifti1Pair(analyze.AnalyzeImage, SerializableImage):
+class Nifti1Pair(analyze.AnalyzeImage):
     """ Class for NIfTI1 format image, header pair
     """
     header_class = Nifti1PairHeader
@@ -2026,7 +2026,7 @@ class Nifti1Pair(analyze.AnalyzeImage, SerializableImage):
         return img
 
 
-class Nifti1Image(Nifti1Pair):
+class Nifti1Image(Nifti1Pair, SerializableImage):
     """ Class for single file NIfTI1 format image
     """
     header_class = Nifti1Header

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -5,7 +5,7 @@ from itertools import product
 
 import numpy as np
 
-from ..filebasedimages import FileBasedHeader, FileBasedImage
+from ..filebasedimages import FileBasedHeader, FileBasedImage, SerializableImage
 
 from .test_image_api import GenericImageAPI, SerializeMixin
 
@@ -50,8 +50,11 @@ class FBNumpyImage(FileBasedImage):
         self.arr = self.arr.astype(dtype)
 
 
-class TestFBImageAPI(GenericImageAPI,
-                     SerializeMixin):
+class SerializableNumpyImage(FBNumpyImage, SerializableImage):
+    pass
+
+
+class TestFBImageAPI(GenericImageAPI):
     """ Validation for FileBasedImage instances
     """
     # A callable returning an image from ``image_maker(data, header)``
@@ -79,6 +82,10 @@ class TestFBImageAPI(GenericImageAPI,
                 shape=shape,
                 is_proxy=False)
             yield func, params
+
+
+class TestSerializableImageAPI(TestFBImageAPI, SerializeMixin):
+    image_maker = SerializableNumpyImage
 
 
 def test_filebased_header():

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -5,9 +5,9 @@ from itertools import product
 
 import numpy as np
 
-from nibabel.filebasedimages import FileBasedHeader, FileBasedImage
+from ..filebasedimages import FileBasedHeader, FileBasedImage
 
-from nibabel.tests.test_image_api import GenericImageAPI
+from .test_image_api import GenericImageAPI, SerializeMixin
 
 from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_not_equal)
@@ -50,7 +50,8 @@ class FBNumpyImage(FileBasedImage):
         self.arr = self.arr.astype(dtype)
 
 
-class TestFBImageAPI(GenericImageAPI):
+class TestFBImageAPI(GenericImageAPI,
+                     SerializeMixin):
     """ Validation for FileBasedImage instances
     """
     # A callable returning an image from ``image_maker(data, header)``

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -87,6 +87,12 @@ class TestFBImageAPI(GenericImageAPI):
 class TestSerializableImageAPI(TestFBImageAPI, SerializeMixin):
     image_maker = SerializableNumpyImage
 
+    @staticmethod
+    def _header_eq(header_a, header_b):
+        """ FileBasedHeader is an abstract class, so __eq__ is undefined.
+        Checking for the same header type is sufficient, here. """
+        return type(header_a) == type(header_b) == FileBasedHeader
+
 
 def test_filebased_header():
     # Test stuff about the default FileBasedHeader

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -38,6 +38,7 @@ _, have_h5py, _ = optional_package('h5py')
 
 from .. import (AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage,
                 Nifti1Pair, Nifti1Image, Nifti2Pair, Nifti2Image,
+                GiftiImage,
                 MGHImage, Minc1Image, Minc2Image, is_proxy)
 from ..spatialimages import SpatialImage
 from .. import minc1, minc2, parrec, brikhead
@@ -729,6 +730,12 @@ class TestMGHAPI(ImageHeaderAPI, SerializeMixin):
     has_scaling = True
     can_save = True
     standard_extension = '.mgh'
+
+
+class TestGiftiAPI(LoadImageAPI, SerializeMixin):
+    klass = image_maker = GiftiImage
+    can_save = True
+    standard_extension = '.gii'
 
 
 class TestAFNIAPI(LoadImageAPI):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -493,6 +493,19 @@ class AffineMixin(object):
             assert_true(aff is img.get_affine())
 
 
+class SerializeMixin(object):
+
+    def validate_serialize(self, imaker, params):
+        img = imaker()
+        serialized = img.serialize()
+        with InTemporaryDirectory():
+            fname = 'img' + self.standard_extension
+            img.to_filename(fname)
+            with open(fname, 'rb') as fobj:
+                file_contents = fobj.read()
+        assert serialized == file_contents
+
+
 class LoadImageAPI(GenericImageAPI,
                    DataInterfaceMixin,
                    AffineMixin,
@@ -613,7 +626,7 @@ class TestNifti1PairAPI(TestSpm99AnalyzeAPI):
     can_save = True
 
 
-class TestNifti1API(TestNifti1PairAPI):
+class TestNifti1API(TestNifti1PairAPI, SerializeMixin):
     klass = image_maker = Nifti1Image
     standard_extension = '.nii'
 
@@ -660,7 +673,7 @@ class TestPARRECAPI(LoadImageAPI):
 #    standard_extension = '.v'
 
 
-class TestMGHAPI(ImageHeaderAPI):
+class TestMGHAPI(ImageHeaderAPI, SerializeMixin):
     klass = image_maker = MGHImage
     example_shapes = ((2, 3, 4), (2, 3, 4, 5))  # MGH can only do >= 3D
     has_scaling = True

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -520,6 +520,8 @@ class SerializeMixin(object):
 
                 assert self._header_eq(img_a.header, img_b.header)
                 assert np.array_equal(img_a.get_data(), img_b.get_data())
+                del img_a
+                del img_b
 
     def validate_to_from_bytes(self, imaker, params):
         img = imaker()
@@ -538,6 +540,8 @@ class SerializeMixin(object):
                 assert img_b.to_bytes() == bytes_a
                 assert self._header_eq(img_a.header, img_b.header)
                 assert np.array_equal(img_a.get_data(), img_b.get_data())
+                del img_a
+                del img_b
 
     @staticmethod
     def _header_eq(header_a, header_b):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -545,19 +545,13 @@ class SerializeMixin(object):
 
     @staticmethod
     def _header_eq(header_a, header_b):
-        """ Quick-and-dirty header equality check
+        """ Header equality check that can be overridden by a subclass of this test
 
-        Abstract classes may have undefined equality, in which case test for
-        same type
+        This allows us to retain the same tests above when testing an image that uses an
+        abstract class as a header, namely when testing the FileBasedImage API, which
+        raises a NotImplementedError for __eq__
         """
-        not_implemented = False
-        header_eq = True
-        try:
-            header_eq = header_a == header_b
-        except NotImplementedError:
-            header_eq = type(header_a) == type(header_b)
-
-        return header_eq
+        return header_a == header_b
 
 
 

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -505,24 +505,36 @@ class SerializeMixin(object):
         assert serialized == file_contents
 
     def validate_from_bytes(self, imaker, params):
-        for img_params in self.example_images:
-            img_a = self.klass.from_filename(img_params['fname'])
-            with open(img_params['fname'], 'rb') as fobj:
-                img_b = self.klass.from_bytes(fobj.read())
+        img = imaker()
+        with InTemporaryDirectory():
+            fname = 'img' + self.standard_extension
+            img.to_filename(fname)
 
-            assert img_a.header == img_b.header
-            assert np.array_equal(img_a.get_data(), img_b.get_data())
+            all_images = list(getattr(self, 'example_images', [])) + [{'fname': fname}]
+            for img_params in all_images:
+                img_a = self.klass.from_filename(img_params['fname'])
+                with open(img_params['fname'], 'rb') as fobj:
+                    img_b = self.klass.from_bytes(fobj.read())
 
-    def validate_round_trip(self, imaker, params):
-        for img_params in self.example_images:
-            img_a = self.klass.from_filename(img_params['fname'])
-            bytes_a = img_a.to_bytes()
+                assert img_a.header == img_b.header
+                assert np.array_equal(img_a.get_data(), img_b.get_data())
 
-            img_b = self.klass.from_bytes(bytes_a)
+    def validate_to_from_bytes(self, imaker, params):
+        img = imaker()
+        with InTemporaryDirectory():
+            fname = 'img' + self.standard_extension
+            img.to_filename(fname)
 
-            assert img_b.to_bytes() == bytes_a
-            assert img_a.header == img_b.header
-            assert np.array_equal(img_a.get_data(), img_b.get_data())
+            all_images = list(getattr(self, 'example_images', [])) + [{'fname': fname}]
+            for img_params in all_images:
+                img_a = self.klass.from_filename(img_params['fname'])
+                bytes_a = img_a.to_bytes()
+
+                img_b = self.klass.from_bytes(bytes_a)
+
+                assert img_b.to_bytes() == bytes_a
+                assert img_a.header == img_b.header
+                assert np.array_equal(img_a.get_data(), img_b.get_data())
 
 
 class LoadImageAPI(GenericImageAPI,


### PR DESCRIPTION
Closes #639.

Implements to/from_bytes for single-image variants of NIfTI-1, NIfTI-2, GIFTI and CIFTI2 images, as well as MGH images.

Created an abstract class deriving from `FileBasedImage` that can be used in other images, if it becomes desirable, but didn't want to spend a ton of time nailing it down for image types I have an, at best, passing familiarity with.