### PR TITLE
NF: Enable data scaling within the target dtype

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -362,11 +362,8 @@ class ArrayProxy(object):
         use_dtype = scl_slope.dtype if dtype is None else dtype
         slope = scl_slope.astype(use_dtype)
         inter = scl_inter.astype(use_dtype)
-        # Read array
-        raw_data = self._get_unscaled(slicer=slicer)
-        # Upcast as necessary for big slopes, intercepts
-        scaled = apply_read_scaling(raw_data, slope, inter)
-        del raw_data
+        # Read array and upcast as necessary for big slopes, intercepts
+        scaled = apply_read_scaling(self._get_unscaled(slicer=slicer), slope, inter)
         if dtype is not None:
             scaled = scaled.astype(np.promote_types(scaled.dtype, dtype), copy=False)
         return scaled

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -359,14 +359,17 @@ class ArrayProxy(object):
         # Ensure scale factors have dtypes
         scl_slope = np.asanyarray(self._slope)
         scl_inter = np.asanyarray(self._inter)
-        if dtype is None:
-            dtype = scl_slope.dtype
-        slope = scl_slope.astype(dtype)
-        inter = scl_inter.astype(dtype)
+        use_dtype = scl_slope.dtype if dtype is None else dtype
+        slope = scl_slope.astype(use_dtype)
+        inter = scl_inter.astype(use_dtype)
         # Read array
         raw_data = self._get_unscaled(slicer=slicer)
         # Upcast as necessary for big slopes, intercepts
