### PR TITLE
ENH: Add NIFTI_XFORM_TEMPLATE_OTHER xform code

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -125,7 +125,9 @@ xform_codes = Recoder((  # code, label, niistring
     (1, 'scanner', "NIFTI_XFORM_SCANNER_ANAT"),
     (2, 'aligned', "NIFTI_XFORM_ALIGNED_ANAT"),
     (3, 'talairach', "NIFTI_XFORM_TALAIRACH"),
-    (4, 'mni', "NIFTI_XFORM_MNI_152")), fields=('code', 'label', 'niistring'))
+    (4, 'mni', "NIFTI_XFORM_MNI_152"),
+    (5, 'template', "NIFTI_XFORM_TEMPLATE_OTHER"),
+    ), fields=('code', 'label', 'niistring'))
 
 # unit codes
 unit_codes = Recoder((  # code, label

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -226,6 +226,18 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         assert_equal(message,
                      'sform_code -1 not valid; setting to 0')
 
+    def test_nifti_xform_codes(self):
+        # Verify that all xform codes can be set in both qform and sform
+        hdr = self.header_class()
+        xform_codes = nifti1.xform_codes
+        all_codes = list(xform_codes.keys())
+        affine = np.eye(4)
+        for code in all_codes:
+            hdr.set_qform(affine, code)
+            assert_equal(hdr['qform_code'], xform_codes[code])
+            hdr.set_sform(affine, code)
+            assert_equal(hdr['sform_code'], xform_codes[code])
+
     def test_magic_offset_checks(self):
         # magic and offset
         HC = self.header_class

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -229,14 +229,12 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
     def test_nifti_xform_codes(self):
         # Verify that all xform codes can be set in both qform and sform
         hdr = self.header_class()
-        xform_codes = nifti1.xform_codes
-        all_codes = list(xform_codes.keys())
         affine = np.eye(4)
-        for code in all_codes:
+        for code in nifti1.xform_codes.keys():
             hdr.set_qform(affine, code)
-            assert_equal(hdr['qform_code'], xform_codes[code])
+            assert_equal(hdr['qform_code'], nifti1.xform_codes[code])
             hdr.set_sform(affine, code)
-            assert_equal(hdr['sform_code'], xform_codes[code])
+            assert_equal(hdr['sform_code'], nifti1.xform_codes[code])
 
     def test_magic_offset_checks(self):
         # magic and offset

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -236,6 +236,11 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
             hdr.set_sform(affine, code)
             assert_equal(hdr['sform_code'], nifti1.xform_codes[code])
 
+        # Raise KeyError on unknown code
+        for bad_code in (-1, 6, 10):
+            assert_raises(KeyError, hdr.set_qform, affine, bad_code)
+            assert_raises(KeyError, hdr.set_sform, affine, bad_code)
+
     def test_magic_offset_checks(self):
         # magic and offset
         HC = self.header_class


### PR DESCRIPTION
This is an initial implementation of the proposed xform code 5. The test might be redundant, but I didn't immediately see anything that would exercise this addition, so it's just a simple verification that any defined code can be set without raising errors and retrieved reliably.

I used the macro name I proposed, but am content to revert to `NIFTI_XFORM_GEN_STANDARD`, if that's the consensus.

Closes #730.

cc @mrneont @afni-rickr @satra 

Ref: [NITRC thread 10029 - Proposed (minor) update for NIFTI sform values](https://www.nitrc.org/forum/forum.php?thread_id=10029&forum_id=1942)