### PR TITLE
RF: compare data types using .dtype.type to avoid effect of endianness

### DIFF
--- a/nibabel/cmdline/diff.py
+++ b/nibabel/cmdline/diff.py
@@ -9,6 +9,11 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """
 Quick summary of the differences among a set of neuroimaging files
+
+Notes:
+    - difference in data types for header fields will be detected, but
+      endianness difference will not be detected. It is done so to compare files
+      with native endianness used in data files.
 """
 from __future__ import division, print_function, absolute_import
 
@@ -99,7 +104,8 @@ def are_values_different(*values):
         if type(value0) != type(value):  # if types are different, then we consider them different
             return True
         elif isinstance(value0, np.ndarray):
-            if value0.dtype != value.dtype or \
+            # use .dtype.type to provide endianness agnostic comparison
+            if value0.dtype.type != value.dtype.type or \
                value0.shape != value.shape:
                 return True
             # there might be nans and they need special treatment

--- a/nibabel/tests/test_diff.py
+++ b/nibabel/tests/test_diff.py
@@ -72,3 +72,9 @@ def test_diff_values_array():
     # and some inf should not be a problem
     assert not are_values_different(array([0, inf]), array([0, inf]))
     assert are_values_different(array([0, inf]), array([inf, 0]))
+
+    # we will allow for types to be of different endianness but the
+    # same in "instnatiation" type and value
+    assert not are_values_different(np.array(1, dtype='<i4'), np.array(1, dtype='>i4'))
+    # but do report difference if instantiation type is different:
+    assert are_values_different(np.array(1, dtype='<i4'), np.array(1, dtype='<i2'))


### PR DESCRIPTION
Rationale is that in a typical case user is interested to check that file
contains correct data.  Comparison with effect of endianness would probably
be more of interest to developers.  May be someone later would add a flag
to nib-diff?