### PR TITLE
Corrects import of MutableMapping class for python 3.3+ (required for 3.8)

### DIFF
--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -1,8 +1,13 @@
 import copy
 import numbers
 import numpy as np
-import collections
 from warnings import warn
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    # PY2 compatibility
+    from collections import MutableMapping
 
 from nibabel.affines import apply_affine
 
@@ -19,7 +24,7 @@ def is_lazy_dict(obj):
     return is_data_dict(obj) and callable(list(obj.store.values())[0])
 
 
-class SliceableDataDict(collections.MutableMapping):
+class SliceableDataDict(MutableMapping):
     """ Dictionary for which key access can do slicing on the values.
 
     This container behaves like a standard dictionary but extends key access to
@@ -181,7 +186,7 @@ class PerArraySequenceDict(PerArrayDict):
         self[key].extend(value)
 
 
-class LazyDict(collections.MutableMapping):
+class LazyDict(MutableMapping):
     """ Dictionary of generator functions.
 
     This container behaves like a dictionary but it makes sure its elements are


### PR DESCRIPTION
Hi,

This is a small change that modifies the MutableMapping class import from collections to collections.abc.

This change was made in the python standard library at version 3.3. collections.MutableMapping has been kept available for backwards compatibility but is deprecated and will no longer be available in version 3.8 (next version). A try/catch import is used to maintain compatibility with python versions < 3.3 including python 2.

Cheers,

Jath