-        return apply_read_scaling(raw_data, slope, inter)
+        scaled = apply_read_scaling(raw_data, slope, inter)
+        del raw_data
+        if dtype is not None:
+            scaled = scaled.astype(np.promote_types(scaled.dtype, dtype), copy=False)
+        return scaled
 
     def get_unscaled(self):
         """ Read data from file

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from .deprecated import deprecate_with_version
 from .volumeutils import array_from_file, apply_read_scaling
-from .fileslice import fileslice
+from .fileslice import fileslice, canonical_slicers
 from .keywordonly import kw_only_meth
 from . import openers
 
@@ -336,36 +336,77 @@ class ArrayProxy(object):
                     self.file_like, keep_open=False) as opener:
                 yield opener
 
-    def get_unscaled(self):
-        """ Read of data from file
-
-        This is an optional part of the proxy API
-        """
-        with self._get_fileobj() as fileobj, self._lock:
-            raw_data = array_from_file(self._shape,
+    def _get_unscaled(self, slicer):
+        if canonical_slicers(slicer, self._shape, False) == \
+                canonical_slicers((), self._shape, False):
+            with self._get_fileobj() as fileobj, self._lock:
+                return array_from_file(self._shape,
                                        self._dtype,
                                        fileobj,
                                        offset=self._offset,
                                        order=self.order,
                                        mmap=self._mmap)
-        return raw_data
+        with self._get_fileobj() as fileobj:
+            return fileslice(fileobj,
+                             slicer,
+                             self._shape,
+                             self._dtype,
+                             self._offset,
+                             order=self.order,
+                             lock=self._lock)
+
+    def _get_scaled(self, dtype, slicer):
+        # Ensure scale factors have dtypes
+        scl_slope = np.asanyarray(self._slope)
+        scl_inter = np.asanyarray(self._inter)
+        if dtype is None:
+            dtype = scl_slope.dtype
+        slope = scl_slope.astype(dtype)
+        inter = scl_inter.astype(dtype)
+        # Read array
+        raw_data = self._get_unscaled(slicer=slicer)
+        # Upcast as necessary for big slopes, intercepts
+        return apply_read_scaling(raw_data, slope, inter)
+
+    def get_unscaled(self):
+        """ Read data from file
+
+        This is an optional part of the proxy API
+        """
+        return self._get_unscaled(slicer=())
+
+    def get_scaled(self, dtype=None):
+        """ Read data from file and apply scaling
+
+        The dtype of the returned array is the narrowest dtype that can
+        represent the data without overflow, and is at least as wide as
+        the dtype parameter.
+
+        If dtype is unspecified, it is the wider of the dtypes of the slope
+        or intercept. This will generally be determined by the parameter
+        size in the image header, and so should be consistent for a given
+        image format, but may vary across formats. Notably, these factors
+        are single-precision (32-bit) floats for NIfTI-1 and double-precision
+        (64-bit) floats for NIfTI-2.
+
+        Parameters
+        ----------
+        dtype : numpy dtype specifier
+            A numpy dtype specifier specifying the narrowest acceptable
+            dtype.
+
+        Returns
+        -------
+        array
+            Scaled of image data of data type `dtype`.
+        """
+        return self._get_scaled(dtype=dtype, slicer=())
 
     def __array__(self):
-        # Read array and scale
-        raw_data = self.get_unscaled()
-        return apply_read_scaling(raw_data, self._slope, self._inter)
+        return self._get_scaled(dtype=None, slicer=())
 
     def __getitem__(self, slicer):
-        with self._get_fileobj() as fileobj:
-            raw_data = fileslice(fileobj,
-                                 slicer,
-                                 self._shape,
-                                 self._dtype,
-                                 self._offset,
-                                 order=self.order,
-                                 lock=self._lock)
-        # Upcast as necessary for big slopes, intercepts
-        return apply_read_scaling(raw_data, self._slope, self._inter)
+        return self._get_scaled(dtype=None, slicer=slicer)
 
     def reshape(self, shape):
         """ Return an ArrayProxy with a new shape, without modifying data """

--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -10,6 +10,7 @@ This can either be an actual numpy array, or an object that:
 
 import numpy as np
 
+from .arrayproxy import is_proxy
 from .filebasedimages import FileBasedImage
 from .keywordonly import kw_only_meth
 from .deprecated import deprecate_with_version
@@ -350,7 +351,14 @@ class DataobjImage(FileBasedImage):
         if self._fdata_cache is not None:
             if self._fdata_cache.dtype.type == dtype.type:
                 return self._fdata_cache
-        data = np.asanyarray(self._dataobj).astype(dtype, copy=False)
+        dataobj = self._dataobj
+        # Attempt to confine data array to dtype during scaling
+        # On overflow, may still upcast
+        if is_proxy(dataobj):
+            dataobj = dataobj.get_scaled(dtype=dtype)
+        # Always return requested data type
+        # For array proxies, will only copy on overflow
+        data = np.asanyarray(dataobj, dtype=dtype)
         if caching == 'fill':
             self._fdata_cache = data
         return data

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -705,6 +705,25 @@ class EcatImageArrayProxy(object):
         return data
 
     def get_scaled(self, dtype=None):
+        """ Read data from file and apply scaling
+
+        The dtype of the returned array is the narrowest dtype that can
+        represent the data without overflow, and is at least as wide as
+        the dtype parameter.
+
+        If dtype is unspecified, it is automatically determined.
+
+        Parameters
+        ----------
+        dtype : numpy dtype specifier
+            A numpy dtype specifier specifying the narrowest acceptable
+            dtype.
+
+        Returns
+        -------
+        array
+            Scaled of image data of data type `dtype`.
+        """
         data = self.__array__()
         if dtype is None:
             return data

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -704,6 +704,12 @@ class EcatImageArrayProxy(object):
                 frame_mapping[i][0])
         return data
 
+    def get_scaled(self, dtype=None):
+        data = self.__array__()
+        if dtype is not None and np.dtype(dtype) > data.dtype:
+            data = data.astype(dtype)
+        return data
+
     def __getitem__(self, sliceobj):
         """ Return slice `sliceobj` from ECAT data, optimizing if possible
         """

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -706,9 +706,10 @@ class EcatImageArrayProxy(object):
 
     def get_scaled(self, dtype=None):
         data = self.__array__()
-        if dtype is not None and np.dtype(dtype) > data.dtype:
-            data = data.astype(dtype)
-        return data
+        if dtype is None:
+            return data
+        final_type = np.promote_types(data.dtype, dtype)
+        return data.astype(final_type, copy=False)
 
     def __getitem__(self, sliceobj):
         """ Return slice `sliceobj` from ECAT data, optimizing if possible

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -261,13 +261,22 @@ class MincImageArrayProxy(object):
     def is_proxy(self):
         return True
 
