### PR TITLE
BF: allow for BrainModels or Parcels  to contain a single vertex

### DIFF
--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -517,7 +517,7 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             vertices = self.struct_state[-1]
-            vertices.extend(np.atleast_1d(np.loadtxt(c, dtype=np.int)))
+            vertices.extend(np.loadtxt(c, dtype=np.int, ndmin=1))
             c.close()
 
         elif self.write_to == 'VoxelIndices':
@@ -531,7 +531,7 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             index = self.struct_state[-1]
-            index.extend(np.atleast_1d(np.loadtxt(c, dtype=np.int)))
+            index.extend(np.loadtxt(c, dtype=np.int, ndmin=1))
             c.close()
 
         elif self.write_to == 'TransformMatrix':

--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -517,7 +517,7 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             vertices = self.struct_state[-1]
-            vertices.extend(np.loadtxt(c, dtype=np.int))
+            vertices.extend(np.atleast_1d(np.loadtxt(c, dtype=np.int)))
             c.close()
 
         elif self.write_to == 'VoxelIndices':
@@ -531,7 +531,7 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             index = self.struct_state[-1]
-            index.extend(np.loadtxt(c, dtype=np.int))
+            index.extend(np.atleast_1d(np.loadtxt(c, dtype=np.int)))
             c.close()
 
         elif self.write_to == 'TransformMatrix':


### PR DESCRIPTION
Fixes an edge case in the reading of CIFTI files.
Tests for this edge case have been added for both the BrainModel and Parcel axes.