### PR TITLE
TEST: Numpy changed longdouble str representations in 1.18

### DIFF
--- a/nibabel/tests/test_h5py_compat.py
+++ b/nibabel/tests/test_h5py_compat.py
@@ -40,5 +40,8 @@ def test_disabled_h5py_cases():
         # Verify that the root cause is present
         # If any tests fail, they will likely be these, so they may be
         # ill-advised...
-        assert_equal(str(np.longdouble), str(np.float64))
+        if LooseVersion(np.__version__) < '1.18':
+            assert_equal(str(np.longdouble), str(np.float64))
+        else:
+            assert_not_equal(str(np.longdouble), str(np.float64))
         assert_not_equal(np.longdouble, np.float64)


### PR DESCRIPTION
numpy/numpy#10151 broke the [h5py compatibility tests](https://dev.azure.com/nipy/nibabel/_build/results?buildId=288&view=logs&j=5648a722-02bc-5c74-865c-69e37017d3ea&t=9bbb20ae-a36e-539c-fc66-72c5fcdc2f8c&l=195) which checked for string matching.

That wasn't an important test, but it did explain why the issue took so long to track down. This update adds numpy 1.18's changes to the logic.

All of this will go away when we drop Python 3.5.