### PR TITLE
ENH: Add a utility to calculate obliquity of affines

### DIFF
--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -2,8 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Utility routines for working with points and affine transforms
 """
-
-from math import acos, pi as PI
 import numpy as np
 
 from functools import reduce
@@ -299,17 +297,27 @@ def voxel_sizes(affine):
     return np.sqrt(np.sum(top_left ** 2, axis=0))
 
 
-def obliquity(affine, degrees=False):
+def obliquity(affine):
     r"""
-    Estimate the obliquity an affine's axes represent, in degrees from plumb.
+    Estimate the *obliquity* an affine's axes represent.
 
+    The term *obliquity* is defined here as the rotation of those axes with
+    respect to the cardinal axes.
     This implementation is inspired by `AFNI's implementation
     <https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/thd_coords.c#L660-L698>`_
 
+    Parameters
+    ----------
+    affine : 2D array-like
+        Affine transformation array.  Usually shape (4, 4), but can be any 2D
+        array.
+
+    Returns
+    -------
+    angles : 1D array-like
+        The *obliquity* of each axis with respect to the cardinal axes, in radians.
+
     """
     vs = voxel_sizes(affine)
-    fig_merit = (affine[:-1, :-1] / vs[np.newaxis, ...]).max(axis=1).min()
-    radians = abs(acos(fig_merit))
-    if not degrees:
-        return radians
-    return radians * 180 / PI
+    best_cosines = np.abs((affine[:-1, :-1] / vs).max(axis=1))
+    return np.arccos(best_cosines)

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -321,5 +321,5 @@ def obliquity(affine):
 
     """
     vs = voxel_sizes(affine)
-    best_cosines = np.abs((affine[:-1, :-1] / vs).max(axis=1))
+    best_cosines = np.abs(affine[:-1, :-1] / vs).max(axis=1)
     return np.arccos(best_cosines)

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -3,6 +3,7 @@
 """ Utility routines for working with points and affine transforms
 """
 
+from math import acos, pi as PI
 import numpy as np
 
 from functools import reduce
