### PR TITLE
REL: 3.0.0rc1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,6 +14,7 @@ Basile Pinsard <basile.pinsard@gmail.com> bpinsard <basile.pinsard@gmail.com>
 Basile Pinsard <basile.pinsard@gmail.com> bpinsard <bpinsard@imed.jussieu.fr>
 Ben Cipollini <ben.cipollini@gmail.com> Ben Cipollini <bcipolli@ucsd.edu>
 Bertrand Thirion <bertrand.thirion@inria.fr> bthirion <bertrand.thirion@inria.fr>
+Cameron Riddell <cameronriddell1@gmail.com> <31414128+CRiddler@users.noreply.github.com>
 Christian Haselgrove <christian.haselgrove@umassmed.edu> Christian Haselgrove <Christian.Haselgrove@umassmed.edu>
 Christopher J. Markiewicz <markiewicz@stanford.edu> Chris Johnson <effigies@bu.edu>
 Christopher J. Markiewicz <markiewicz@stanford.edu> Chris Markiewicz <effigies@gmail.com>
@@ -40,6 +41,8 @@ Kesshi Jordan <Kesshi.Jordan@ucsf.edu> kesshijordan <Kesshi.Jordan@ucsf.edu>
 Kevin S. Hahn <kevinshahn@gmail.com> Kevin S. Hahn <kshahn@stanford.edu>
 Konstantinos Raktivan <constracti@gmail.com> constracti <constracti@gmail.com>
 Krish Subramaniam <krish.subramaniam@gmail.com> Krish Subramaniam <krish@monster.nmr.mgh.harvard.edu>
+Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com>
+Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com> <chrisgo@google.com>
 Marc-Alexandre Côté <marc.cote.19@gmail.com> Marc-Alexandre Cote <marc.cote.19@gmail.com>
 Mathias Goncalves <mathiasg@mit.edu> mathiasg <mathiasg@mit.edu>
 Matthew Cieslak <mattcieslak@gmail.com> Matt Cieslak <mattcieslak@gmail.com>
@@ -48,6 +51,7 @@ Michael Hanke <michael.hanke@gmail.com> <michaelhanke@mvpa1.dartmouth.edu>
 Michiel Cottaar <MichielCottaar@protonmail.com> Michiel Cottaar <MichielCottaar@protonmail.ch>
 Ly Nguyen <nguyen60@seattleu.edu> lxn2 <lxn2@uw.edu>
 Oliver P. Hinds <ohinds@gmail.com> ohinds <ohinds@gmail.com>
