### PR TITLE
 DOC: Update Sphinx config to support recent Sphinx/numpydoc

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for building docs
 -r requirements.txt
-# Sphinx >= 1.6 breaks the math_dollar extension
-sphinx<=1.5.6
+sphinx
 numpydoc
 texext
 matplotlib>=1.3
+mock

--- a/doc/source/_templates/reggie.html
+++ b/doc/source/_templates/reggie.html
@@ -1,0 +1,1 @@
+<p><img src="{{ pathto('_static/reggie.png',1) }}" alt="Reggie -- the one" /></p>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -201,7 +201,7 @@ html_index = 'index.html'
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'index': 'indexsidebar.html'}
+html_sidebars = {'index': ['localtoc.html', 'relations.html', 'sourcelink.html', 'indexsidebar.html', 'searchbox.html', 'reggie.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
Builds are breaking on master due to the numpydoc 0.9.0 release and https://github.com/numpy/numpydoc/issues/210. We have an old constraint keeping us at Sphinx < 1.6 (added a4a667df060c666adbb2f2bca7c797a48a6179ed), which is exactly the new minimum version required by numpydoc. I've tested with removing the constraint and LaTeX support seems to have been restored.

Additional changes:

* The `html_sidebar` options have been updated, and the old options deprecated at 2.0, so the new config/template maintains the current sidebar.
* The autodoc module now triggers a `mock` import, so I just added it to the dependencies.