### PR TITLE
WIP,BF: Fix interaction between `indexed_gzip` presence and `keep_file_open` flag

### DIFF
--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -107,7 +107,7 @@ def test_BinOpener():
 
 class MockIndexedGzipFile(GzipFile):
     def __init__(self, *args, **kwargs):
-        kwargs.pop('drop_handles', False)
+        self._drop_handles = kwargs.pop('drop_handles', False)
         super(MockIndexedGzipFile, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
According to the discussion in #614, the behaviour of the `keep_file_open` flag should be as follows (copied verbatim from [this comment](https://github.com/nipy/nibabel/pull/614#issuecomment-394177749), which I believe was the behaviour that was agreed upon):


HAVE_INDEXED_GZIP | keep_file_open | Library used | ArrayProxy persists opener | indexed_gzip.drop_handles
-- | -- | -- | -- | --
False | False | gzip | No | na
False | 'auto' | gzip | No | na
False | True | gzip | Yes | na
True | False | indexed_gzip | Yes | True
True | 'auto' | indexed_gzip | Yes | False
True | True | indexed_gzip | Yes | False

But the behaviour of `nibabel` 2.3.0 doesn't match this expected behaviour. 

Assuming that `indexed_gzip` is installed, a simple test shows that the `ArrayProxy` is not creating and persisting one `ImageOpener`:

```python
In [1]: import nibabel as nib

In [2]: from nibabel.openers import HAVE_INDEXED_GZIP

In [3]: HAVE_INDEXED_GZIP
Out[3]: True

In [4]: img = nib.load('some_image.nii.gz')

In [5]: _ = img.dataobj[..., 0]

In [6]: img.dataobj._opener
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-356fc96fb10d> in <module>()
----> 1 img.dataobj._opener

AttributeError: 'ArrayProxy' object has no attribute '_opener'

In [7]:
```

This PR aims to fix the behaviour of `nibabel` so that it matches what was discussed in #614.