+Oscar Esteban <code@oscaresteban.es>
 Paul McCarthy <pauldmccarthy@gmail.com> Paul McCarthy <pauld.mccarthy@gmail.com>
 Satrajit Ghosh <satra@mit.edu> Satrajit Ghosh <satrajit.ghosh@gmail.com>
 Serge Koudoro <skab12@gmail.com> skoudoro <skab12@gmail.com>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -69,6 +69,10 @@
       "orcid": "0000-0001-8895-2740"
     },
     {
+      "name": "Wang, Hao-Ting",
+      "orcid": "0000-0003-4078-2038"
+    },
+    {
       "affiliation": "Harvard University - Psychology",
       "name": "Kastman, Erik",
       "orcid": "0000-0001-7221-9042"
@@ -91,6 +95,11 @@
       "affiliation": "MIT",
       "name": "Goncalves, Mathias",
       "orcid": "0000-0002-7252-7771"
+    },
+    {
+      "affiliation": "Department of Psychology, University of California Davis, CA, USA",
+      "name": "Riddell, Cameron",
+      "orcid": "0000-0001-8950-0375"
     },
     {
       "name": "Burns, Christopher"
@@ -120,7 +129,22 @@
       "name": "Vincent, Robert D."
     },
     {
+      "affiliation": "Center for Magnetic Resonance Research, University of Minnesota",
+      "name": "Braun, Henry",
+      "orcid": "0000-0001-7003-9822"
+    },
+    {
       "name": "Subramaniam, Krish"
+    },
+    {
+      "affiliation": "MIT",
+      "name": "Jarecka, Dorota",
+      "orcid": "0000-0003-1857-8129"
+    },
+    {
+      "affiliation": "Google",
+      "name": "Gorgolewski, Krzysztof J.",
+      "orcid": "0000-0003-3321-7583"
     },
     {
       "affiliation": "Rotman Research Institute, Baycrest Health Sciences, Toronto, ON, Canada",
@@ -148,6 +172,11 @@
       "name": "Hymers, Mark"
     },
     {
+      "affiliation": "Department of Psychology, Stanford University, CA, USA",
+      "name": "Esteban, Oscar",
+      "orcid": "0000-0001-8435-6191"
+    },
+    {
       "name": "Koudoro, Serge"
     },
     {
@@ -169,6 +198,10 @@
     },
     {
       "name": "St-Jean, Samuel"
+    },
+    {
+      "name": "Panfilov, Egor",
+      "orcid": "0000-0002-2500-6375"
     },
     {
       "name": "Garyfallidis, Eleftherios"
@@ -196,9 +229,6 @@
     },
     {
       "name": "Fauber, Bennet"
-    },
-    {
-      "name": "Panfilov, Egor"
     },
     {
       "affiliation": "McGill University",
@@ -243,11 +273,6 @@
       "affiliation": "University College London",
       "name": "P\u00e9rez-Garc\u00eda, Fernando",
       "orcid": "0000-0001-9090-3024"
-    },
-    {
-      "affiliation": "Center for Magnetic Resonance Research, University of Minnesota",
-      "name": "Braun, Henry",
-      "orcid": "0000-0001-7003-9822"
     },
     {
       "name": "Solovey, Igor"

--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,59 @@ Eric Larson (EL), Demian Wassermann, and Stephan Gerhard.
 
 References like "pr/298" refer to github pull request numbers.
 
+3.0.0 (To Be Determined)
+========================
+
+New features
+------------
+* ArrayProxy method ``get_scaled()`` scales data with a dtype of a
+  specified precision, promoting as necessary to avoid overflow. This
+  is to used in ``img.get_fdata()`` to control memory usage. (pr/833)
+  (CM, reviewed by Ross Markello)
+* GiftiImage method ``agg_data()`` to return usable data arrays (pr/793)
+  (Hao-Ting Wang, reviewed by CM)
+* Accept ``os.PathLike`` objects in place of filenames (pr/610) (Cameron
+  Riddell, reviewed by MB, CM)
+* Function to calculate obliquity of affines (pr/815) (Oscar Esteban,
+  reviewed by MB)
+
+Enhancements
+------------
+* ``get_fdata(dtype=np.float32)`` will attempt to avoid casting data to
+  ``np.float64`` when scaling parameters would otherwise promote the data
+  type unnecessarily. (pr/833) (CM, reviewed by Ross Markello)
+* ``ArraySequence`` now supports a large set of Python operators to combine
+  or update in-place. (pr/811) (MC, reviewed by Serge Koudoro, Philippe Poulin,
+  CM, MB)
+* Warn, rather than fail, on DICOMs with unreadable Siemens CSA tags (pr/818)
+  (Henry Braun, reviewed by CM)
+* Improve clarity of coordinate system tutorial (pr/823) (Egor Panfilov,
+  reviewed by MB)
+
+Bug fixes
+---------
+* Sliced ``Tractogram``s no longer ``apply_affine`` to the original
+  ``Tractogram``'s streamlines. (pr/811) (MC, reviewed by Serge Koudoro,
+  Philippe Poulin, CM, MB)
+* Re-import externals/netcdf.py from scipy to resolve numpy deprecation
+  (pr/821) (CM)
+
+Maintenance
+-----------
+* Support Python >=3.5.1, including Python 3.8.0 (pr/787) (CM)
+* Manage versioning with slightly customized Versioneer (pr/786) (CM)
+* Reference Nipy Community Code and Nibabel Developer Guidelines in
+  GitHub community documents (pr/778) (CM, reviewed by MB)
+
+API changes and deprecations
+----------------------------
+* Deprecate ``ArraySequence.data`` in favor of ``ArraySequence.get_data()``,
+  which will return a copy. ``ArraySequence.data`` now returns a read-only
+  view. (pr/811) (MC, reviewed by Serge Koudoro, Philippe Poulin, CM, MB)
+* Deprecate ``DataobjImage.get_data()`` API, to be removed in nibabel 5.0
+  (pr/794, pr/809) (CM, reviewed by MB)
+
+
 2.5.1 (Monday 23 September 2019)
 ================================
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -96,9 +96,14 @@ contributed code and discussion (in rough order of appearance):
 * Samir Reddigari
 * Konstantinos Raktivan
 * Matt Cieslak
