### PR TITLE
Ignore unreadable siemens private headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ dist: xenial
 sudo: true
 language: python
 
-cache:
-  directories:
-    - $HOME/.cache/pip
+cache: pip
 env:
     global:
         - SETUP_REQUIRES="pip setuptools>=30.3.0 wheel"
@@ -54,8 +52,8 @@ matrix:
     - python: 3.5
       env:
         - DEPENDS="numpy git+https://github.com/pydicom/pydicom.git@master"
-    # test 3.5 against pre-release builds of everything
-    - python: 3.5
+    # test 3.7 against pre-release builds of everything
+    - python: 3.7
       env:
         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     - python: 3.5

--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -100,7 +100,7 @@ def read(csa_str):
     csa_dict['n_tags'], csa_dict['check'] = up_str.unpack('2I')
     if not 0 < csa_dict['n_tags'] <= MAX_CSA_ITEMS:
         raise CSAReadError('Number of tags `t` should be '
-                           '0 < t <= %d. Instead found %d tags.' 
+                           '0 < t <= %d. Instead found %d tags.'
                            % (MAX_CSA_ITEMS, csa_dict['n_tags']))
     for tag_no in range(csa_dict['n_tags']):
         name, vm, vr, syngodt, n_items, last3 = \

--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -100,7 +100,8 @@ def read(csa_str):
     csa_dict['n_tags'], csa_dict['check'] = up_str.unpack('2I')
     if not 0 < csa_dict['n_tags'] <= MAX_CSA_ITEMS:
         raise CSAReadError('Number of tags `t` should be '
-                           '0 < t <= %d. Instead found %d tags.' % (MAX_CSA_ITEMS, csa_dict['n_tags']))
+                           '0 < t <= %d. Instead found %d tags.' 
+                           % (MAX_CSA_ITEMS, csa_dict['n_tags']))
     for tag_no in range(csa_dict['n_tags']):
         name, vm, vr, syngodt, n_items, last3 = \
             up_str.unpack('64si4s3i')

--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -100,7 +100,7 @@ def read(csa_str):
     csa_dict['n_tags'], csa_dict['check'] = up_str.unpack('2I')
     if not 0 < csa_dict['n_tags'] <= MAX_CSA_ITEMS:
         raise CSAReadError('Number of tags `t` should be '
-                           '0 < t <= %d' % MAX_CSA_ITEMS)
+                           '0 < t <= %d. Instead found %d tags.' % (MAX_CSA_ITEMS, csa_dict['n_tags']))
     for tag_no in range(csa_dict['n_tags']):
         name, vm, vr, syngodt, n_items, last3 = \
             up_str.unpack('64si4s3i')

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -84,7 +84,7 @@ def wrapper_from_data(dcm_data):
         csa = csar.get_csa_header(dcm_data)
     except csar.CSAReadError as e:
         warnings.warn('Error while attempting to read CSA header: ' +
-                      str(e.args) + 
+                      str(e.args) +
                       '\n Ignoring Siemens private (CSA) header info.')
         csa = None
     if csa is None:

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -79,7 +79,12 @@ def wrapper_from_data(dcm_data):
         return MultiframeWrapper(dcm_data)
     # Check for Siemens DICOM format types
     # Only Siemens will have data for the CSA header
-    csa = csar.get_csa_header(dcm_data)
+    try: 
+        csa = csar.get_csa_header(dcm_data)
+    except csar.CSAReadError as e:
+        warnings.warn('Error while attempting to read CSA header: '+ 
+              str(e.args) + '\n ignoring Siemens private (CSA) header info.')
+        csa = None
     if csa is None:
         return Wrapper(dcm_data)
     if csar.is_mosaic(csa):

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -80,11 +80,12 @@ def wrapper_from_data(dcm_data):
         return MultiframeWrapper(dcm_data)
     # Check for Siemens DICOM format types
     # Only Siemens will have data for the CSA header
-    try: 
+    try:
         csa = csar.get_csa_header(dcm_data)
     except csar.CSAReadError as e:
-        warnings.warn('Error while attempting to read CSA header: '+ 
-              str(e.args) + '\n Ignoring Siemens private (CSA) header info.')
+        warnings.warn('Error while attempting to read CSA header: ' +
+                      str(e.args) + 
+                      '\n Ignoring Siemens private (CSA) header info.')
         csa = None
     if csa is None:
         return Wrapper(dcm_data)

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -83,7 +83,7 @@ def wrapper_from_data(dcm_data):
         csa = csar.get_csa_header(dcm_data)
     except csar.CSAReadError as e:
         warnings.warn('Error while attempting to read CSA header: '+ 
-              str(e.args) + '\n ignoring Siemens private (CSA) header info.')
+              str(e.args) + '\n Ignoring Siemens private (CSA) header info.')
         csa = None
     if csa is None:
         return Wrapper(dcm_data)


### PR DESCRIPTION
Workaround for #812. 
dicomwrappers.py will catch and recover from a `CSAReadError` in csarereader.py, setting `csa=None` and giving a warning.  This allows use on some dicoms with CSA headers that are unreadable by nibabel, either because they are corrupted or not supported yet.