### PR TITLE
FIX: Set TRK byte order to little-endian before filling values

### DIFF
--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -295,8 +295,8 @@ class AFNIHeader(SpatialHeader):
         --------
         >>> fname = os.path.join(datadir, 'example4d+orig.HEAD')
         >>> header = AFNIHeader(parse_AFNI_header(fname))
-        >>> header.get_data_dtype()
-        dtype('int16')
+        >>> header.get_data_dtype().str
+        '<i2'
         >>> header.get_zooms()
         (3.0, 3.0, 3.0, 3.0)
         >>> header.get_data_shape()

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -269,7 +269,8 @@ class TrkFile(TractogramFile):
     def _default_structarr(cls):
         """ Return an empty compliant TRK header as numpy structured array
         """
-        st_arr = np.zeros((), dtype=header_2_dtype)
+        # Enforce little-endian byte order for header
+        st_arr = np.zeros((), dtype=header_2_dtype).newbyteorder('<')
 
         # Default values
         st_arr[Field.MAGIC_NUMBER] = cls.MAGIC_NUMBER
@@ -395,8 +396,7 @@ class TrkFile(TractogramFile):
             pointing to TRK file (and ready to write from the beginning
             of the TRK header data).
         """
-        # Enforce little-endian byte order for header
-        header = self._default_structarr().newbyteorder('<')
+        header = self._default_structarr()
 
         # Override hdr's fields by those contained in `header`.
         for k, v in self.header.items():


### PR DESCRIPTION
TRK header creation is done such that the little-endian byte order is enforced after some default values are generated.

This change sets the byte order before any non-zero values are set.

Fixes #775. 

@yarikoptic @sanjayankur31 If either of you has a minute to test these changes on an s390x, it would be most appreciated.