### PR TITLE
BUG: Fix deprecation warning on use of `np.fromstring`.

### DIFF
--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -47,7 +47,7 @@ def read_data_block(encoding, endian, ordering, datatype, shape, data):
         dec = base64.b64decode(data.encode('ascii'))
         dt = data_type_codes.type[datatype]
         sh = tuple(shape)
-        newarr = np.fromstring(dec, dtype=dt)
+        newarr = np.frombuffer(dec, dtype=dt)
         if len(newarr.shape) != len(sh):
             newarr = newarr.reshape(sh, order=ord)
 
@@ -59,7 +59,7 @@ def read_data_block(encoding, endian, ordering, datatype, shape, data):
         zdec = zlib.decompress(dec)
         dt = data_type_codes.type[datatype]
         sh = tuple(shape)
-        newarr = np.fromstring(zdec, dtype=dt)
+        newarr = np.frombuffer(zdec, dtype=dt)
         if len(newarr.shape) != len(sh):
             newarr = newarr.reshape(sh, order=ord)
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -579,7 +579,7 @@ class Nifti1Extensions(list):
             # otherwise there should be a full extension header
             if not len(ext_def) == 8:
                 raise HeaderDataError('failed to read extension header')
-            ext_def = np.fromstring(ext_def, dtype=np.int32)
+            ext_def = np.frombuffer(ext_def, dtype=np.int32)
             if byteswap:
                 ext_def = ext_def.byteswap()
             # be extra verbose

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -341,7 +341,7 @@ def _process_gen_dict(gen_dict):
             value = props[1](value)
         elif len(props) == 3:
             # array with dtype and shape
-            value = np.fromstring(value, props[1], sep=' ')
+            value = np.frombuffer(value, props[1], sep=' ')
             # if shape is None, allow arbitrary length
             if props[2] is not None:
                 value.shape = props[2]

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -559,7 +559,7 @@ class TrkFile(TractogramFile):
 
             # Read the header in one block.
             header_str = f.read(header_2_dtype.itemsize)
-            header_rec = np.fromstring(string=header_str, dtype=header_2_dtype)
+            header_rec = np.frombuffer(string=header_str, dtype=header_2_dtype)
 
             # Check endianness
             endianness = native_code


### PR DESCRIPTION
Fix deprecation warning on use of `np.fromstring`. Fixes:
```
DeprecationWarning: The binary mode of fromstring is deprecated, as it
behaves surprisingly on unicode inputs. Use frombuffer instead
```

observed in projects using Nibabel, e.g. DIPY:
https://travis-ci.org/nipy/dipy/jobs/471947136