+    def _get_scaled(self, dtype, slicer):
+        data = self.minc_file.get_scaled_data(slicer)
+        if dtype is not None and np.dtype(dtype) > data.dtype:
+            data = data.astype(dtype)
+        return data
+
+    def get_scaled(self, dtype=None):
+        return self._get_scaled(dtype=dtype, slicer=())
+
     def __array__(self):
         ''' Read of data from file '''
-        return self.minc_file.get_scaled_data()
+        return self._get_scaled(dtype=None, slicer=())
 
     def __getitem__(self, sliceobj):
         """ Read slice `sliceobj` of data from file """
-        return self.minc_file.get_scaled_data(sliceobj)
+        return self._get_scaled(dtype=None, slicer=sliceobj)
 
 
 class MincHeader(SpatialHeader):

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -263,9 +263,10 @@ class MincImageArrayProxy(object):
 
     def _get_scaled(self, dtype, slicer):
         data = self.minc_file.get_scaled_data(slicer)
-        if dtype is not None and np.dtype(dtype) > data.dtype:
-            data = data.astype(dtype)
-        return data
+        if dtype is None:
+            return data
+        final_type = np.promote_types(data.dtype, dtype)
+        return data.astype(final_type, copy=False)
 
     def get_scaled(self, dtype=None):
         return self._get_scaled(dtype=dtype, slicer=())

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -269,6 +269,25 @@ class MincImageArrayProxy(object):
         return data.astype(final_type, copy=False)
 
     def get_scaled(self, dtype=None):
+        """ Read data from file and apply scaling
+
+        The dtype of the returned array is the narrowest dtype that can
+        represent the data without overflow, and is at least as wide as
+        the dtype parameter.
+
+        If dtype is unspecified, it is automatically determined.
+
+        Parameters
+        ----------
+        dtype : numpy dtype specifier
+            A numpy dtype specifier specifying the narrowest acceptable
+            dtype.
+
+        Returns
+        -------
+        array
+            Scaled of image data of data type `dtype`.
+        """
         return self._get_scaled(dtype=dtype, slicer=())
 
     def __array__(self):

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -633,12 +633,6 @@ class PARRECArrayProxy(object):
     def is_proxy(self):
         return True
 
-    def get_unscaled(self):
-        with ImageOpener(self.file_like) as fileobj:
-            return _data_from_rec(fileobj, self._rec_shape, self._dtype,
-                                  self._slice_indices, self._shape,
-                                  mmap=self._mmap)
-
     def _get_unscaled(self, slicer):
         indices = self._slice_indices
         if slicer == ():
@@ -674,6 +668,9 @@ class PARRECArrayProxy(object):
         # Slice scaling to give output shape
         return raw_data * slopes[slicer].astype(final_type) + inters[slicer].astype(final_type)
 
+
+    def get_unscaled(self):
+        return self._get_unscaled(slicer=())
 
     def get_scaled(self, dtype=None):
         return self._get_scaled(dtype=dtype, slicer=())

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -664,23 +664,15 @@ class PARRECArrayProxy(object):
             return raw_data.astype(final_type, copy=False)
 
         # Broadcast scaling to shape of original data
-        slopes, inters = self._slice_scaling
         fake_data = strided_scalar(self._shape)
-        _, slopes, inters = np.broadcast_arrays(fake_data, slopes, inters)
+        _, slopes, inters = np.broadcast_arrays(fake_data, *self._slice_scaling)
 
         final_type = np.result_type(raw_data, slopes, inters)
         if dtype is not None:
             final_type = np.promote_types(final_type, dtype)
 
