### PR TITLE
RF: Improve fallback version check, require PyPA packaging module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ provides =
 python_requires = >=3.5.1
 install_requires =
     numpy >=1.12
+    packaging
 tests_require =
     nose >=0.11
     pytest


### PR DESCRIPTION
This moves us fully to PEP440-compliance, and uses the [packaging.version](https://packaging.pypa.io/en/latest/version/) module, a carve-out of pip. Using their `Version` object allows us to avoid manual munging of version strings.

This is a new dependency, but a fairly lightweight one. It reintroduces `six` and adds `pyparsing` to our dependency tree. I expect `six` will probably disappear in a version or two, and `pyparsing` itself has no dependencies.

Due to the new dependency, this is proposed for 3.1.

Fixes #855.