### PR TITLE
MAINT: Move fully to setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     # Absolute minimum dependencies
     - python: 2.7
       env:
-        - DEPENDS="numpy==1.8"
+        - DEPENDS="numpy==1.8 setuptools==30.3.0"
     # Absolute minimum dependencies
     - python: 2.7
       env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include tools *
 # put this stuff back into setup.py (package_data) once I'm enlightened
 # enough to accomplish this herculean task
 recursive-include nibabel/tests/data *
+recursive-include nibabel/externals/tests/data *
 recursive-include nibabel/nicom/tests/data *
 recursive-include nibabel/gifti/tests/data *
 include nibabel/COMMIT_INFO.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,7 +21,10 @@
 
 import sys
 import os
-from configparser import ConfigParser
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser  # PY2
 
 # Check for external Sphinx extensions we depend on
 try:
@@ -59,6 +62,10 @@ with open('_long_description.inc', 'wt') as fobj:
 # Load metadata from setup.cfg
 config = ConfigParser()
 config.read(os.path.join('..', '..', 'setup.cfg'))
+try:
+    metadata = config['metadata']
+except AttributeError:
+    metadata = dict(config.items('metadata'))  # PY2
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -92,7 +99,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'NiBabel'
-copyright = u'2006-2019, %(maintainer)s <%(author_email)s>' % config['metadata']
+copyright = u'2006-2019, %(maintainer)s <%(author_email)s>' % metadata
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,6 +21,7 @@
 
 import sys
 import os
+from configparser import ConfigParser
 
 # Check for external Sphinx extensions we depend on
 try:
@@ -53,7 +54,11 @@ with open(os.path.join('..', '..', 'nibabel', 'info.py'), 'r') as fobj:
 
 # Write long description from info
 with open('_long_description.inc', 'wt') as fobj:
-    fobj.write(rel['LONG_DESCRIPTION'])
+    fobj.write(rel['long_description'])
+
+# Load metadata from setup.cfg
+config = ConfigParser()
+config.read(os.path.join('..', '..', 'setup.cfg'))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -87,7 +92,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'NiBabel'
-copyright = u'2006-2019, %(MAINTAINER)s <%(AUTHOR_EMAIL)s>' % rel
+copyright = u'2006-2019, %(maintainer)s <%(author_email)s>' % config['metadata']
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -173,3 +173,5 @@ the top of the release notes.  Click on the badge for more information.
 .. _zenodo: https://zenodo.org
 .. _Digital Object Identifier: https://en.wikipedia.org/wiki/Digital_object_identifier
 """
+
+VERSION = __version__

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -84,16 +84,6 @@ def cmp_pkg_version(version_str, pkg_version_str=__version__):
             else _cmp(extra, pkg_extra))
 
 
-CLASSIFIERS = ["Development Status :: 4 - Beta",
-               "Environment :: Console",
-               "Intended Audience :: Science/Research",
-               "License :: OSI Approved :: MIT License",
-               "Operating System :: OS Independent",
-               "Programming Language :: Python",
-               "Topic :: Scientific/Engineering"]
-
-description = 'Access a multitude of neuroimaging data formats'
-
 # Note: this long_description is the canonical place to edit this text.
 # It also appears in README.rst, but it should get there by running
 # ``tools/refresh_readme.py`` which pulls in this version.
@@ -183,34 +173,3 @@ the top of the release notes.  Click on the badge for more information.
 .. _zenodo: https://zenodo.org
 .. _Digital Object Identifier: https://en.wikipedia.org/wiki/Digital_object_identifier
 """
-
-# versions for dependencies. Check these against:
-# doc/source/installation.rst
-# requirements.txt
-# .travis.yml
-NUMPY_MIN_VERSION = '1.8'
-PYDICOM_MIN_VERSION = '0.9.9'
-SIX_MIN_VERSION = '1.3'
-
-# Main setup parameters
-NAME = 'nibabel'
-MAINTAINER = "Chris Markiewicz"
-MAINTAINER_EMAIL = "neuroimaging@python.org"
-DESCRIPTION = description
-LONG_DESCRIPTION = long_description
-URL = "http://nipy.org/nibabel"
-DOWNLOAD_URL = "https://github.com/nipy/nibabel"
-LICENSE = "MIT license"
-CLASSIFIERS = CLASSIFIERS
-AUTHOR = "nibabel developers"
-AUTHOR_EMAIL = "neuroimaging@python.org"
-PLATFORMS = "OS Independent"
-MAJOR = _version_major
-MINOR = _version_minor
-MICRO = _version_micro
-ISRELEASE = _version_extra == ''
-VERSION = __version__
-PROVIDES = ["nibabel", 'nisext']
-REQUIRES = ["numpy>=%s" % NUMPY_MIN_VERSION,
-            "six>=%s" % SIX_MIN_VERSION,
-            'bz2file; python_version < "3.0"']

--- a/nibabel/tests/scriptrunner.py
+++ b/nibabel/tests/scriptrunner.py
@@ -129,9 +129,6 @@ class ScriptRunner(object):
             # the script through the Python interpreter
             cmd = [sys.executable,
                    pjoin(self.local_script_dir, cmd[0])] + cmd[1:]
