### PR TITLE
BF(workaround): skip test_diff if hypothesis is not importable

### DIFF
--- a/nibabel/tests/test_diff.py
+++ b/nibabel/tests/test_diff.py
@@ -7,9 +7,13 @@ from __future__ import division, print_function, absolute_import
 from os.path import (dirname, join as pjoin, abspath)
 import numpy as np
 
-from hypothesis import given
-import hypothesis.strategies as st
-
+try:
+    import hypothesis
+    from hypothesis import given
+    import hypothesis.strategies as st
+except Exception as exc:
+    from nose import SkipTest
+    raise SkipTest("Failed to import hypothesis or its components: %s" % exc)
 
 DATA_PATH = abspath(pjoin(dirname(__file__), 'data'))
 


### PR DESCRIPTION
Apparently hypothesis  is quite a tricky beast.  It might either fail to install
on elderly systems from source tarball, or even if it is installable, apparently
might rely on some coverage API which is present only in more recent versions
and thus fail upon import.

All those are of relevance for older systems and only for testing.

I know that e.g. #661 would add tests in the `test_diff.py`  which would not even need hypothesis, but I do not see easy way to make it work since hypothesis's given is used as a decorator.