### PR TITLE
CI: Test installing from git archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ matrix:
         - INSTALL_TYPE=requirements
     - python: 2.7
       env:
+        - INSTALL_TYPE=archive
+    - python: 2.7
+      env:
         - CHECK_TYPE="style"
     - python: 3.5
       env:
@@ -122,6 +125,9 @@ install:
       elif [ "$INSTALL_TYPE" == "requirements" ]; then
           pip install $EXTRA_PIP_FLAGS -r requirements.txt
           python setup.py install
+      elif [ "$INSTALL_TYPE" == "archive" ]; then
+          git archive -o package.tar.gz HEAD
+          pip install $EXTRA_PIP_FLAGS package.tar.gz
       fi
     # Point to nibabel data directory
     - export NIBABEL_DATA_DIR="$PWD/nibabel-data"


### PR DESCRIPTION
Related to #786. It looks like Versioneer doesn't handle archives that don't include tags very well, so I'm verifying the usefulness of the current setup, and we'll need to find a way to make this work with Versioneer, if it's worth moving to Versioneer at all at this point.