### PR TITLE
FIX: Allow tr=0 in MGH files

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -277,11 +277,14 @@ class MGHHeader(LabeledWrapStruct):
         if len(zooms) > ndims:
             raise HeaderDataError('Expecting %d zoom values' % ndims)
         if np.any(zooms[:3] <= 0):
-            raise HeaderDataError('zooms[:3] must be positive')
+            raise HeaderDataError('Spatial (first three) zooms must be '
+                                  'positive; got {!r}'
+                                  ''.format(tuple(zooms[:3])))
         hdr['delta'] = zooms[:3]
         if len(zooms) == 4:
             if zooms[3] < 0:
-                raise HeaderDataError('zooms[3] must be non-negative')
+                raise HeaderDataError('TR must be non-negative; got {!r}'
+                                      ''.format(zooms[3]))
             hdr['tr'] = zooms[3]
 
     def get_data_shape(self):

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -276,10 +276,12 @@ class MGHHeader(LabeledWrapStruct):
         ndims = self._ndims()
         if len(zooms) > ndims:
             raise HeaderDataError('Expecting %d zoom values' % ndims)
-        if np.any(zooms <= 0):
-            raise HeaderDataError('zooms must be positive')
+        if np.any(zooms[:3] <= 0):
+            raise HeaderDataError('zooms[:3] must be positive')
         hdr['delta'] = zooms[:3]
         if len(zooms) == 4:
+            if zooms[3] < 0:
+                raise HeaderDataError('zooms[3] must be non-negative')
             hdr['tr'] = zooms[3]
 
     def get_data_shape(self):

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -159,6 +159,8 @@ def test_set_zooms():
                   (1, 1, 1, 1, 5)):
         with assert_raises(HeaderDataError):
             h.set_zooms(zooms)
+    # smoke test for tr=0
+    h.set_zooms((1, 1, 1, 0))
 
 
 def bad_dtype_mgh():


### PR DESCRIPTION
I have an MGH image that had zooms of `(1, 1, 1, 0)`. Simlply calling `set_zooms(get_zooms())` would fail on this file without this change.

Notably, the base class uses a non-negative check rather than strictly positive, but the less invasive change for MGH was to relax the check for only the last element.