### PR TITLE
MRG: record handover to Chris of maintainer role

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -18,12 +18,13 @@ documentation is covered by the MIT license.
 
   The MIT License
 
-  Copyright (c) 2009-2014 Matthew Brett <matthew.brett@gmail.com>
+  Copyright (c) 2009-2019 Matthew Brett <matthew.brett@gmail.com>
   Copyright (c) 2010-2013 Stephan Gerhard <git@unidesign.ch>
   Copyright (c) 2006-2014 Michael Hanke <michael.hanke@gmail.com>
   Copyright (c) 2011 Christian Haselgrove <christian.haselgrove@umassmed.edu>
   Copyright (c) 2010-2011 Jarrod Millman <jarrod.millman@gmail.com>
-  Copyright (c) 2011-2014 Yaroslav Halchenko <debian@onerussian.com>
+  Copyright (c) 2011-2019 Yaroslav Halchenko <debian@onerussian.com>
+  Copyright (c) 2015-2019 Chris Markiewicz <effigies@gmail.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/Changelog
+++ b/Changelog
@@ -18,9 +18,10 @@ The full VCS changelog is available here:
 Nibabel releases
 ****************
 
-Most work on NiBabel so far has been by Matthew Brett (MB), Michael Hanke (MH)
-Ben Cipollini (BC), Marc-Alexandre Côté (MC), Chris Markiewicz (CM), Stephan
-Gerhard (SG), Eric Larson (EL), Yaroslav Halchenko (YOH) and Chris Cheng (CC).
+Most work on NiBabel so far has been by Matthew Brett (MB), Chris Markiewicz
+(CM), Michael Hanke (MH), Marc-Alexandre Côté (MC), Ben Cipollini (BC), Paul
+McCarthy (PM), Chris Cheng (CC), Yaroslav Halchenko (YOH), Satra Ghosh (SG),
+Eric Larson (EL), Demien Wasserman, and Stephan Gerhard.
 
 References like "pr/298" refer to github pull request numbers.
 
@@ -116,16 +117,16 @@ Enhancements
 * Simplfiy MGHImage and add footer fields (pr/569) (CM, reviewed by MB)
 * Force sform/qform codes to be ints, rather than numpy types (pr/575) (Paul
   McCarthy, reviewed by MB, CM)
-* Auto-fill color table in FreeSurfer annotation file (pr/592) (Paul McCarthy,
+* Auto-fill color table in FreeSurfer annotation file (pr/592) (PM,
   reviewed by CM, MB)
 * Set default intent code for CIFTI2 images (pr/604) (Mathias Goncalves,
-  reviewed by CM, Satra Ghosh, MB, Tim Coalson)
+  reviewed by CM, SG, MB, Tim Coalson)
 * Raise informative error on empty files (pr/611) (Pradeep Raamana, reviewed
   by CM, MB)
 * Accept degenerate filenames such as ``.nii`` (pr/621) (Dimitri
   Papadopoulos-Orfanos, reviewed by Yaroslav Halchenko)
 * Take advantage of ``IndexedGzipFile`` ``drop_handles`` flag to release
-  filehandles by default (pr/614) (Paul McCarthy, reviewed by CM, MB)
+  filehandles by default (pr/614) (PM, reviewed by CM, MB)
 
 Bug fixes
 ---------
@@ -135,7 +136,7 @@ Bug fixes
   CM, MB)
 * Accept lower-case orientation codes in TRK files (pr/600) (Kesshi Jordan,
   MB, reviewed by MB, MC, CM)
-* Annotation file reading (pr/592) (Paul McCarthy, reviewed by CM, MB)
+* Annotation file reading (pr/592) (PM, reviewed by CM, MB)
 * Fix buffer size calculation in ArraySequence (pr/597) (Serge Koudoro,
   reviewed by MC, MB, Eleftherios Garyfallidis, CM)
 * Resolve ``UnboundLocalError`` in Python 3 (pr/607) (Jakub Kaczmarzyk,
@@ -175,14 +176,14 @@ Bug fixes
 
 * Set L/R labels in orthoview correctly (pr/564) (CM)
 * Defer use of ufunc / memmap test - allows "freezing" (pr/572) (MB, reviewed
-  by Satra Ghosh)
+  by SG)
 * Fix doctest failures with pre-release numpy (pr/582) (MB, reviewed by CM)
 
 Maintenance
 -----------
 
