### PR TITLE
RF: Circumvents a deprecation warning from `np.fromstring`

### DIFF
--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -58,7 +58,7 @@ def test_cifti2_metadata():
     assert_equal(md.data, dict(metadata_test))
 
     assert_equal(list(iter(md)), list(iter(collections.OrderedDict(metadata_test))))
-    
+
     md.update({'a': 'aval', 'b': 'bval'})
     assert_equal(md.data, dict(metadata_test))
 
@@ -310,7 +310,7 @@ def test_matrix():
 
     assert_raises(ci.Cifti2HeaderError, m.insert, 0, mim_none)
     assert_equal(m.mapped_indices, [])
-   
+
     h = ci.Cifti2Header(matrix=m)
     assert_equal(m.mapped_indices, [])
     m.insert(0, mim_0)

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -37,7 +37,7 @@ from mmap import mmap, ACCESS_READ
 
 import numpy as np  # noqa
 from ..py3k import asbytes, asstr
-from numpy import fromstring, ndarray, dtype, empty, array, asarray
+from numpy import frombuffer, ndarray, dtype, empty, array, asarray
 from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
 
@@ -519,7 +519,7 @@ class netcdf_file(object):
         if not magic == b'CDF':
             raise TypeError("Error: %s is not a valid NetCDF 3 file" %
                             self.filename)
-        self.__dict__['version_byte'] = fromstring(self.fp.read(1), '>b')[0]
+        self.__dict__['version_byte'] = frombuffer(self.fp.read(1), '>b')[0]
 
         # Read file headers and set data.
         self._read_numrecs()
@@ -608,7 +608,7 @@ class netcdf_file(object):
                 # Calculate size to avoid problems with vsize (above)
                 a_size = reduce(mul, shape, 1) * size
                 if self.file_bytes >= 0 and begin_ + a_size > self.file_bytes:
