### PR TITLE
MNT: Drop test data from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,11 +3,5 @@ include Changelog TODO requirements.txt
 recursive-include doc *
 recursive-include bin *
 recursive-include tools *
-# put this stuff back into setup.py (package_data) once I'm enlightened
-# enough to accomplish this herculean task
-recursive-include nibabel/tests/data *
-recursive-include nibabel/externals/tests/data *
-recursive-include nibabel/nicom/tests/data *
-recursive-include nibabel/gifti/tests/data *
 include versioneer.py
 include nibabel/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ tests_require =
 test_suite = nose.collector
 zip_safe = False
 packages = find:
-include_package_data = True
 
 [options.extras_require]
 dicom =


### PR DESCRIPTION
Update setup.cfg option to enable package data specification.

Looks like `include_package_data=True` has the effect of ignoring the `package_data` dict.