-* Update documentation around NIfTI qform/sform codes (pr/576) (Paul McCarthy,
-  reviewed by MB, CM) + (pr/580) (Bennet Fauber, reviewed by Paul McCarthy)
+* Update documentation around NIfTI qform/sform codes (pr/576) (PM,
+  reviewed by MB, CM) + (pr/580) (Bennet Fauber, reviewed by PM)
 * Skip precision test on macOS, newer numpy (pr/583) (MB, reviewed by CM)
 * Simplify AppVeyor script, removing conda (pr/584) (MB, reviewed by CM)
 
@@ -192,12 +193,11 @@ Maintenance
 New features
 ------------
 
-* CIFTI support (pr/249) (Satra Ghosh, Michiel Cottaar, BC, CM, Demian
-  Wassermann, MB)
+* CIFTI support (pr/249) (SG, Michiel Cottaar, BC, CM, Demian Wasserman, MB)
 * Support for MRtrix TCK streamlines file format (pr/486) (MC, reviewed by
   MB, Arnaud Bore, J-Donald Tournier, Jean-Christophe Houde)
 * Added ``get_fdata()`` as default method to retrieve scaled floating point
-  data from ``DataobjImage``s (pr/551) (MB, reviewed by CM, Satra Ghosh)
+  data from ``DataobjImage``s (pr/551) (MB, reviewed by CM, SG)
 
 Enhancements
 ------------
@@ -211,19 +211,19 @@ Enhancements
 * Allow dtype specifiers as fileslice input (pr/485) (MB)
 * Support "headerless" ArrayProxy specification, enabling memory-efficient
   ArrayProxy reshaping (pr/521) (CM)
-* Allow unknown NIfTI intent codes, add FSL codes (pr/528) (Paul McCarthy)
+* Allow unknown NIfTI intent codes, add FSL codes (pr/528) (PM)
 * Improve error handling for ``img.__getitem__`` (pr/533) (Ariel Rokem)
 * Delegate reorientation to SpatialImage classes (pr/544) (Mark Hymers, CM,
   reviewed by MB)
 * Enable using ``indexed_gzip`` to reduce memory usage when reading from
-  gzipped NIfTI and MGH files (pr/552) (Paul McCarthy, reviewed by MB, CM)
+  gzipped NIfTI and MGH files (pr/552) (PM, reviewed by MB, CM)
 
 Bug fixes
 ---------
 
 * Miscellaneous MINC reader fixes (pr/493) (Robert D. Vincent, reviewed by CM,
   MB)
-* Fix corner case in ``wrapstruct.get`` (pr/516) (Paul McCarthy, reviewed by
+* Fix corner case in ``wrapstruct.get`` (pr/516) (PM, reviewed by
   CM, MB)
 
 Maintenance
@@ -524,7 +524,7 @@ Special thanks to Chris Burns, Jarrod Millman and Yaroslav Halchenko.
 
 * New feature release
 * Python 3.2 support
-* Substantially enhanced gifti reading support (SG)
+* Substantially enhanced gifti reading support (Stephan Gerhard)
 * Refactoring of trackvis read / write to allow reading and writing of voxel
   points and mm points in tracks.  Deprecate use of negative voxel sizes;
   set voxel_order field in trackvis header.  Thanks to Chris Filo

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,9 +27,9 @@ discussions, release procedure and more.
 Authors and Contributors
 ========================
 
-The main authors of NiBabel are `Matthew Brett`_, `Michael Hanke`_, `Ben
-Cipollini`_, `Marc-Alexandre Côté`_, Chris Markiewicz, `Stephan Gerhard`_ and
-`Eric Larson`_.  The authors are grateful to the following people who have
+Most work on NiBabel so far has been by `Matthew Brett`_, Chris Markiewicz,
+`Michael Hanke`_, `Marc-Alexandre Côté`_, `Ben Cipollini`_, Paul McCarthy and
+Chris Cheng.  The authors are grateful to the following people who have
 contributed code and discussion (in rough order of appearance):
 
 * `Yaroslav O. Halchenko`_

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -192,7 +192,7 @@ SIX_MIN_VERSION = '1.3'
 
 # Main setup parameters
 NAME = 'nibabel'
-MAINTAINER = "Matthew Brett, Michael Hanke, Eric Larson, Chris Markiewicz"
+MAINTAINER = "Chris Markiewicz"
 MAINTAINER_EMAIL = "neuroimaging@python.org"
 DESCRIPTION = description
 LONG_DESCRIPTION = long_description


### PR DESCRIPTION
Update various docs to show Chris is maintainer now.

Reorder authors according to current contributions.