### PR TITLE
TEST: Check non-integral slopes, intercepts in ArrayProxy API

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -29,8 +29,7 @@ jobs:
       displayName: 'Update build tools'
     - script: |
         python -m pip install --find-links %EXTRA_WHEELS% %DEPENDS%
-        python -m pip install nose mock coverage codecov
-        python -m pip install pytest
+        python -m pip install nose mock coverage codecov pytest
       displayName: 'Install dependencies'
     - script: |
         python -m pip install .
@@ -41,7 +40,6 @@ jobs:
         cd for_testing
         cp ../.coveragerc .
         nosetests --with-doctest --with-coverage --cover-package nibabel nibabel
-        pytest -v ../nibabel/tests/test_affines.py ../nibabel/tests/test_volumeutils.py
       displayName: 'Nose tests'
     - script: |
         cd for_testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,6 @@ script:
           cd for_testing
           cp ../.coveragerc .
           nosetests --with-doctest --with-coverage --cover-package nibabel nibabel
-          pytest -v ../nibabel/tests/test_affines.py ../nibabel/tests/test_volumeutils.py
       else
           false
       fi

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -360,10 +360,13 @@ class ArrayProxy(object):
         scl_slope = np.asanyarray(self._slope)
         scl_inter = np.asanyarray(self._inter)
         use_dtype = scl_slope.dtype if dtype is None else dtype
-        slope = scl_slope.astype(use_dtype)
-        inter = scl_inter.astype(use_dtype)
+
+        if np.can_cast(scl_slope, use_dtype):
+            scl_slope = scl_slope.astype(use_dtype)
+        if np.can_cast(scl_inter, use_dtype):
+            scl_inter = scl_inter.astype(use_dtype)
         # Read array and upcast as necessary for big slopes, intercepts
-        scaled = apply_read_scaling(self._get_unscaled(slicer=slicer), slope, inter)
+        scaled = apply_read_scaling(self._get_unscaled(slicer=slicer), scl_slope, scl_inter)
         if dtype is not None:
             scaled = scaled.astype(np.promote_types(scaled.dtype, dtype), copy=False)
         return scaled

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -221,6 +221,8 @@ class TestAnalyzeProxyAPI(_TestProxyAPI):
             offsets = (self.header_class().get_data_offset(),)
         else:
             offsets = (0, 16)
+        # For non-integral parameters, cast to float32 value can be losslessly cast
+        # later, enabling exact checks, then back to float for consistency
         slopes = (1., 2., float(np.float32(3.1416))) if self.has_slope else (1.,)
         inters = (0., 10., float(np.float32(2.7183))) if self.has_inter else (0.,)
         for shape, dtype, offset, slope, inter in product(self.shapes,

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -216,8 +216,8 @@ class TestAnalyzeProxyAPI(_TestProxyAPI):
             offsets = (self.header_class().get_data_offset(),)
         else:
             offsets = (0, 16)
-        slopes = (1., 2.) if self.has_slope else (1.,)
-        inters = (0., 10.) if self.has_inter else (0.,)
+        slopes = (1., 2., 3.1416) if self.has_slope else (1.,)
+        inters = (0., 10., 2.7183) if self.has_inter else (0.,)
         dtypes = (np.uint8, np.int16, np.float32)
         for shape, dtype, offset, slope, inter in product(self.shapes,
                                                           dtypes,

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -47,6 +47,7 @@ from .. import minc2
 from .._h5py_compat import h5py, have_h5py
 from .. import ecat
 from .. import parrec
+from ..casting import have_binary128
 
 from ..arrayproxy import ArrayProxy, is_proxy
 
@@ -192,6 +193,7 @@ class TestAnalyzeProxyAPI(_TestProxyAPI):
     shapes = ((2,), (2, 3), (2, 3, 4), (2, 3, 4, 5))
     has_slope = False
     has_inter = False
+    data_dtypes = (np.uint8, np.int16, np.int32, np.float32, np.complex64, np.float64)
     array_order = 'F'
     # Cannot set offset for Freesurfer
     settable_offset = True
@@ -218,9 +220,8 @@ class TestAnalyzeProxyAPI(_TestProxyAPI):
             offsets = (0, 16)
         slopes = (1., 2., 3.1416) if self.has_slope else (1.,)
         inters = (0., 10., 2.7183) if self.has_inter else (0.,)
-        dtypes = (np.uint8, np.int16, np.float32)
         for shape, dtype, offset, slope, inter in product(self.shapes,
-                                                          dtypes,
+                                                          self.data_dtypes,
                                                           offsets,
                                                           slopes,
                                                           inters):
@@ -325,6 +326,10 @@ class TestSpm2AnalyzeProxyAPI(TestSpm99AnalyzeProxyAPI):
 class TestNifti1ProxyAPI(TestSpm99AnalyzeProxyAPI):
     header_class = Nifti1Header
     has_inter = True
+    data_dtypes = (np.uint8, np.int16, np.int32, np.float32, np.complex64, np.float64,
+                   np.int8, np.uint16, np.uint32, np.int64, np.uint64, np.complex128)
+    if have_binary128():
+        data_dtypes.extend(np.float128, np.complex256)
 
 
 class TestMGHAPI(TestAnalyzeProxyAPI):
@@ -334,6 +339,7 @@ class TestMGHAPI(TestAnalyzeProxyAPI):
     has_inter = False
     settable_offset = False
     data_endian = '>'
+    data_dtypes = (np.uint8, np.int16, np.int32, np.float32)
 
 
 class TestMinc1API(_TestProxyAPI):


### PR DESCRIPTION
Realized the ArrayProxy API tests are only using integral slopes and intercepts. Added some 5 s.f. parameters.

Currently breaks tests. Will look in detail when I can, but more eyes are always welcome.

This should be resolved and merged into #844, to ensure that the changes to results stay within tolerance.