-        elif os.name == 'nt':
-            # Need .bat file extension for windows
-            cmd[0] += '.bat'
         if os.name == 'nt':
             # Quote any arguments with spaces. The quotes delimit the arguments
             # on Windows, and the arguments might be file paths with spaces.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = nibabel
-version = attr: nibabel.__version__
 url = https://nipy.org/nibabel
 download_url = https://github.com/nipy/nibabel
 author = nibabel developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,79 @@
+[metadata]
+name = nibabel
+version = attr: nibabel.__version__
+url = https://nipy.org/nibabel
+download_url = https://github.com/nipy/nibabel
+author = nibabel developers
+author_email = neuroimaging@python.org
+maintainer = Chris Markiewicz
+maintainer_email = neuroimaging@python.org
+classifiers =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: Scientific/Engineering
+license = MIT License
+description = Access a multitude of neuroimaging data formats
+long_description = file:README.rst
+long_description_content_type = text/x-rst; charset=UTF-8
+platforms = OS Independent
+provides =
+    nibabel
+    nisext
+
+[options]
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+install_requires =
+    numpy >=1.8
+    six >=1.3
+    bz2file ; python_version < "3.0"
+tests_require = nose
+test_suite = nose.collector
+zip_safe = False
+packages = find:
+include_package_data = True
+
+[options.extras_require]
+dicom =
+    dicom >=0.9.9
+doc =
+    sphinx >=0.3
+test =
+    nose >=0.10.1
+all =
+    %(dicom)s
+    %(doc)s
+    %(test)s
+
+[options.entry_points]
+console_scripts =
+    nib-ls=nibabel.cmdline.ls:main
+    nib-dicomfs=nibabel.cmdline.dicomfs:main
+    nib-diff=nibabel.cmdline.diff:main
+    nib-nifti-dx=nibabel.cmdline.nifti_dx:main
+    nib-tck2trk=nibabel.cmdline.tck2trk:main
+    nib-trk2tck=nibabel.cmdline.trk2tck:main
+    parrec2nii=nibabel.cmdline.parrec2nii:main
+
+[options.package_data]
+nibabel =
+    tests/data/*
+    */tests/data/*
+
+[flake8]
+max-line-length = 100
+ignore = D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D208,D209,D210,D300,D301,D400,D401,D403,E24,E121,E123,E126,E226,E266,E402,E704,E731,F821,I100,I101,I201,N802,N803,N804,N806,W503,W504,W605
+exclude =
+    *test*
+    *sphinx*
+    nibabel/externals/*
+    */__init__.py
+

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,6 @@
 """Build helper."""
 
 import os
-from os.path import join as pjoin
-import sys
-from functools import partial
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
@@ -21,105 +18,8 @@ if os.path.exists('MANIFEST'):
 
 from setuptools import setup
 
-# Commit hash writing, and dependency checking
-from nisext.sexts import (get_comrec_build, package_check, install_scripts_bat,
-                          read_vars_from)
-cmdclass = {'build_py': get_comrec_build('nibabel'),
-            'install_scripts': install_scripts_bat}
-
-# Get project related strings.
-INFO = read_vars_from(pjoin('nibabel', 'info.py'))
-
-# Prepare setuptools args
-if 'setuptools' in sys.modules:
-    extra_setuptools_args = dict(
-        tests_require=['nose'],
-        test_suite='nose.collector',
-        zip_safe=False,
-        extras_require=dict(
-            doc='Sphinx>=0.3',
-            test='nose>=0.10.1'),
-    )
-    pkg_chk = partial(package_check, setuptools_args = extra_setuptools_args)
-else:
-    extra_setuptools_args = {}
-    pkg_chk = package_check
-
-# Do dependency checking
-pkg_chk('numpy', INFO.NUMPY_MIN_VERSION)
-pkg_chk('six', INFO.SIX_MIN_VERSION)
-custom_pydicom_messages = {'missing opt': 'Missing optional package "%s"'
-        ' provided by package "pydicom"'
-}
-pkg_chk('dicom',
-        INFO.PYDICOM_MIN_VERSION,
-        optional='dicom',
-        messages = custom_pydicom_messages)
-
-def main(**extra_args):
-    setup(name='nibabel',
-          maintainer=INFO.MAINTAINER,
-          maintainer_email=INFO.MAINTAINER_EMAIL,
-          description=INFO.DESCRIPTION,
-          long_description=INFO.LONG_DESCRIPTION,
-          url=INFO.URL,
-          download_url=INFO.DOWNLOAD_URL,
-          license=INFO.LICENSE,
-          classifiers=INFO.CLASSIFIERS,
-          author=INFO.AUTHOR,
-          author_email=INFO.AUTHOR_EMAIL,
-          platforms=INFO.PLATFORMS,
-          version=INFO.VERSION,
-          provides=INFO.PROVIDES,
-          install_requires=INFO.REQUIRES,
-          packages     = ['nibabel',
-                          'nibabel.externals',
-                          'nibabel.externals.tests',
-                          'nibabel.gifti',
-                          'nibabel.gifti.tests',
-                          'nibabel.cifti2',
-                          'nibabel.cifti2.tests',
-                          'nibabel.cmdline',
-                          'nibabel.cmdline.tests',
-                          'nibabel.nicom',
-                          'nibabel.freesurfer',
-                          'nibabel.freesurfer.tests',
-                          'nibabel.nicom.tests',
-                          'nibabel.testing',
-                          'nibabel.tests',
-                          'nibabel.benchmarks',
-                          'nibabel.streamlines',
-                          'nibabel.streamlines.tests',
-                          # install nisext as its own package
-                          'nisext',
-                          'nisext.tests'],
-          # The package_data spec has no effect for me (on python 2.6) -- even
-          # changing to data_files doesn't get this stuff included in the source
-          # distribution -- not sure if it has something to do with the magic
-          # above, but distutils is surely the worst piece of code in all of
-          # python -- duplicating things into MANIFEST.in but this is admittedly
-          # only a workaround to get things started -- not a solution
-          package_data = {'nibabel':
-                          [pjoin('tests', 'data', '*'),
-                           pjoin('externals', 'tests', 'data', '*'),
-                           pjoin('nicom', 'tests', 'data', '*'),
-                           pjoin('gifti', 'tests', 'data', '*'),
-                           pjoin('streamlines', 'tests', 'data', '*'),
-                          ]},
-          scripts      = [pjoin('bin', 'parrec2nii'),
-                          pjoin('bin', 'nib-ls'),
-                          pjoin('bin', 'nib-dicomfs'),
-                          pjoin('bin', 'nib-nifti-dx'),
-                          pjoin('bin', 'nib-tck2trk'),
-                          pjoin('bin', 'nib-trk2tck'),
-                          pjoin('bin', 'nib-diff'),
-                          ],
-          cmdclass = cmdclass,
-          **extra_args
-         )
-
+# Commit hash writing
+from nisext.sexts import get_comrec_build
 
 if __name__ == "__main__":
