### PR TITLE
MRG: Safer warning registry manipulation when checking for overflows

### DIFF
--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -1256,7 +1256,7 @@ def test__ftype4scaled_finite_warningfilters():
     # 32MiB reliably produces the error on my machine; use 128 for safety
     shape = (1024, 1024, 32)
     tst_arr = np.zeros(shape, dtype=np.float32)
-    # Ensure that an overflow will happen
+    # Ensure that an overflow will happen for < float64
     tst_arr[0, 0, 0] = np.finfo(np.float32).max
     tst_arr[-1, -1, -1] = np.finfo(np.float32).min
     go = threading.Event()
@@ -1274,7 +1274,7 @@ def test__ftype4scaled_finite_warningfilters():
         def run(self):
             go.wait()
             try:
-                # Use float16 to buy us two failures
+                # Use float16 to ensure two failures and increase time in function
                 _ftype4scaled_finite(tst_arr, 2.0, 1.0, default=np.float16)
             except Exception as e:
                 err.append(e)

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -1340,25 +1340,18 @@ def _ftype4scaled_finite(tst_arr, slope, inter, direction='read',
         slope = slope.astype(ftype)
         inter = inter.astype(ftype)
         try:
-            if direction == 'read':  # as in reading of image from disk
-                if slope != 1.0:
-                    # Keep warning contexts small to reduce the odds of a race
-                    with warnings.catch_warnings():
-                        # Error on overflows to short circuit the logic
-                        warnings.filterwarnings(*overflow_filter)
+            with warnings.catch_warnings():
+                # Error on overflows to short circuit the logic
+                warnings.filterwarnings(*overflow_filter)
+                if direction == 'read':  # as in reading of image from disk
+                    if slope != 1.0:
                         tst_trans = tst_trans * slope
-                if inter != 0.0:
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings(*overflow_filter)
+                    if inter != 0.0:
                         tst_trans = tst_trans + inter
-            elif direction == 'write':
-                if inter != 0.0:
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings(*overflow_filter)
+                elif direction == 'write':
+                    if inter != 0.0:
                         tst_trans = tst_trans - inter
-                if slope != 1.0:
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings(*overflow_filter)
+                    if slope != 1.0:
                         tst_trans = tst_trans / slope
             # Double-check that result is finite
             if np.all(np.isfinite(tst_trans)):


### PR DESCRIPTION
Following @matthew-brett's suggestion in https://github.com/nipy/nibabel/issues/616#issuecomment-379192456.

This approach unconditionally prepends the filter, which hopefully reduces the odds that removing it at the end will interfere with any other threads attempts to modify the registry. In particular, it should be re-entrant, so multiple threads calling this same function should not interfere with each other unless they happen to race on modifying the list. We could add a lock around the insertion/removal to avoid self-interference, though as noted in the other thread, no other libraries will respect it.

Looking at Python 3.4+, adding filters to the filter list is followed by a call to `warnings._filters_mutated()`, so I'm adding that behavior in, even though it's not part of the API. When Python 2 is dropped, the `getattr` part can be removed, though perhaps it's safer to do this for private functions anyway.

Sorry it took so long to get back to this. I completely forgot about that discussion.

@tomvars In case you're still having this issue, could you verify that this resolves it for you?

Closes #616.