### PR TITLE
Fixing ArraySequence functionalities

### DIFF
--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -1,6 +1,5 @@
 
 import numbers
-import warnings
 from operator import mul
 from functools import reduce
 
@@ -156,7 +155,9 @@ class ArraySequence(object):
                             '3.0', '4.0')
     def data(self):
         """ Elements in this array sequence. """
-        return self.get_data()
+        view = self._data.view()
+        view.setflags(write=False)
+        return view
 
     def get_data(self):
         """ Returns a *copy* of the elements in this array sequence.

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -1,5 +1,6 @@
 
 import numbers
+import warnings
 from operator import mul
 from functools import reduce
 
@@ -147,7 +148,22 @@ class ArraySequence(object):
     @property
     def data(self):
         """ Elements in this array sequence. """
-        return self._data
+        warnings.warn("The 'ArraySequence.data' property has been deprecated"
+                      " in favor of 'ArraySequence.get_data()'.",
+                      DeprecationWarning,
+                      stacklevel=2)
+        return self.get_data()
+
+    def get_data(self):
+        """ Returns a copy of the elements in this array sequence.
+
+        Notes
+        -----
+        To modify the data on this array sequence, one can use
+        in-place mathematical operators (e.g., `seq += ...`) or the use
+        assignment operator (i.e, `seq[...] = value`).
+        """
+        return self.copy()._data
 
     def _check_shape(self, arrseq):
         """ Check whether this array sequence is compatible with another. """

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -5,8 +5,7 @@ from functools import reduce
 
 import numpy as np
 
-from nibabel.deprecated import deprecate_with_version
-
+from ..deprecated import deprecate_with_version
 
 MEGABYTE = 1024 * 1024
 

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -547,7 +547,7 @@ class ArraySequence(object):
         return seq
 
 
-def create_arraysequences_from_generator(gen, n):
+def create_arraysequences_from_generator(gen, n, buffer_sizes=None):
     """ Creates :class:`ArraySequence` objects from a generator yielding tuples
 
     Parameters
@@ -557,8 +557,13 @@ def create_arraysequences_from_generator(gen, n):
         array sequences.
     n : int
         Number of :class:`ArraySequences` object to create.
