### PR TITLE
FIX: Use raw strings to fix escape characters; MNT: Avoid numpy.testing deprecation warning

### DIFF
--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -238,7 +238,7 @@ def append_diag(aff, steps, starts=()):
 
 
 def dot_reduce(*args):
-    """ Apply numpy dot product function from right to left on arrays
+    r""" Apply numpy dot product function from right to left on arrays
 
     For passed arrays :math:`A, B, C, ... Z` returns :math:`A \dot B \dot C ...
     \dot Z` where "." is the numpy array dot product.

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -32,7 +32,7 @@ __version__ = "%s.%s.%s%s" % (_version_major,
 def _parse_version(version_str):
     """ Parse version string `version_str` in our format
     """
-    match = re.match('([0-9.]*\d)(.*)', version_str)
+    match = re.match(r'([0-9.]*\d)(.*)', version_str)
     if match is None:
         raise ValueError('Invalid version ' + version_str)
     return match.groups()

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -18,7 +18,11 @@ from os.path import dirname, abspath, join as pjoin
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from numpy.testing.decorators import skipif
+try:
+    from numpy.testing import dec
+    skipif = dec.skipif
+except ImportError:
+    from numpy.testing.decorators import skipif
 # Allow failed import of nose if not now running tests
 try:
     from nose.tools import (assert_equal, assert_not_equal,


### PR DESCRIPTION
Fixes a couple of escape char problems, and a NumPy import that is deprecated in 1.15 leading to:
```
DeprecationWarning: Importing from numpy.testing.decorators is deprecated since numpy 1.15.0, import from numpy.testing instead.
```
I still need to ping the NumPy people to see if the workaround for `skipif` is the correct one, so WIP for now.