### PR TITLE
CI: Move AppVeyor to Miniconda instead of native Python installations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,17 @@
 # CI on Windows via appveyor
 
 environment:
-
   matrix:
-    - PYTHON: C:\Python27
-    - PYTHON: C:\Python27-x64
-    - PYTHON: C:\Python34
-    - PYTHON: C:\Python34-x64
-    - PYTHON: C:\Python35
-    - PYTHON: C:\Python35-x64
-    - PYTHON: C:\Python36
-    - PYTHON: C:\Python36-x64
-    - PYTHON: C:\Python37
-    - PYTHON: C:\Python37-x64
+    - PYTHON: C:\Miniconda
+    - PYTHON: C:\Miniconda-x64
+    - PYTHON: C:\Miniconda34
+    - PYTHON: C:\Miniconda34-x64
+    - PYTHON: C:\Miniconda35
+    - PYTHON: C:\Miniconda35-x64
+    - PYTHON: C:\Miniconda36
+    - PYTHON: C:\Miniconda36-x64
+    - PYTHON: C:\Miniconda37
+    - PYTHON: C:\Miniconda37-x64
 
 install:
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ install:
 
   # Install the dependencies of the project.
   - python -m pip install --upgrade pip setuptools wheel
-  - pip install numpy scipy matplotlib nose h5py mock pydicom
-  - pip install .
+  - python -m pip install numpy scipy matplotlib nose h5py mock pydicom
+  - python -m pip install .
   - SET NIBABEL_DATA_DIR=%CD%\nibabel-data
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
     - PYTHON: C:\Miniconda37-x64
 
 install:
+  - ls C:\
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,8 @@ test_script:
   # Change into an innocuous directory and find tests from installation
   - mkdir for_testing
   - cd for_testing
+  # Print Python, numpy versions
+  - python -c "import sys, numpy; print('Python', sys.version); print('numpy', numpy.__version__)"
+  # Show all environment variables to ease possible future debugging
+  - set
   - nosetests --with-doctest nibabel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   # Install the dependencies of the project.
+  - conda install -y pip
   - python -m pip install --upgrade pip setuptools wheel
   - python -m pip install numpy scipy matplotlib nose h5py mock pydicom
   - python -m pip install .


### PR DESCRIPTION
Fixes #665.

Closes #676.
Closes #680.
