### PR TITLE
CI: Fix AppVeyor codecov paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "venv/Lib/site-packages/::"


### PR DESCRIPTION
CodeCov is currently double-counting files, most likely due to AppVeyor not finding the correct paths. This should resolve it.