-    # Do not use nisext's dynamically updated install_requires
-    extra_setuptools_args.pop('install_requires', None)
-    main(**extra_setuptools_args)
+    setup(cmdclass={'build_py': get_comrec_build('nibabel')})

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ if os.path.exists('MANIFEST'):
 from setuptools import setup
 
 # Commit hash writing
-from nisext.sexts import get_comrec_build
+from nisext.sexts import get_comrec_build, read_vars_from
+
+INFO = read_vars_from(os.path.join('nibabel', 'info.py'))
 
 if __name__ == "__main__":
-    setup(cmdclass={'build_py': get_comrec_build('nibabel')})
+    setup(name='nibabel',
+          version=INFO.VERSION,
+          cmdclass={'build_py': get_comrec_build('nibabel')})

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,7 @@
 
 import os
 
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-# update it when the contents of directories change.
-if os.path.exists('MANIFEST'):
-    os.remove('MANIFEST')
-
-from setuptools import setup
+import setuptools
 
 # Commit hash writing
 from nisext.sexts import get_comrec_build, read_vars_from
@@ -24,6 +19,7 @@ from nisext.sexts import get_comrec_build, read_vars_from
 INFO = read_vars_from(os.path.join('nibabel', 'info.py'))
 
 if __name__ == "__main__":
-    setup(name='nibabel',
-          version=INFO.VERSION,
-          cmdclass={'build_py': get_comrec_build('nibabel')})
+    setuptools.setup(name='nibabel',
+                     version=INFO.VERSION,
+                     setup_requires=['setuptools>=30.3.0'],
+                     cmdclass={'build_py': get_comrec_build('nibabel')})

--- a/tools/refresh_readme.py
+++ b/tools/refresh_readme.py
@@ -19,7 +19,7 @@ with open('README.rst', 'rt') as fobj:
 
 rel = runpy.run_path(os.path.join('nibabel', 'info.py'))
 
-readme = ''.join(readme_lines) + '\n' + rel['LONG_DESCRIPTION']
+readme = ''.join(readme_lines) + '\n' + rel['long_description']
 
 with open('README.rst', 'wt') as fobj:
     fobj.write(readme)

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,3 @@ deps =
 deps =
 [testenv:np-1.2.1]
 deps =
-[flake8]
-max-line-length=100
-ignore=D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D208,D209,D210,D300,D301,D400,D401,D403,E24,E121,E123,E126,E226,E266,E402,E704,E731,F821,I100,I101,I201,N802,N803,N804,N806,W503,W504,W605
-exclude=*test*,*sphinx*,nibabel/externals/*,*/__init__.py
-


### PR DESCRIPTION
Dug through nisext finally, and I agree with https://github.com/nipy/nibabel/issues/717#issuecomment-472726035 that we can probably drop most of that from our setup.py. While I'm at it, I'm moving us to a `setup.cfg`-based setup.

No rush on this one. Would be nice to move by 2.5 or 3.0.

Closes #717.