### PR TITLE
BUG: Fix future warning on use of `np.issubdtype`.

### DIFF
--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -20,7 +20,7 @@ def is_array_sequence(obj):
 def is_ndarray_of_int_or_bool(obj):
     return (isinstance(obj, np.ndarray) and
             (np.issubdtype(obj.dtype, np.integer) or
-            np.issubdtype(obj.dtype, np.bool)))
+            np.issubdtype(obj.dtype, np.bool_)))
 
 
 class _BuildCache(object):


### PR DESCRIPTION
Fix future warning on use of `np.issubdtype`. Fixes:
```
/home/travis/build/nipy/dipy/venv/lib/python3.4/site-packages/nibabel/streamlines/array_sequence.py:23:
FutureWarning: Conversion of the second argument of issubdtype from `bool`
to `np.generic` is deprecated. In future, it will be treated as `np.bool_
== np.dtype(bool).type`.
```

observed in projects using Nibabel, e.g. DIPY:
https://travis-ci.org/nipy/dipy/jobs/471947136

More information about the issue and the fix at:
https://github.com/numpy/numpy/issues/2334
https://github.com/numpy/numpy/pull/9505