### PR TITLE
Don't refcheck on this resize, to avoid errors

### DIFF
--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -199,7 +199,8 @@ class ArraySequence(object):
             self._data.resize(new_shape)
 
     def shrink_data(self):
-        self._data.resize((self._get_next_offset(),) + self.common_shape)
+        self._data.resize((self._get_next_offset(),) + self.common_shape,
+                          refcheck=False)
 
     def extend(self, elements):
         """ Appends all `elements` to this array sequence.


### PR DESCRIPTION
I stumbled into this in the course of my work on [pyAFQ](http://yeatmanlab.github.io/pyAFQ/). 

For testing, part of the code reads data from a trk file. This seems to cause some issues in this method, but only on 3.7: https://travis-ci.org/arokem/pyAFQ/jobs/483151878. Unfortunately, I was not able to reproduce these errors locally on my machine...

After reading about what this might be, and implementing the proposed change, these tests are now passing on the Travis build for that branch, though. 

Any objections to this?