### PR TITLE
MRG: Pacify upstream Deprecation/FutureWarnings

### DIFF
--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -108,7 +108,7 @@ class Minc2File(Minc1File):
 
     def _get_scalar(self, var):
         """ Get scalar value from HDF5 scalar """
-        return var.value
+        return var[()]
 
     def _get_array(self, var):
         """ Get array from HDF5 array """

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -117,7 +117,7 @@ def same_transform(taff, ornt, shape):
     o2t_pts = np.dot(itaff[:3, :3], arr_pts) + itaff[:3, 3][:, None]
     assert np.allclose(np.round(o2t_pts), o2t_pts)
     # fancy index out the t_arr values
-    vals = t_arr[list(o2t_pts.astype('i'))]
+    vals = t_arr[tuple(o2t_pts.astype('i'))]
     return np.all(vals == arr.ravel())
 
 

--- a/nibabel/viewers.py
+++ b/nibabel/viewers.py
@@ -414,7 +414,7 @@ class OrthoSlicer3D(object):
             idx = [slice(None)] * len(self._axes)
             for ii in range(3):
                 idx[self._order[ii]] = self._data_idx[ii]
-            vdata = self._data[idx].ravel()
+            vdata = self._data[tuple(idx)].ravel()
             vdata = np.concatenate((vdata, [vdata[-1]]))
             self._volume_ax_objs['patch'].set_x(self._data_idx[3] - 0.5)
             self._volume_ax_objs['step'].set_ydata(vdata)


### PR DESCRIPTION
Seeing in the tests:

```
h5py/_hl/dataset.py:313: H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.
nibabel/viewers.py:417: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
nibabel/tests/test_orientations.py:120: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
```

I think these are the three issues resolved. We'll see. Reviews welcome.