### PR TITLE
FIX: Correctly handle Philips DICOMs w/ derived volume

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "nibabel-data/nitest-cifti2"]
 	path = nibabel-data/nitest-cifti2
 	url = https://github.com/demianw/nibabel-nitest-cifti2.git
+[submodule "nibabel-data/nitest-dicom"]
+	path = nibabel-data/nitest-dicom
+	url = https://github.com/effigies/nitest-dicom

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -511,21 +511,23 @@ class MultiframeWrapper(Wrapper):
         has_derived = False
         if hasattr(first_frame, 'get') and first_frame.get([0x18, 0x9117]):
             # DWI image may include derived isotropic, ADC or trace volume
-            # check and remove
             try:
                 self.frames = Sequence(
                     frame for frame in self.frames if
                     frame.MRDiffusionSequence[0].DiffusionDirectionality
                     != 'ISOTROPIC'
                     )
-                n_frames = len(self.frames)
-                has_derived = True
+                if n_frames != len(self.frames):
+                    warnings.warn("Derived images found and removed")
+                    n_frames = len(self.frames)
+                    has_derived = True
             except IndexError:
                 # Sequence tag is found but missing items!
                 raise WrapperError("Diffusion file missing information")
             except AttributeError:
                 # DiffusionDirectionality tag is not required
                 pass
