### PR TITLE
RF: Centralize import of decorators from numpy.testing

### DIFF
--- a/nibabel/nicom/tests/test_csareader.py
+++ b/nibabel/nicom/tests/test_csareader.py
@@ -12,7 +12,7 @@ from .. import dwiparams as dwp
 
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 
-from numpy.testing.decorators import skipif
+from ...testing import skipif
 
 from nibabel.pydicom_compat import dicom_test, pydicom
 from .test_dicomwrappers import (IO_DATA_PATH, DATA)

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -21,8 +21,18 @@ from numpy.testing import assert_array_equal
 try:
     from numpy.testing import dec
     skipif = dec.skipif
+    slow = dec.slow
 except ImportError:
     from numpy.testing.decorators import skipif
+
+    # Recent (1.2) versions of numpy have this decorator
+    try:
+        from numpy.testing.decorators import slow
+    except ImportError:
+        def slow(t):
+            t.slow = True
+            return t
+
 # Allow failed import of nose if not now running tests
 try:
     from nose.tools import (assert_equal, assert_not_equal,

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -23,15 +23,7 @@ try:
     skipif = dec.skipif
     slow = dec.slow
 except ImportError:
-    from numpy.testing.decorators import skipif
-
-    # Recent (1.2) versions of numpy have this decorator
-    try:
-        from numpy.testing.decorators import slow
-    except ImportError:
-        def slow(t):
-            t.slow = True
-            return t
+    from numpy.testing.decorators import (skipif, slow)
 
 # Allow failed import of nose if not now running tests
 try:

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -17,13 +17,9 @@ from os.path import dirname, abspath, join as pjoin
 
 import numpy as np
 from numpy.testing import assert_array_equal
-
-try:
-    from numpy.testing import dec
-    skipif = dec.skipif
-    slow = dec.slow
-except ImportError:
-    from numpy.testing.decorators import (skipif, slow)
+from numpy.testing import dec
+skipif = dec.skipif
+slow = dec.slow
 
 # Allow failed import of nose if not now running tests
 try:

--- a/nibabel/tests/nibabel_data.py
+++ b/nibabel/tests/nibabel_data.py
@@ -4,7 +4,7 @@
 from os import environ, listdir
 from os.path import dirname, realpath, join as pjoin, isdir, exists
 
-from numpy.testing.decorators import skipif
+from ..testing import skipif
 
 
 def get_nibabel_data():

--- a/nibabel/tests/test_processing.py
+++ b/nibabel/tests/test_processing.py
@@ -30,7 +30,7 @@ from nibabel.eulerangles import euler2mat
 
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal)
-from numpy.testing.decorators import skipif
+from ..testing import skipif
 
 from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal, assert_not_equal)

--- a/nibabel/tests/test_quaternions.py
+++ b/nibabel/tests/test_quaternions.py
@@ -11,14 +11,7 @@
 import numpy as np
 from numpy import pi
 
-# Recent (1.2) versions of numpy have this decorator
-try:
-    from numpy.testing.decorators import slow
-except ImportError:
-    def slow(t):
-        t.slow = True
-        return t
-
+from ..testing import slow
 from nose.tools import assert_raises, assert_true, assert_false, \
     assert_equal
 

--- a/nibabel/tests/test_viewers.py
+++ b/nibabel/tests/test_viewers.py
@@ -14,7 +14,7 @@ import numpy as np
 from ..optpkg import optional_package
 from ..viewers import OrthoSlicer3D
 
-from numpy.testing.decorators import skipif
+from ..testing import skipif
 from numpy.testing import assert_array_equal, assert_equal
 
 from nose.tools import assert_raises, assert_true


### PR DESCRIPTION
I kept receiving messages that imports from numpy.testing.decorators are
deprecated (since 1.5 IIRC), so I found that some places still import them
in the test files instead of centraly from nibabel.testing which already
provides imports adaptor.  So I RFed to avoid such imports, and moved a
stub for @slow there too