-* Egor Pafilov
+* Egor Panfilov
 * Jath Palasubramaniam
 * Henry Braun
+* Oscar Esteban
+* Cameron Riddell
+* Hao-Ting Wang
+* Dorota Jarecka
+* Chris Gorgolewski
 
 License reprise
 ===============

--- a/nibabel/_version.py
+++ b/nibabel/_version.py
@@ -208,6 +208,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
+            # CJM: Nibabel fix to filter out refs that exactly match prefix
+            # or that don't start with a number once the prefix is stripped
+            # (Mostly a concern when prefix is '')
+            if not re.match(r'\d', r):
+                continue
             if verbose:
                 print("picking %s" % r)
             return {"version": r,

--- a/nibabel/info.py
+++ b/nibabel/info.py
@@ -13,7 +13,7 @@ relative imports.
 _version_major = 3
 _version_minor = 0
 _version_micro = 0
-_version_extra = 'dev'
+_version_extra = 'rc1'
 # _version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"

--- a/versioneer.py
+++ b/versioneer.py
@@ -629,6 +629,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
+            # CJM: Nibabel fix to filter out refs that exactly match prefix
+            # or that don't start with a number once the prefix is stripped
+            # (Mostly a concern when prefix is '')
+            if not re.match(r'\d', r):
+                continue
             if verbose:
                 print("picking %%s" %% r)
             return {"version": r,
@@ -1029,6 +1034,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
+            # CJM: Nibabel fix to filter out refs that exactly match prefix
+            # or that don't start with a number once the prefix is stripped
+            # (Mostly a concern when prefix is '')
+            if not re.match(r'\d', r):
+                continue
             if verbose:
                 print("picking %s" % r)
             return {"version": r,


### PR DESCRIPTION
Preparation for 3.0.0 Release Candidate 1, targeting Monday, October 28.

This will mark a feature freeze for Nibabel 3.0, so there will be a strong inclination to delay for features that are being actively completed. Bug fixes will be accepted between the release candidate and the final release.

* [x] #793 (Submitter: @htwangtw)
* [x] #811 (Submitter: @MarcCote)

Please comment to flag any other issues that should be addressed. There is the [3.0.0 RC1 milestone](https://github.com/nipy/nibabel/milestone/4) but a few of them are pretty stale, and I don't have the bandwidth to push them, so they're very likely to get dropped in this cycle.

Pre-release checklist
--------
* [x] Review the open list of [nibabel issues](https://github.com/nipy/nibabel/issues). Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release. Label them!
* [x] Review and update the release notes. Review and update the [Changelog file](https://github.com/nipy/nibabel/blob/master/Changelog).
* [x] Look at [`doc/source/index.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/index.rst) and add any authors not yet acknowledged.
* [x] Use the opportunity to update the [`.mailmap file`](https://github.com/nipy/nibabel/blob/master/.mailmap) if there are any duplicate authors listed from `git shortlog -nse`.
* [x] Check the copyright year in [doc/source/conf.py](https://github.com/nipy/nibabel/blob/master/doc/source/conf.py)
* [x] Refresh the [README.rst](https://github.com/nipy/nibabel/blob/master/README.rst) text from the `LONG_DESCRIPTION` in [`info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) by running `make refresh-readme`.
* [x] Check the dependencies listed in [`setup.cfg`](https://github.com/nipy/nibabel/blob/master/setup.cfg) (e.g., `install_requires`, `options.extras_require`) and in [`doc/source/installation.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/installation.rst) and in [`requirements.txt`](https://github.com/nipy/nibabel/blob/master/requirements.txt) and [`.travis.yml`](https://github.com/nipy/nibabel/blob/master/.travis.yml). They should at least match. Do they still hold? Make sure nibabel on travis is testing the minimum dependencies specifically.
* [x] Make sure all tests pass (from the nibabel root directory): `nosetests --with-doctest nibabel`
* [x] Edit [`nibabel/info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) to set `_version_extra` to `''`; commit

Adapted from http://nipy.org/nibabel/devel/make_release.html#release-checklist