+
         assert len(self.frames) == n_frames
         frame_indices = np.array(
             [frame.FrameContentSequence[0].DimensionIndexValues

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -467,7 +467,7 @@ class MultiframeWrapper(Wrapper):
         except TypeError:
             raise WrapperError("PerFrameFunctionalGroupsSequence is empty.")
         # DWI image where derived isotropic, ADC or trace volume was appended to the series
-        if self.frames[0].get([0x18, 0x9117]):
+        if self.frames[0] and self.frames[0].get([0x18, 0x9117], None):
             self.frames = Sequence(
                 frame for frame in self.frames if
                 frame.get([0x18, 0x9117])[0].get([0x18, 0x9075]).value

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -550,7 +550,7 @@ class MultiframeWrapper(Wrapper):
             ns_unique.pop(1)
         shape = (rows, cols) + tuple(ns_unique)
         n_vols = np.prod(shape[3:])
-        if n_frames == self.get('NumberOfFrames') and n_frames != n_vols * shape[2]:
+        if n_frames != n_vols * shape[2]:
             raise WrapperError("Calculated shape does not match number of "
                                "frames.")
         return tuple(shape)

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -547,9 +547,15 @@ class MultiframeWrapper(Wrapper):
         if stackid_tag in dim_seq:
             stackid_dim_idx = dim_seq.index(stackid_tag)
             frame_indices = np.delete(frame_indices, stackid_dim_idx, axis=1)
+            dim_seq.pop(stackid_dim_idx)
         if has_derived:
             # derived volume is included
-            frame_indices = np.delete(frame_indices, 1, axis=1)
+            derived_tag = tag_for_keyword("DiffusionBValue")
+            if derived_tag not in dim_seq:
+                raise WrapperError("Missing information, cannot remove indices "
+                                   "with confidence.")
+            derived_dim_idx = dim_seq.index(derived_tag)
+            frame_indices = np.delete(frame_indices, derived_dim_idx, axis=1)
         # account for the 2 additional dimensions (row and column) not included
         # in the indices
         n_dim = frame_indices.shape[1] + 2

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -517,16 +517,17 @@ class MultiframeWrapper(Wrapper):
                     frame.MRDiffusionSequence[0].DiffusionDirectionality
                     != 'ISOTROPIC'
                     )
-                if n_frames != len(self.frames):
-                    warnings.warn("Derived images found and removed")
-                    n_frames = len(self.frames)
-                    has_derived = True
             except IndexError:
                 # Sequence tag is found but missing items!
                 raise WrapperError("Diffusion file missing information")
             except AttributeError:
                 # DiffusionDirectionality tag is not required
                 pass
+            else:
+                if n_frames != len(self.frames):
+                    warnings.warn("Derived images found and removed")
+                    n_frames = len(self.frames)
+                    has_derived = True
 
         assert len(self.frames) == n_frames
         frame_indices = np.array(

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -466,14 +466,18 @@ class MultiframeWrapper(Wrapper):
             self.frames[0]
         except TypeError:
             raise WrapperError("PerFrameFunctionalGroupsSequence is empty.")
-        # DWI image where derived isotropic, ADC or trace volume was appended to the series
-        if self.frames[0] and self.frames[0].get([0x18, 0x9117], None):
-            self.frames = Sequence(
-                frame for frame in self.frames if
-                frame.get([0x18, 0x9117])[0].get([0x18, 0x9075]).value
-                != 'ISOTROPIC'
-            )
-            self._nframes = len(self.frames)
+        try:
+            # DWI image where derived isotropic, ADC or trace volume
+            # was appended to the series
+            if self.frames[0].get([0x18, 0x9117], None):
+                self.frames = Sequence(
+                    frame for frame in self.frames if
+                    frame.get([0x18, 0x9117])[0].get([0x18, 0x9075]).value
+                    != 'ISOTROPIC'
+                    )
+                self._nframes = len(self.frames)
+        except AttributeError:
+            pass
         try:
             self.shared = dcm_data.get('SharedFunctionalGroupsSequence')[0]
         except TypeError:

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -21,6 +21,7 @@ from nose.tools import (assert_true, assert_false, assert_equal,
                         assert_not_equal, assert_raises)
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
+from ...tests.nibabel_data import get_nibabel_data, needs_nibabel_data
 
 IO_DATA_PATH = pjoin(dirname(__file__), 'data')
 DATA_FILE = pjoin(IO_DATA_PATH, 'siemens_dwi_1000.dcm.gz')
@@ -36,7 +37,8 @@ DATA_FILE_SLC_NORM = pjoin(IO_DATA_PATH, 'csa_slice_norm.dcm')
 DATA_FILE_DEC_RSCL = pjoin(IO_DATA_PATH, 'decimal_rescale.dcm')
 DATA_FILE_4D = pjoin(IO_DATA_PATH, '4d_multiframe_test.dcm')
 DATA_FILE_EMPTY_ST = pjoin(IO_DATA_PATH, 'slicethickness_empty_string.dcm')
-DATA_FILE_4D_DERIVED = pjoin(IO_DATA_PATH, '4d_multiframe_with_derived.dcm')
+DATA_FILE_4D_DERIVED = pjoin(get_nibabel_data(), 'nitest-dicom',
+                             '4d_multiframe_with_derived.dcm')
 
 # This affine from our converted image was shown to match our image spatially
 # with an image from SPM DICOM conversion. We checked the matching with SPM
@@ -624,6 +626,7 @@ class TestMultiFrameWrapper(TestCase):
         assert_equal(dw.voxel_sizes[2], 1.0)
 
     @dicom_test
+    @needs_nibabel_data('nitest-dicom')
     def test_data_derived_shape(self):
         # Test 4D diffusion data with an additional trace volume included
         # Excludes the trace volume and generates the correct shape

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -36,6 +36,7 @@ DATA_FILE_SLC_NORM = pjoin(IO_DATA_PATH, 'csa_slice_norm.dcm')
 DATA_FILE_DEC_RSCL = pjoin(IO_DATA_PATH, 'decimal_rescale.dcm')
 DATA_FILE_4D = pjoin(IO_DATA_PATH, '4d_multiframe_test.dcm')
 DATA_FILE_EMPTY_ST = pjoin(IO_DATA_PATH, 'slicethickness_empty_string.dcm')
+DATA_FILE_4D_DERIVED = pjoin(IO_DATA_PATH, '4d_multiframe_with_derived.dcm')
 
 # This affine from our converted image was shown to match our image spatially
 # with an image from SPM DICOM conversion. We checked the matching with SPM
@@ -621,6 +622,13 @@ class TestMultiFrameWrapper(TestCase):
     def test_slicethickness_fallback(self):
         dw = didw.wrapper_from_file(DATA_FILE_EMPTY_ST)
         assert_equal(dw.voxel_sizes[2], 1.0)
+
+    @dicom_test
+    def test_data_derived_shape(self):
+        # Test 4D diffusion data with an additional trace volume included
+        # Excludes the trace volume and generates the correct shape
+        dw = didw.wrapper_from_file(DATA_FILE_4D_DERIVED)
+        assert_equal(dw.image_shape, (96, 96, 60, 33))
 
     @dicom_test
     def test_data_fake(self):

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -25,9 +25,6 @@ pydicom = read_file = tag_for_keyword = Sequence = None
 
 try:
     import dicom as pydicom
-    # Values not imported by default
-    import dicom.values
-    from dicom.sequence import Sequence
 except ImportError:
     try:
         import pydicom
@@ -39,6 +36,9 @@ except ImportError:
         # Values not imported by default
         import pydicom.values
 else:  # dicom module available
+    # Values not imported by default
+    import dicom.values
+    from dicom.sequence import Sequence
     read_file = pydicom.read_file
 
 if have_dicom:

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -40,6 +40,7 @@ else:  # dicom module available
     read_file = pydicom.read_file
 
 if have_dicom:
+    from pydicom.sequence import Sequence
     try:
         # Versions >= 1.0
         tag_for_keyword = pydicom.datadict.tag_for_keyword

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -21,7 +21,7 @@ without error, and always defines:
 import numpy as np
 
 have_dicom = True
-pydicom = read_file = tag_for_keyword = None
+pydicom = read_file = tag_for_keyword = Sequence = None
 
 try:
     import dicom as pydicom

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -27,6 +27,7 @@ try:
     import dicom as pydicom
     # Values not imported by default
     import dicom.values
+    from dicom.sequence import Sequence
 except ImportError:
     try:
         import pydicom
@@ -34,13 +35,13 @@ except ImportError:
         have_dicom = False
     else:  # pydicom module available
         from pydicom.dicomio import read_file
+        from pydicom.sequence import Sequence
         # Values not imported by default
         import pydicom.values
 else:  # dicom module available
     read_file = pydicom.read_file
 
 if have_dicom:
-    from pydicom.sequence import Sequence
     try:
         # Versions >= 1.0
         tag_for_keyword = pydicom.datadict.tag_for_keyword


### PR DESCRIPTION
Rewrite of #727 using a data submodule. Paths currently still assume the file is directly in nibabel.

cc @mgxd

Fixes #693.