### PR TITLE
REL: 2.5.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -88,6 +88,11 @@
       "name": "Moloney, Brendan"
     },
     {
+      "affiliation": "MIT",
+      "name": "Goncalves, Mathias",
+      "orcid": "0000-0002-7252-7771"
+    },
+    {
       "name": "Burns, Christopher"
     },
     {
@@ -129,11 +134,6 @@
     },
     {
       "name": "Baker, Eric M."
-    },
-    {
-      "affiliation": "MIT",
-      "name": "Goncalves, Mathias",
-      "orcid": "0000-0002-7252-7771"
     },
     {
       "name": "Hayashi, Soichi"
@@ -243,6 +243,9 @@
       "affiliation": "University College London",
       "name": "P\u00e9rez-Garc\u00eda, Fernando",
       "orcid": "0000-0001-9090-3024"
+    },
+    {
+      "name": "Braun, Henry"
     },
     {
       "name": "Solovey, Igor"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -245,7 +245,9 @@
       "orcid": "0000-0001-9090-3024"
     },
     {
-      "name": "Braun, Henry"
+      "affiliation": "Center for Magnetic Resonance Research, University of Minnesota",
+      "name": "Braun, Henry",
+      "orcid": "0000-0001-7003-9822"
     },
     {
       "name": "Solovey, Igor"

--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,33 @@ Eric Larson (EL), Demian Wassermann, and Stephan Gerhard.
 
 References like "pr/298" refer to github pull request numbers.
 
+2.5.1 (Monday 23 September 2019)
+================================
+
+Enhancements
+------------
+* Ignore endianness in ``nib-diff`` if values match (pr/799) (YOH, reviewed
+  by CM)
+
+Bug fixes
+---------
+* Correctly handle Philips DICOMs w/ derived volume (pr/795) (Mathias
+  Goncalves, reviewed by CM)
+* Raise CSA tag limit to 1000, parametrize for future relaxing (pr/798,
+  backported to 2.5.x in pr/800) (Henry Braun, reviewed by CM, MB)
+* Coerce data types to match NIfTI intent codes when writing GIFTI data
+  arrays (pr/806) (CM, reported by Tom Holroyd)
+
+Maintenance
+-----------
+* Require h5py 2.10 for Windows + Python < 3.6 to resolve unexpected dtypes
+  in Minc2 data (pr/804) (CM, reviewed by YOH)
+
+API changes and deprecations
+----------------------------
+* Deprecate ``nicom.dicomwrappers.Wrapper.get_affine()`` in favor of ``affine``
+  property; final removal in nibabel 4.0 (pr/796) (YOH, reviewed by CM)
+
 2.5.0 (Sunday 4 August 2019)
 ============================
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -98,6 +98,7 @@ contributed code and discussion (in rough order of appearance):
 * Matt Cieslak
 * Egor Pafilov
 * Jath Palasubramaniam
+* Henry Braun
 
 License reprise
 ===============

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -19,8 +19,8 @@ from distutils.version import StrictVersion
 _version_major = 2
 _version_minor = 5
 _version_micro = 1
-_version_extra = 'dev'
-# _version_extra = ''
+# _version_extra = 'dev'
+_version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,8 @@ install_requires =
     numpy >=1.8
     six >=1.3
     bz2file ; python_version < "3.0"
-tests_require = nose
+tests_require =
+    nose >=0.11
 test_suite = nose.collector
 zip_safe = False
 packages = find:
@@ -46,7 +47,7 @@ dicom =
 doc =
     sphinx >=0.3
 test =
-    nose >=0.10.1
+    nose >=0.11
 all =
     %(dicom)s
     %(doc)s


### PR DESCRIPTION
Preparation for 2.5.1 release, targeting Monday, September 23.

Getting started mostly as a heads up, but I also expect a busy weekend next week, so it'd be nice to have everything merged and tested by Friday morning (EDT).

Open issues/PRs that could go in quickly
--------
* [ ] #712 [BUG] Incorrect TR reported for Minc2 (Submitter: @ltetrel)
* [x] #806 [FIX] Coerce data types on writing GIFTI DataArrays (Submitter: @effigies; Reporter: @hyperbolicTom)

Please add any other issues that should be addressed to the [2.5.1 milestone](https://github.com/nipy/nibabel/milestone/7) (or comment, if you don't have permissions), and if they come with a PR, all the better.

Pre-release checklist
--------
* [x] Review the open list of [nibabel issues](https://github.com/nipy/nibabel/issues). Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release. Label them!
* [x] Review and update the release notes. Review and update the [Changelog file](https://github.com/nipy/nibabel/blob/master/Changelog).
* [x] Look at [`doc/source/index.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/index.rst) and add any authors not yet acknowledged.
* [x] Use the opportunity to update the [`.mailmap file`](https://github.com/nipy/nibabel/blob/master/.mailmap) if there are any duplicate authors listed from `git shortlog -nse`.
* [x] Check the copyright year in [doc/source/conf.py](https://github.com/nipy/nibabel/blob/master/doc/source/conf.py)
* [x] Refresh the [README.rst](https://github.com/nipy/nibabel/blob/master/README.rst) text from the `LONG_DESCRIPTION` in [`info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) by running `make refresh-readme`.
* [x] Check the dependencies listed in [`setup.cfg`](https://github.com/nipy/nibabel/blob/master/setup.cfg) (e.g., `install_requires`, `options.extras_require`) and in [`doc/source/installation.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/installation.rst) and in [`requirements.txt`](https://github.com/nipy/nibabel/blob/master/requirements.txt) and [`.travis.yml`](https://github.com/nipy/nibabel/blob/master/.travis.yml). They should at least match. Do they still hold? Make sure nibabel on travis is testing the minimum dependencies specifically.
* [x] Make sure all tests pass (from the nibabel root directory): `nosetests --with-doctest nibabel`
* [x] Edit [`nibabel/info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) to set `_version_extra` to `''`; commit

Adapted from http://nipy.org/nibabel/devel/make_release.html#release-checklist