### PR TITLE
FIX/TEST: Numpy casting rules have gotten more strict, raise different exception

### DIFF
--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -700,7 +700,7 @@ def test_a2f_non_numeric():
     # Some versions of numpy can cast structured types to float, others not
     try:
         arr.astype(float)
-    except ValueError:
+    except (TypeError, ValueError):
         pass
     else:
         back_arr = write_return(arr, fobj, float)


### PR DESCRIPTION
Pre-tests breaking on numpy 1.17-dev, probably resulting from numpy/numpy#13648.

I don't see any obvious behavioral changes for nibabel users here, just adapting a test to new numpy constraints.

Reviews welcome, otherwise plan to merge in 1 week.