### PR TITLE
MNT: Remove deprecated numpy.asscalar

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -1057,10 +1057,8 @@ class AnalyzeImage(SpatialImage):
         # Store consumable values for later restore
         offset = hdr.get_data_offset()
         # Scalars of slope, offset to get immutable values
-        slope = (np.asscalar(hdr['scl_slope']) if hdr.has_data_slope
-                 else np.nan)
-        inter = (np.asscalar(hdr['scl_inter']) if hdr.has_data_intercept
-                 else np.nan)
+        slope = hdr['scl_slope'].item() if hdr.has_data_slope else np.nan
+        inter = hdr['scl_inter'].item() if hdr.has_data_intercept else np.nan
         # Check whether to calculate slope / inter
         scale_me = np.all(np.isnan((slope, inter)))
         if scale_me:

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -657,8 +657,8 @@ class EcatSubHeader(object):
         subhdr = self.subheaders[frame]
         raw_data = self.raw_data_from_fileobj(frame, orientation)
         # Scale factors have to be set to scalars to force scalar upcasting
-        data = raw_data * np.asscalar(header['ecat_calibration_factor'])
-        data = data * np.asscalar(subhdr['scale_factor'])
+        data = raw_data * header['ecat_calibration_factor'].item()
+        data = data * subhdr['scale_factor'].item()
         return data
 
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1330,7 +1330,7 @@ class Nifti1Header(SpmAnalyzeHeader):
             raise TypeError('repr can be "label" or "code"')
         n_params = len(recoder.parameters[code]) if known_intent else 0
         params = (float(hdr['intent_p%d' % (i + 1)]) for i in range(n_params))
-        name = asstr(np.asscalar(hdr['intent_name']))
+        name = asstr(hdr['intent_name'].item())
         return label, tuple(params), name
 
     def set_intent(self, code, params=(), name='', allow_unknown=False):
@@ -1679,7 +1679,7 @@ class Nifti1Header(SpmAnalyzeHeader):
     @staticmethod
     def _chk_magic(hdr, fix=False):
         rep = Report(HeaderDataError)
-        magic = np.asscalar(hdr['magic'])
+        magic = hdr['magic'].item()
         if magic in (hdr.pair_magic, hdr.single_magic):
             return hdr, rep
         rep.problem_msg = ('magic string "%s" is not valid' %
@@ -1693,8 +1693,8 @@ class Nifti1Header(SpmAnalyzeHeader):
     def _chk_offset(hdr, fix=False):
         rep = Report(HeaderDataError)
         # for ease of later string formatting, use scalar of byte string
-        magic = np.asscalar(hdr['magic'])
-        offset = np.asscalar(hdr['vox_offset'])
+        magic = hdr['magic'].item()
+        offset = hdr['vox_offset'].item()
         if offset == 0:
             return hdr, rep
         if magic == hdr.single_magic and offset < hdr.single_vox_offset:

--- a/nibabel/trackvis.py
+++ b/nibabel/trackvis.py
@@ -156,7 +156,7 @@ def read(fileobj, as_generator=False, points_space=None, strict=True):
     hdr = np.ndarray(shape=(),
                      dtype=header_2_dtype,
                      buffer=hdr_str)
-    if np.asscalar(hdr['id_string'])[:5] != b'TRACK':
+    if hdr['id_string'].item()[:5] != b'TRACK':
         raise HeaderError('Expecting TRACK as first '
                           '5 characters of id_string')
     if hdr['hdr_size'] == 1000:
@@ -492,7 +492,7 @@ def _check_hdr_points_space(hdr, points_space):
             raise HeaderError('Affine zooms %s differ from voxel_size '
                               'field value %s' % (aff_zooms, zooms))
         aff_order = ''.join(aff2axcodes(affine))
-        voxel_order = asstr(np.asscalar(hdr['voxel_order']))
+        voxel_order = asstr(hdr['voxel_order'].item())
         if voxel_order == '':
             voxel_order = 'LPS'  # trackvis default
         if not voxel_order == aff_order:
@@ -526,7 +526,7 @@ def _hdr_from_mapping(hdr=None, mapping=None, endianness=native_code):
     for key, value in mapping.items():
         hdr[key] = value
     # check header values
-    if np.asscalar(hdr['id_string'])[:5] != b'TRACK':
+    if hdr['id_string'].item()[:5] != b'TRACK':
         raise HeaderError('Expecting TRACK as first '
                           '5 characaters of id_string')
     if hdr['version'] not in (1, 2):
@@ -556,7 +556,7 @@ def empty_header(endianness=None, version=2):
     >>> hdr = empty_header()
     >>> print(hdr['version'])
     2
-    >>> np.asscalar(hdr['id_string']) == b'TRACK'
+    >>> hdr['id_string'].item() == b'TRACK'
     True
     >>> endian_codes[hdr['version'].dtype.byteorder] == native_code
     True
@@ -654,7 +654,7 @@ def aff_from_hdr(trk_hdr, atleast_v2=None):
     aff = np.dot(DPCS_TO_TAL, aff)
     # Next we check against the 'voxel_order' field if present and not empty.
     try:
-        voxel_order = asstr(np.asscalar(trk_hdr['voxel_order']))
+        voxel_order = asstr(trk_hdr['voxel_order'].item())
     except (KeyError, ValueError):
         voxel_order = ''
     if voxel_order == '':

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -1545,7 +1545,7 @@ def rec2dict(rec):
     for key in rec.dtype.fields:
         val = rec[key]
         try:
-            val = np.asscalar(val)
+            val = val.item()
         except ValueError:
             pass
         dct[key] = val


### PR DESCRIPTION
I think this should fix the error in the prerelease tests: https://travis-ci.org/nipy/nibabel/jobs/444811573

The semantics of `ndarray.item()` have not changed since before 1.7.1, so there is no need to update the minimum numpy version.