### PR TITLE
Fix small typos in the help of the parrec cmdline tool

### DIFF
--- a/nibabel/cmdline/parrec2nii.py
+++ b/nibabel/cmdline/parrec2nii.py
@@ -89,7 +89,7 @@ def get_opt_parser():
     p.add_option(
         Option("--minmax", action="store", nargs=2, dest="minmax",
                help=one_line(
-                   """Mininum and maximum settings to be stored in the NIfTI
+                   """Minimum and maximum settings to be stored in the NIfTI
                    header. If any of them is set to 'parse', the scaled data is
                    scanned for the actual minimum and maximum.  To bypass this
                    potentially slow and memory intensive step (the data has to
@@ -103,7 +103,7 @@ def get_opt_parser():
                default=False,
                help=one_line(
                    """If set, all information from the PAR header is stored in
-                   an extension ofthe NIfTI file header.  Default: off""")))
+                   an extension of the NIfTI file header.  Default: off""")))
     p.add_option(
         Option("--scaling", action="store", dest="scaling", default='dv',
                help=one_line(


### PR DESCRIPTION
Whilst I was working on #681, I came across these two small typos in the flag help of the parrec2nii command line tool.