-        slopes = slopes.astype(final_type)
-        inters = inters.astype(final_type)
-
-        if slicer is not None:
-            slopes = slopes[slicer]
-            inters = inters[slicer]
-
         # Slice scaling to give output shape
-        return raw_data * slopes + inters
+        return raw_data * slopes[slicer].astype(final_type) + inters[slicer].astype(final_type)
 
 
     def get_scaled(self, dtype=None):

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -670,9 +670,33 @@ class PARRECArrayProxy(object):
 
 
     def get_unscaled(self):
+        """ Read data from file
+
+        This is an optional part of the proxy API
+        """
         return self._get_unscaled(slicer=())
 
     def get_scaled(self, dtype=None):
+        """ Read data from file and apply scaling
+
+        The dtype of the returned array is the narrowest dtype that can
+        represent the data without overflow, and is at least as wide as
+        the dtype parameter.
+
+        If dtype is unspecified, it is the wider of the dtypes of the slopes
+        or intercepts
+
+        Parameters
+        ----------
+        dtype : numpy dtype specifier
+            A numpy dtype specifier specifying the narrowest acceptable
+            dtype.
+
+        Returns
+        -------
+        array
+            Scaled of image data of data type `dtype`.
+        """
         return self._get_scaled(dtype=dtype, slicer=())
 
     def __array__(self):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -44,7 +44,7 @@ from .. import minc1, minc2, parrec, brikhead
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_raises, assert_equal)
 
-from numpy.testing import assert_almost_equal, assert_array_equal, assert_warns
+from numpy.testing import assert_almost_equal, assert_array_equal, assert_warns, assert_allclose
 from ..testing import clear_and_catch_warnings
 from ..tmpdirs import InTemporaryDirectory
 
@@ -314,18 +314,18 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         # New data dtype, no caching, doesn't use or alter cache
         fdata_new_dt = img.get_fdata(caching='unchanged', dtype='f4')
         # We get back the original read, not the modified cache
-        assert_array_equal(fdata_new_dt, proxy_data.astype('f4'))
+        assert_allclose(fdata_new_dt, proxy_data.astype('f4'), rtol=1e-05, atol=1e-08)
         assert_equal(fdata_new_dt.dtype, np.float32)
         # The original cache stays in place, for default float64
         assert_array_equal(img.get_fdata(), 42)
         # And for not-default float32, because we haven't cached
         fdata_new_dt[:] = 43
         fdata_new_dt = img.get_fdata(caching='unchanged', dtype='f4')
-        assert_array_equal(fdata_new_dt, proxy_data.astype('f4'))
+        assert_allclose(fdata_new_dt, proxy_data.astype('f4'), rtol=1e-05, atol=1e-08)
         # Until we reset with caching='fill', at which point we
         # drop the original float64 cache, and have a float32 cache
         fdata_new_dt = img.get_fdata(caching='fill', dtype='f4')
-        assert_array_equal(fdata_new_dt, proxy_data.astype('f4'))
+        assert_allclose(fdata_new_dt, proxy_data.astype('f4'), rtol=1e-05, atol=1e-08)
         # We're using the cache, for dtype='f4' reads
         fdata_new_dt[:] = 43
         assert_array_equal(img.get_fdata(dtype='f4'), 43)

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -314,6 +314,9 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         # New data dtype, no caching, doesn't use or alter cache
         fdata_new_dt = img.get_fdata(caching='unchanged', dtype='f4')
         # We get back the original read, not the modified cache
+        # Allow for small rounding error when the data is scaled with 32-bit
+        # factors, rather than 64-bit factors and then cast to float-32
+        # Use rtol/atol from numpy.allclose
         assert_allclose(fdata_new_dt, proxy_data.astype('f4'), rtol=1e-05, atol=1e-08)
         assert_equal(fdata_new_dt.dtype, np.float32)
         # The original cache stays in place, for default float64

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -52,7 +52,7 @@ from ..arrayproxy import ArrayProxy, is_proxy
 
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_raises,
-                        assert_equal, assert_not_equal)
+                        assert_equal, assert_not_equal, assert_greater_equal)
 
 from numpy.testing import (assert_almost_equal, assert_array_equal)
 