-                    data = fromstring(b'\x00'*a_size, dtype=dtype_)
+                    data = frombuffer(b'\x00'*a_size, dtype=dtype_)
                 elif self.use_mmap:
                     mm = mmap(self.fp.fileno(), begin_+a_size, access=ACCESS_READ)
                     data = ndarray.__new__(ndarray, shape, dtype=dtype_,
@@ -622,7 +622,7 @@ class netcdf_file(object):
                     buf = self.fp.read(a_size)
                     if len(buf) < a_size:
                         buf = b'\x00'*a_size
-                    data = fromstring(buf, dtype=dtype_)
+                    data = frombuffer(buf, dtype=dtype_)
                     data.shape = shape
                     self.fp.seek(pos)
 
@@ -644,7 +644,7 @@ class netcdf_file(object):
             else:
                 pos = self.fp.tell()
                 self.fp.seek(begin)
-                rec_array = fromstring(self.fp.read(self._recs*self._recsize), dtype=dtypes)
+                rec_array = frombuffer(self.fp.read(self._recs*self._recsize), dtype=dtypes)
                 rec_array.shape = (self._recs,)
                 self.fp.seek(pos)
 
@@ -687,7 +687,7 @@ class netcdf_file(object):
         self.fp.read(-count % 4)  # read padding
 
         if typecode is not 'c':
-            values = fromstring(values, dtype='>%s' % typecode)
+            values = frombuffer(values, dtype='>%s' % typecode)
             if values.shape == (1,):
                 values = values[0]
         else:
@@ -705,14 +705,14 @@ class netcdf_file(object):
     _pack_int32 = _pack_int
 
     def _unpack_int(self):
-        return int(fromstring(self.fp.read(4), '>i')[0])
+        return int(frombuffer(self.fp.read(4), '>i')[0])
     _unpack_int32 = _unpack_int
 
     def _pack_int64(self, value):
         self.fp.write(array(value, '>q').tostring())
 
     def _unpack_int64(self):
-        return fromstring(self.fp.read(8), '>q')[0]
+        return frombuffer(self.fp.read(8), '>q')[0]
 
     def _pack_string(self, s):
         count = len(s)

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -47,7 +47,7 @@ def read_data_block(encoding, endian, ordering, datatype, shape, data):
         dec = base64.b64decode(data.encode('ascii'))
         dt = data_type_codes.type[datatype]
         sh = tuple(shape)
-        newarr = np.fromstring(dec, dtype=dt)
+        newarr = np.frombuffer(dec, dtype=dt)
         if len(newarr.shape) != len(sh):
             newarr = newarr.reshape(sh, order=ord)
 
@@ -59,7 +59,7 @@ def read_data_block(encoding, endian, ordering, datatype, shape, data):
         zdec = zlib.decompress(dec)
         dt = data_type_codes.type[datatype]
         sh = tuple(shape)
-        newarr = np.fromstring(zdec, dtype=dt)
+        newarr = np.frombuffer(zdec, dtype=dt)
         if len(newarr.shape) != len(sh):
             newarr = newarr.reshape(sh, order=ord)
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -579,7 +579,7 @@ class Nifti1Extensions(list):
             # otherwise there should be a full extension header
             if not len(ext_def) == 8:
                 raise HeaderDataError('failed to read extension header')
-            ext_def = np.fromstring(ext_def, dtype=np.int32)
+            ext_def = np.frombuffer(ext_def, dtype=np.int32)
             if byteswap:
                 ext_def = ext_def.byteswap()
             # be extra verbose

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -209,6 +209,9 @@ class Opener(object):
     def read(self, *args, **kwargs):
         return self.fobj.read(*args, **kwargs)
 
+    def readinto(self, *args, **kwargs):
+        return self.fobj.readinto(*args, **kwargs)
+
     def write(self, *args, **kwargs):
         return self.fobj.write(*args, **kwargs)
 

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -557,10 +557,10 @@ class TrkFile(TractogramFile):
 
         with Opener(fileobj) as f:
 
-            # Read the header in one block.
-            header_str = f.read(header_2_dtype.itemsize)
-            header_rec = np.frombuffer(buffer=bytearray(header_str),
-                                       dtype=header_2_dtype)
+            # Read the header into a bytearray.
+            header_buf = bytearray(header_2_dtype.itemsize)
+            n_read = f.readinto(header_buf)
+            header_rec = np.frombuffer(buffer=header_buf, dtype=header_2_dtype)
             # Check endianness
             endianness = native_code
             if header_rec['hdr_size'] != TrkFile.HEADER_SIZE:

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -559,8 +559,8 @@ class TrkFile(TractogramFile):
 
             # Read the header in one block.
             header_str = f.read(header_2_dtype.itemsize)
-            header_rec = np.frombuffer(buffer=header_str, dtype=header_2_dtype)
-            header_rec.setflags(write=1)
+            header_rec = np.frombuffer(buffer=bytearray(header_str),
+                                       dtype=header_2_dtype)
             # Check endianness
             endianness = native_code
             if header_rec['hdr_size'] != TrkFile.HEADER_SIZE:

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -559,8 +559,8 @@ class TrkFile(TractogramFile):
 
             # Read the header in one block.
             header_str = f.read(header_2_dtype.itemsize)
-            header_rec = np.fromstring(string=header_str, dtype=header_2_dtype)
-
+            header_rec = np.frombuffer(buffer=header_str, dtype=header_2_dtype)
+            header_rec.setflags(write=1)
             # Check endianness
             endianness = native_code
             if header_rec['hdr_size'] != TrkFile.HEADER_SIZE:

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -559,7 +559,7 @@ class TrkFile(TractogramFile):
 
             # Read the header into a bytearray.
             header_buf = bytearray(header_2_dtype.itemsize)
-            n_read = f.readinto(header_buf)
+            f.readinto(header_buf)
             header_rec = np.frombuffer(buffer=header_buf, dtype=header_2_dtype)
             # Check endianness
             endianness = native_code


### PR DESCRIPTION
I am seeing this warning:

```
/Users/arokem/.virtualenvs/afq/lib/python3.7/site-packages/nibabel/streamlines/trk.py:562: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  header_rec = np.fromstring(string=header_str, dtype=header_2_dtype)
```

I believe this PR fixes that.