### PR TITLE
FIX: Coerce data types on writing GIFTI DataArrays

### DIFF
--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -403,7 +403,7 @@ def test_data_array_round_trip():
     assert_array_equal(vertices, verts)
 
 
-def test_type_coercion():
+def test_darray_dtype_coercion_failures():
     dtypes = (np.uint8, np.int32, np.int64, np.float32, np.float64)
     encodings = ('ASCII', 'B64BIN', 'B64GZ')
     for data_dtype, darray_dtype, encoding in itertools.product(dtypes,

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -21,6 +21,7 @@ from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
 from nibabel.testing import clear_and_catch_warnings
 from .test_parse_gifti_fast import (DATA_FILE1, DATA_FILE2, DATA_FILE3,
                                     DATA_FILE4, DATA_FILE5, DATA_FILE6)
+import itertools
 
 
 def test_gifti_image():
@@ -400,3 +401,20 @@ def test_data_array_round_trip():
     gio = GiftiImage.from_file_map(fmap)
     vertices = gio.darrays[0].data
     assert_array_equal(vertices, verts)
+
+
+def test_type_coercion():
+    dtypes = (np.uint8, np.int32, np.int64, np.float32, np.float64)
+    encodings = ('ASCII', 'B64BIN', 'B64GZ')
+    for data_dtype, darray_dtype, encoding in itertools.product(dtypes,
+                                                                dtypes,
+                                                                encodings):
+        da = GiftiDataArray(np.arange(10).astype(data_dtype),
+                            encoding=encoding,
+                            intent='NIFTI_INTENT_NODE_INDEX',
+                            datatype=darray_dtype)
+        gii = GiftiImage(darrays=[da])
+        gii_copy = GiftiImage.from_bytes(gii.to_bytes())
+        da_copy = gii_copy.darrays[0]
+        assert_equal(np.dtype(da_copy.data.dtype), np.dtype(darray_dtype))
+        assert_array_equal(da_copy.data, da.data)


### PR DESCRIPTION
Starting with a test. I expect uniform failure.

cc @hyperbolicTom

Fixes #792.