+    buffer_sizes : list of float, optional
+        Sizes (in Mb) for each ArraySequence's buffer.
     """
-    seqs = [ArraySequence() for _ in range(n)]
+    if buffer_sizes is None:
+        buffer_sizes = [4] * n
+
+    seqs = [ArraySequence(buffer_size=size) for size in buffer_sizes]
     for data in gen:
         for i, seq in enumerate(seqs):
             if data[i].nbytes > 0:

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -441,6 +441,15 @@ class TestArraySequence(unittest.TestCase):
             # Make sure we can add new elements to it.
             loaded_seq.append(SEQ_DATA['data'][0])
 
+    def test_get_data(self):
+        seq_view = SEQ_DATA['seq'][::2]
+        check_arr_seq_view(seq_view, SEQ_DATA['seq'])
+
+        # We make sure the array sequence data does not
+        # contain more elements than it is supposed to.
+        data = seq_view.get_data()
+        assert len(data) < len(seq_view._data)
+
 
 def test_concatenate():
     seq = SEQ_DATA['seq'].copy()  # In case there is in-place modification.

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -24,7 +24,7 @@ def setup():
 
 
 def generate_data(nb_arrays, common_shape, rng):
-    data = [rng.rand(*(rng.randint(3, 20),) + common_shape)
+    data = [rng.rand(*(rng.randint(3, 20),) + common_shape) * 100
             for _ in range(nb_arrays)]
     return data
 
@@ -228,9 +228,6 @@ class TestArraySequence(unittest.TestCase):
         for i, e in enumerate(SEQ_DATA['seq']):
             assert_array_equal(SEQ_DATA['seq'][i], e)
 
-            if sys.version_info < (3,):
-                assert_array_equal(SEQ_DATA['seq'][long(i)], e)
-
         # Get all items using indexing (creates a view).
         indices = list(range(len(SEQ_DATA['seq'])))
         seq_view = SEQ_DATA['seq'][indices]
@@ -278,49 +275,42 @@ class TestArraySequence(unittest.TestCase):
         check_arr_seq(seq_view, [d[:, 2] for d in SEQ_DATA['data'][::-2]])
 
     def test_arraysequence_operators(self):
-        for op in ["__add__", "__sub__", "__mul__", "__floordiv__", "__truediv__",
-                   "__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__"]:
-            # Test math operators with a scalar.
-            for scalar in [42, 0.5, True]:
-                seq = getattr(SEQ_DATA['seq'], op)(scalar)
-                assert_true(seq is not SEQ_DATA['seq'])
-                check_arr_seq(seq, [getattr(d, op)(scalar) for d in SEQ_DATA['data']])
+        # Disable division per zero warnings.
+        flags = np.seterr(divide='ignore', invalid='ignore')
+        SCALARS = [42, 0.5, True, -3, 0]
+        CMP_OPS = ["__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__"]
+
+        seq = SEQ_DATA['seq'].copy()
+        seq_int = SEQ_DATA['seq'].copy()
+        seq_int._data = seq_int._data.astype(int)
+        seq_bool = SEQ_DATA['seq'].copy() > 30
+
+        ARRSEQS = [seq, seq_int, seq_bool]
+        VIEWS = [seq[::2], seq_int[::2], seq_bool[::2]]
+
+        def _test_unary(op, arrseq):
+            orig = arrseq.copy()
+            seq = getattr(orig, op)()
+            assert_true(seq is not orig)
+            check_arr_seq(seq, [getattr(d, op)() for d in orig])
+
+        def _test_binary(op, arrseq, scalars, seqs, inplace=False):
+            for scalar in scalars:
+                orig = arrseq.copy()
+                seq = getattr(orig, op)(scalar)
+                assert_true((seq is orig) if inplace else (seq is not orig))
+                check_arr_seq(seq, [getattr(e, op)(scalar) for e in arrseq])
 
             # Test math operators with another ArraySequence.
-            seq = getattr(SEQ_DATA['seq'], op)(SEQ_DATA['seq'])
-            assert_true(seq is not SEQ_DATA['seq'])
-            check_arr_seq(seq, [getattr(d, op)(d) for d in SEQ_DATA['data']])
-
-            # Test math operators with ArraySequence views.
-            orig = SEQ_DATA['seq'][::2]
-            seq = getattr(orig, op)(orig)
-            assert_true(seq is not orig)
-            check_arr_seq(seq, [getattr(d, op)(d) for d in SEQ_DATA['data'][::2]])
-
-        # Test in-place operators.
-        for op in ["__iadd__", "__isub__", "__imul__", "__ifloordiv__", "__itruediv__"]:
-            # Test in-place math operators with a scalar.
-            for scalar in [42, 0.5, True]:
-                seq = seq_orig = SEQ_DATA['seq'].copy()
-                seq = getattr(seq, op)(scalar)
-                assert_true(seq is seq_orig)
-                check_arr_seq(seq, [getattr(d.copy(), op)(scalar) for d in SEQ_DATA['data']])
-
-            # Test in-place math operators with another ArraySequence.
-            seq = seq_orig = SEQ_DATA['seq'].copy()
-            seq = getattr(seq, op)(SEQ_DATA['seq'])
-            assert_true(seq is seq_orig)
-            check_arr_seq(seq, [getattr(d.copy(), op)(d) for d in SEQ_DATA['data']])
-
-            # Test in-place math operators with ArraySequence views.
-            seq = seq_orig = SEQ_DATA['seq'].copy()[::2]
-            seq = getattr(seq, op)(seq)
-            assert_true(seq is seq_orig)
-            check_arr_seq(seq, [getattr(d.copy(), op)(d) for d in SEQ_DATA['data'][::2]])
+            for other in seqs:
+                orig = arrseq.copy()
+                seq = getattr(orig, op)(other)
+                assert_true(seq is not SEQ_DATA['seq'])
+                check_arr_seq(seq, [getattr(e1, op)(e2) for e1, e2 in zip(arrseq, other)])
 
             # Operations between array sequences of different lengths.
-            seq = SEQ_DATA['seq'].copy()
-            assert_raises(ValueError, getattr(seq, op), SEQ_DATA['seq'][::2])
+            orig = arrseq.copy()
+            assert_raises(ValueError, getattr(orig, op), orig[::2])
 
             # Operations between array sequences with different amount of data.
             seq1 = ArraySequence(np.arange(10).reshape(5, 2))
@@ -332,24 +322,65 @@ class TestArraySequence(unittest.TestCase):
             seq2 = ArraySequence(np.arange(8).reshape(2, 2, 2))
             assert_raises(ValueError, getattr(seq1, op), seq2)
 
+
+        for op in ["__add__", "__sub__", "__mul__", "__mod__",
+                   "__floordiv__", "__truediv__"] + CMP_OPS:
+            _test_binary(op, seq, SCALARS, ARRSEQS)
+            _test_binary(op, seq_int, SCALARS, ARRSEQS)
+
+            # Test math operators with ArraySequence views.
+            _test_binary(op, seq[::2], SCALARS, VIEWS)
+            _test_binary(op, seq_int[::2], SCALARS, VIEWS)
+
+            if op in CMP_OPS:
+                continue
+
+            op = "__i{}__".format(op.strip("_"))
+            _test_binary(op, seq, SCALARS, ARRSEQS, inplace=True)
+
+            if op == "__itruediv__":
+                continue  # Going to deal with it separately.
+
+            _test_binary(op, seq_int, [42, -3, True, 0], [seq_int, seq_bool, -seq_int], inplace=True)  # int <-- int
+            assert_raises(TypeError, _test_binary, op, seq_int, [0.5], [], inplace=True)  # int <-- float
+            assert_raises(TypeError, _test_binary, op, seq_int, [], [seq], inplace=True)  # int <-- float
+
+        # __pow__ : Integers to negative integer powers are not allowed.
+        _test_binary("__pow__", seq, [42, -3, True, 0], [seq_int, seq_bool, -seq_int])
+        _test_binary("__ipow__", seq, [42, -3, True, 0], [seq_int, seq_bool, -seq_int], inplace=True)
+        assert_raises(ValueError, _test_binary, "__pow__", seq_int, [-3], [])
+        assert_raises(ValueError, _test_binary, "__ipow__", seq_int, [-3], [], inplace=True)
+
+        # __itruediv__ is only valid with float arrseq.
+        for scalar in SCALARS + ARRSEQS:
+            assert_raises(TypeError, getattr(seq_int.copy(), "__itruediv__"), scalar)
+
+        # Bitwise operators
+        for op in ("__lshift__", "__rshift__", "__or__", "__and__", "__xor__"):
+            _test_binary(op, seq_bool, [42, -3, True, 0], [seq_int, seq_bool, -seq_int])
+            assert_raises(TypeError, _test_binary, op, seq_bool, [0.5], [])
+            assert_raises(TypeError, _test_binary, op, seq, [], [seq])
+
         # Unary operators
-        for op in ["__neg__"]:
-            seq = getattr(SEQ_DATA['seq'], op)()
-            assert_true(seq is not SEQ_DATA['seq'])
-            check_arr_seq(seq, [getattr(d, op)() for d in SEQ_DATA['data']])
+        for op in ["__neg__", "__abs__"]:
+            _test_unary(op, seq)
+            _test_unary(op, -seq)
+            _test_unary(op, seq_int)
+            _test_unary(op, -seq_int)
+
+        _test_unary("__abs__", seq_bool)
+        _test_unary("__invert__", seq_bool)
+        assert_raises(TypeError, _test_unary, "__invert__", seq)
+
+        # Restore flags.
+        np.seterr(**flags)
+
 
     def test_arraysequence_setitem(self):
         # Set one item
         seq = SEQ_DATA['seq'] * 0
         for i, e in enumerate(SEQ_DATA['seq']):
             seq[i] = e
-
-        check_arr_seq(seq, SEQ_DATA['seq'])
-
-        if sys.version_info < (3,):
-            seq = ArraySequence(SEQ_DATA['seq'] * 0)
-            for i, e in enumerate(SEQ_DATA['seq']):
-                seq[long(i)] = e
 
         check_arr_seq(seq, SEQ_DATA['seq'])
 

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -267,6 +267,19 @@ class TestLoadSave(unittest.TestCase):
                     tfile = nib.streamlines.load(filename, lazy_load=False)
                     assert_tractogram_equal(tfile.tractogram, tractogram)
 
+    def test_save_sliced_tractogram(self):
+        tractogram = Tractogram(DATA['streamlines'],
+                                affine_to_rasmm=np.eye(4))
+        original_tractogram = tractogram.copy()
+        for ext, cls in FORMATS.items():
+            with InTemporaryDirectory():
+                filename = 'streamlines' + ext
+                nib.streamlines.save(tractogram[::2], filename)
+                tfile = nib.streamlines.load(filename, lazy_load=False)
+                assert_tractogram_equal(tfile.tractogram, tractogram[::2])
+                # Make sure original tractogram hasn't changed.
+                assert_tractogram_equal(tractogram, original_tractogram)
+
     def test_load_unknown_format(self):
         assert_raises(ValueError, nib.streamlines.load, "")
 

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -539,9 +539,6 @@ class TestTractogram(unittest.TestCase):
         for i, t in enumerate(DATA['tractogram']):
             assert_tractogram_item_equal(DATA['tractogram'][i], t)
 
-            if sys.version_info < (3,):
-                assert_tractogram_item_equal(DATA['tractogram'][long(i)], t)
-
         # Get one TractogramItem out of two.
         tractogram_view = DATA['simple_tractogram'][::2]
         check_tractogram(tractogram_view, DATA['streamlines'][::2])

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -688,6 +688,22 @@ class TestTractogram(unittest.TestCase):
                            np.dot(np.eye(4), np.dot(np.linalg.inv(affine),
                                                     np.linalg.inv(affine))))
 
+        # Applying the affine to a tractogram that has been indexed or sliced
+        # shouldn't affect the remaining streamlines.
+        tractogram = DATA['tractogram'].copy()
+        transformed_tractogram = tractogram[::2].apply_affine(affine)
+        assert_true(transformed_tractogram is not tractogram)
+        check_tractogram(tractogram[::2],
+                         streamlines=[s*scaling for s in DATA['streamlines'][::2]],
+                         data_per_streamline=DATA['tractogram'].data_per_streamline[::2],
+                         data_per_point=DATA['tractogram'].data_per_point[::2])
+
+        # Remaining streamlines should match the original ones.
+        check_tractogram(tractogram[1::2],
+                         streamlines=DATA['streamlines'][1::2],
+                         data_per_streamline=DATA['tractogram'].data_per_streamline[1::2],
+                         data_per_point=DATA['tractogram'].data_per_point[1::2])
+
         # Check that applying an affine and its inverse give us back the
         # original streamlines.
         tractogram = DATA['tractogram'].copy()

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -432,11 +432,8 @@ class Tractogram(object):
         if np.all(affine == np.eye(4)):
             return self  # No transformation.
 
-        BUFFER_SIZE = 10000000  # About 128 Mb since pts shape is 3.
-        for start in range(0, len(self.streamlines.data), BUFFER_SIZE):
-            end = start + BUFFER_SIZE
-            pts = self.streamlines._data[start:end]
-            self.streamlines.data[start:end] = apply_affine(affine, pts)
+        for i in range(len(self.streamlines)):
+            self.streamlines[i] = apply_affine(affine, self.streamlines[i])
 
         if self.affine_to_rasmm is not None:
             # Update the affine that brings back the streamlines to RASmm.


### PR DESCRIPTION
This PR aims to address the issues related to exposing ArraySequence's internal data (e.g. as discussed in #729 and https://github.com/nipy/dipy/pull/1956 - [this post exactly](https://github.com/nipy/dipy/pull/1956#discussion_r321023963), and my original answer to those issues can be found [here](https://github.com/nipy/nibabel/issues/729#issuecomment-467959221)).

There are three parts to this PR (I've made separate commits for convenience).

1. `ArraySequence.data` will now return a copy of the data. This way, altering the data of sliced/indexed tractogram will not affect the original data.
2. `ArraySequence` now supports some Python operators to modify its internal data (e.g. +=, -=, ...). Also, assigning/overwriting sequences can be done using `arr_seq[idx] = arr_seq2` (provided the shape are compatible).
3. Fixing a bug in `Tractogram.apply_affine` where calling that function on a sliced/indexed `Tractogram` object would result in modifying all streamlines (i.e. even those not selected).

If you think it is missing some Python operators that might be useful let me know.

@skoudoro 
NB: I haven't looked extensively but this PR would affect Dipy a bit. For instance, this part (https://github.com/nipy/dipy/blob/master/dipy/tracking/streamlinespeed.pyx#L104-L115) should have been using `._data` like the other functions in that file. Also, some of @frheault's `StatefulTractogram` code might be affected.