@@ -296,3 +297,24 @@ def voxel_sizes(affine):
     """
     top_left = affine[:-1, :-1]
     return np.sqrt(np.sum(top_left ** 2, axis=0))
+
+
+def obliquity(affine):
+    r"""
+    Estimate the obliquity an affine's axes represent, in degrees from plumb.
+
+    This implementation is inspired by `AFNI's implementation
+    <https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/thd_coords.c#L660-L698>`_
+
+    >>> affine = np.array([
+    ...    [2.74999725e+00, -2.74999817e-03, 2.74999954e-03, -7.69847980e+01],
+    ...    [2.98603540e-03, 2.73886840e+00, -2.47165887e-01, -8.36692043e+01],
+    ...    [-2.49170222e-03, 2.47168626e-01, 2.73886865e+00, -8.34056848e+01],
+    ...    [ 0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 1.00000000e+00]])
+    >>> abs(5.15699 - obliquity(affine)) < 0.0001
+    True
+
+    """
+    vs = voxel_sizes(affine)
+    fig_merit = (affine[:-1, :-1] / vs[np.newaxis, ...]).max(axis=1).min()
+    return abs(acos(fig_merit) * 180 / PI)

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -306,14 +306,6 @@ def obliquity(affine):
     This implementation is inspired by `AFNI's implementation
     <https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/thd_coords.c#L660-L698>`_
 
-    >>> affine = np.array([
-    ...    [2.74999725e+00, -2.74999817e-03, 2.74999954e-03, -7.69847980e+01],
-    ...    [2.98603540e-03, 2.73886840e+00, -2.47165887e-01, -8.36692043e+01],
-    ...    [-2.49170222e-03, 2.47168626e-01, 2.73886865e+00, -8.34056848e+01],
-    ...    [ 0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 1.00000000e+00]])
-    >>> abs(5.15699 - obliquity(affine)) < 0.0001
-    True
-
     """
     vs = voxel_sizes(affine)
     fig_merit = (affine[:-1, :-1] / vs[np.newaxis, ...]).max(axis=1).min()

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -304,7 +304,9 @@ def obliquity(affine):
     The term *obliquity* is defined here as the rotation of those axes with
     respect to the cardinal axes.
     This implementation is inspired by `AFNI's implementation
-    <https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/thd_coords.c#L660-L698>`_
+    <https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/thd_coords.c#L660-L698>`_.
+    For further details about *obliquity*, check `AFNI's documentation
+    <https://sscc.nimh.nih.gov/sscc/dglen/Obliquity>_.
 
     Parameters
     ----------

--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -299,7 +299,7 @@ def voxel_sizes(affine):
     return np.sqrt(np.sum(top_left ** 2, axis=0))
 
 
-def obliquity(affine):
+def obliquity(affine, degrees=False):
     r"""
     Estimate the obliquity an affine's axes represent, in degrees from plumb.
 
@@ -309,4 +309,7 @@ def obliquity(affine):
     """
     vs = voxel_sizes(affine)
     fig_merit = (affine[:-1, :-1] / vs[np.newaxis, ...]).max(axis=1).min()
-    return abs(acos(fig_merit) * 180 / PI)
+    radians = abs(acos(fig_merit))
+    if not degrees:
+        return radians
+    return radians * 180 / PI

--- a/nibabel/tests/test_affines.py
+++ b/nibabel/tests/test_affines.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ..eulerangles import euler2mat
 from ..affines import (AffineError, apply_affine, append_diag, to_matvec,
-                       from_matvec, dot_reduce, voxel_sizes)
+                       from_matvec, dot_reduce, voxel_sizes, obliquity)
 
 
 from nose.tools import assert_equal, assert_raises
@@ -178,3 +178,13 @@ def test_voxel_sizes():
             rot_affine[:3, :3] = rotation
             full_aff = rot_affine.dot(aff)
             assert_almost_equal(voxel_sizes(full_aff), vox_sizes)
+
+
+def test_obliquity():
+    """Check the calculation of inclination of an affine axes."""
+    aligned = np.diag([2.0, 2.0, 2.3, 1.0])
+    aligned[:-1, -1] = [-10, -10, -7]
+    R = from_matvec(euler2mat(x=0.09, y=0.001, z=0.001), [0.0, 0.0, 0.0])
+    oblique = R.dot(aligned)
+    assert_almost_equal(obliquity(aligned), 0.0)
+    assert_almost_equal(obliquity(oblique), 5.1569948883)

--- a/nibabel/tests/test_affines.py
+++ b/nibabel/tests/test_affines.py
@@ -182,9 +182,11 @@ def test_voxel_sizes():
 
 def test_obliquity():
     """Check the calculation of inclination of an affine axes."""
+    from math import pi
     aligned = np.diag([2.0, 2.0, 2.3, 1.0])
     aligned[:-1, -1] = [-10, -10, -7]
     R = from_matvec(euler2mat(x=0.09, y=0.001, z=0.001), [0.0, 0.0, 0.0])
     oblique = R.dot(aligned)
-    assert_almost_equal(obliquity(aligned), 0.0)
-    assert_almost_equal(obliquity(oblique, degrees=True), 5.1569948883)
+    assert_almost_equal(obliquity(aligned), [0.0, 0.0, 0.0])
+    assert_almost_equal(obliquity(oblique) * 180 / pi,
+                        [0.0810285, 5.1569949, 5.1569376])

--- a/nibabel/tests/test_affines.py
+++ b/nibabel/tests/test_affines.py
@@ -187,4 +187,4 @@ def test_obliquity():
     R = from_matvec(euler2mat(x=0.09, y=0.001, z=0.001), [0.0, 0.0, 0.0])
     oblique = R.dot(aligned)
     assert_almost_equal(obliquity(aligned), 0.0)
-    assert_almost_equal(obliquity(oblique), 5.1569948883)
+    assert_almost_equal(obliquity(oblique, degrees=True), 5.1569948883)


### PR DESCRIPTION
This implementation mimics the implementation of AFNI, and will be useful in #656 .