### PR TITLE
BF: fix dim_info transformation after orientation

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -2020,7 +2020,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
             # otherwise check where we have mapped it to
             if value is None:
                 continue
-            new_dim[idx] = np.where(ornt[:, 0] == idx)[0]
+            new_dim[idx] = ornt[value, 0]
 
         img.header.set_dim_info(*new_dim)
 


### PR DESCRIPTION
Running the following code
```python
import numpy as np
import nibabel as nib

data = np.arange(24).reshape((2,3,4))
img = nib.Nifti1Image(data, np.eye(4))
img.header.set_dim_info(1, 0, 2)

ornt = np.array([[2, 1], [0, 1], [1, 1]])
img_ornt = img.as_reoriented(ornt)
print(ornt[:,0])
print(img.shape)
print(img_ornt.shape)
print(img.header.get_dim_info())
print(img_ornt.header.get_dim_info())
```
we get
```python
[2 0 1]
(2, 3, 4)
(3, 4, 2)
(1, 0, 2)
(1, 2, 0)
```
although the correct output should look like
```python
[2 0 1]
(2, 3, 4)
(3, 4, 2)
(1, 0, 2)
(0, 2, 1)
```
(note the difference in the last line).

This bug can be fixed changing the following code line
https://github.com/nipy/nibabel/blob/5ab94146d569dc905bfbbb5b7a4ae4b190bbd133/nibabel/nifti1.py#L2023
to
```python
new_dim[idx] = ornt[value, 0]
```

This PR fixes this bug, however I'm not sure how to include the testcase.