@@ -130,6 +130,22 @@ class _TestProxyAPI(ValidateAPI):
         assert_dt_equal(out.dtype, params['dtype_out'])
         # Shape matches expected shape
         assert_equal(out.shape, params['shape'])
+
+    def validate_get_scaled(self, pmaker, params):
+        # Check proxy returns expected array from asarray
+        prox, fio, hdr = pmaker()
+        out = prox.get_scaled()
+        assert_array_equal(out, params['arr_out'])
+        assert_dt_equal(out.dtype, params['dtype_out'])
+        # Shape matches expected shape
+        assert_equal(out.shape, params['shape'])
+
+        for dtype in (np.float16, np.float32, np.float64, np.float128):
+            out = prox.get_scaled(dtype=dtype)
+            assert_almost_equal(out, params['arr_out'])
+            assert_greater_equal(out.dtype, np.dtype(dtype))
+            # Shape matches expected shape
+            assert_equal(out.shape, params['shape'])
 
     def validate_header_isolated(self, pmaker, params):
         # Confirm altering input header has no effect

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -140,7 +140,7 @@ class _TestProxyAPI(ValidateAPI):
         # Shape matches expected shape
         assert_equal(out.shape, params['shape'])
 
-        for dtype in np.sctypes['float']:
+        for dtype in np.sctypes['float'] + np.sctypes['int'] + np.sctypes['uint']:
             out = prox.get_scaled(dtype=dtype)
             assert_almost_equal(out, params['arr_out'])
             assert_greater_equal(out.dtype, np.dtype(dtype))

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -140,7 +140,7 @@ class _TestProxyAPI(ValidateAPI):
         # Shape matches expected shape
         assert_equal(out.shape, params['shape'])
 
-        for dtype in (np.float16, np.float32, np.float64, np.float128):
+        for dtype in np.sctypes['float']:
             out = prox.get_scaled(dtype=dtype)
             assert_almost_equal(out, params['arr_out'])
             assert_greater_equal(out.dtype, np.dtype(dtype))

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -195,8 +195,8 @@ class DataLike(object):
     # Minimal class implementing 'data' API
     shape = (3,)
 
-    def __array__(self):
-        return np.arange(3, dtype=np.int16)
+    def __array__(self, dtype='int16'):
+        return np.arange(3, dtype=dtype)
 
 
 class TestSpatialImage(TestCase):


### PR DESCRIPTION
Following some initial discussion in #832, this PR allows for ArrayProxies to scale data objects within a target dtype, rather than always defaulting to float64, which will prevent memory spikes and speed up results for `get_fdata(dtype=np.float32)`.

This obviously has consequences for accumulating rounding errors. The old behavior can be achieved with `get_fdata().astype(np.float32)`, although the caching properties are changed.

This involves a refactor that uniformizes access to unscaled and scaled data using file slices, and `get_scaled()`, `get_unscaled()` and `__array__` will now call `fileslice` with the `()` slicer. With some informal benchmarking, `img.dataobj[()]` is at least as fast as `np.asanyarray(img.dataobj)`:

```Python
In [60]: %timeit _ = np.array(img.dataobj)                                                          
7.38 s ± 169 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [62]: %timeit _ = img.dataobj[:]                                                                 
5.89 s ± 376 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [63]: %timeit _ = img.dataobj[()]                                                                
5.76 s ± 159 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [67]: %timeit _ = np.asanyarray(img.dataobj)                                                     
6.48 s ± 233 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

One question is whether to have `Nifti1Header.get_slope_inter()` return `np.float32`s or continue returning `float`s. By continuing to return `float`, `get_data()` will continue to return `float64` arrays when scale factors are applied.

This is a potentially consequential API change, so I'd appreciate wide comments from @nipy/team-nibabel, and any other interested parties.

Tests on the way.