### PR TITLE
FIX: Python 3 compatibility issue while loading multiframe ECAT files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git://github.com/matthew-brett/nitest-minc2.git
 [submodule "nipy-ecattest"]
 	path = nibabel-data/nipy-ecattest
-	url = https://github.com/freec84/nipy-ecattest
+	url = https://github.com/effigies/nipy-ecattest
 [submodule "nibabel-data/nitest-freesurfer"]
 	path = nibabel-data/nitest-freesurfer
 	url = https://bitbucket.org/nipy/nitest-freesurfer.git

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -561,7 +561,7 @@ class EcatSubHeader(object):
             i = iter(affs)
             first = i.next()
             for item in i:
-                if not np.all(first == item):
+                if not np.allclose(first, item):
                     return False
         return True
 
@@ -760,7 +760,7 @@ class EcatImage(SpatialImage):
 
         Parameters
         ----------
-        dataabj : array-like
+        dataobj : array-like
             image data
         affine : None or (4,4) array-like
             homogeneous affine giving relationship between voxel coords and
@@ -811,6 +811,7 @@ class EcatImage(SpatialImage):
             file_map = self.__class__.make_file_map()
         self.file_map = file_map
         self._data_cache = None
+        self._fdata_cache = None
 
     @property
     def affine(self):

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -559,7 +559,7 @@ class EcatSubHeader(object):
         affs = [self.get_frame_affine(i) for i in range(nframes)]
         if affs:
             i = iter(affs)
-            first = i.next()
+            first = next(i)
             for item in i:
                 if not np.allclose(first, item):
                     return False

--- a/nibabel/tests/test_ecat_data.py
+++ b/nibabel/tests/test_ecat_data.py
@@ -37,7 +37,7 @@ class TestNegatives(object):
         # unit: 1/cm
     )
 
-    @needs_nibabel_data('nitest-minc2')
+    @needs_nibabel_data('nipy-ecattest')
     def test_load(self):
         # Check highest level load of minc works
         img = self.opener(self.example_params['fname'])
@@ -50,3 +50,15 @@ class TestNegatives(object):
         assert_almost_equal(data.min(), self.example_params['min'], 4)
         assert_almost_equal(data.max(), self.example_params['max'], 4)
         assert_almost_equal(data.mean(), self.example_params['mean'], 4)
+
+
+class TestMultiframe(TestNegatives):
+    example_params = dict(
+        fname=os.path.join(ECAT_TEST_PATH, 'ECAT7_testcase_multiframe.v'),
+        shape=(256, 256, 207, 3),
+        type=np.int16,
+        # Zeroed out image
+        min=0.0,
+        max=29170.67905,
+        mean=121.454,
+    )


### PR DESCRIPTION
This PR provides a multiframe ECAT file for our test battery. A couple minor cleanups I saw while looking through this code/docs.

@idoimaging If you would like, you can use my branch as a base to commit your change, e.g.,

```Shell
git remote add effigies https://github.com/effigies/nibabel.git
git fetch effigies
git checkout -t effigies/fix/ecat_py3
<make change>
git add nibabel/ecat.py
git commit -m <commit message>
git push -u origin fix/ecat_py3
```

Edit: I went ahead and added the fix with credit.

Fixes #776.