### PR TITLE
test_proxy_api: replace nonexistent `extend` method call on a tuple with `+=`

### DIFF
--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -345,7 +345,7 @@ class TestNifti1ProxyAPI(TestSpm99AnalyzeProxyAPI):
     data_dtypes = (np.uint8, np.int16, np.int32, np.float32, np.complex64, np.float64,
                    np.int8, np.uint16, np.uint32, np.int64, np.uint64, np.complex128)
     if have_binary128():
-        data_dtypes.extend(np.float128, np.complex256)
+        data_dtypes += (np.float128, np.complex256)
 
 
 class TestMGHAPI(TestAnalyzeProxyAPI):


### PR DESCRIPTION
Previously when `have_binary128()` is `True`:
```
ERROR: Failure: AttributeError ('tuple' object has no attribute 'extend')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/nibabel-3.0.0/nibabel/tests/test_proxy_api.py", line 351, in TestNifti1ProxyAPI
    data_dtypes.extend(np.float128, np.complex256)
AttributeError: 'tuple' object has no attribute 'extend'
```