### PR TITLE
REL: 3.0.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,7 @@ B. Nolan Nichols <nolan.nichols@gmail.com> Nolan Nichols <nolan.nichols@gmail.co
 Basile Pinsard <basile.pinsard@gmail.com> bpinsard <basile.pinsard@gmail.com>
 Basile Pinsard <basile.pinsard@gmail.com> bpinsard <bpinsard@imed.jussieu.fr>
 Ben Cipollini <ben.cipollini@gmail.com> Ben Cipollini <bcipolli@ucsd.edu>
+Benjamin C Darwin <bcdarwin@gmail.com>
 Bertrand Thirion <bertrand.thirion@inria.fr> bthirion <bertrand.thirion@inria.fr>
 Cameron Riddell <cameronriddell1@gmail.com> <31414128+CRiddler@users.noreply.github.com>
 Christian Haselgrove <christian.haselgrove@umassmed.edu> Christian Haselgrove <Christian.Haselgrove@umassmed.edu>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -260,6 +260,9 @@
       "name": "Schwartz, Yannick"
     },
     {
+      "name": "Darwin, Ben"
+    },
+    {
       "affiliation": "INRIA",
       "name": "Thirion, Bertrand",
       "orcid": "0000-0001-5018-7895"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -260,7 +260,8 @@
       "name": "Schwartz, Yannick"
     },
     {
-      "name": "Darwin, Ben"
+      "affiliation": "Hospital for Sick Children",
+      "name": "Darwin, Benjamin C"
     },
     {
       "affiliation": "INRIA",

--- a/Changelog
+++ b/Changelog
@@ -82,6 +82,8 @@ Bug fixes
 * Sliced ``Tractogram``s no longer ``apply_affine`` to the original
   ``Tractogram``'s streamlines. (pr/811) (MC, reviewed by Serge Koudoro,
   Philippe Poulin, CM, MB)
+* Change strings with invalid escapes to raw strings (pr/827) (EL, reviewed
+  by CM)
 * Re-import externals/netcdf.py from scipy to resolve numpy deprecation
   (pr/821) (CM)
 

--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,22 @@ Eric Larson (EL), Demian Wassermann, and Stephan Gerhard.
 
 References like "pr/298" refer to github pull request numbers.
 
+3.0.1 (Monday 27 January 2020)
+==============================
+
+Bug fixes
+---------
+* Test failed by using array method on tuple. (pr/860) (Ben Darwin, reviewed by
+  CM)
+* Validate ``ExpiredDeprecationError``\s, promoted by 3.0 release from
+  ``DeprecationWarning``\s. (pr/857) (CM)
+
+Maintenance
+-----------
+* Remove logic accommodating numpy without float16 types. (pr/866) (CM)
+* Accommodate new numpy dtype strings. (pr/858) (CM)
+
+
 3.0.0 (Wednesday 18 December 2019)
 ==================================
 

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -3,4 +3,4 @@
 sphinx
 numpydoc
 texext
-matplotlib>=1.3
+matplotlib >=1.3.1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -99,7 +99,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'NiBabel'
-copyright = u'2006-2019, %(maintainer)s <%(author_email)s>' % metadata
+copyright = u'2006-2020, %(maintainer)s <%(author_email)s>' % metadata
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -104,7 +104,7 @@ contributed code and discussion (in rough order of appearance):
 * Hao-Ting Wang
 * Dorota Jarecka
 * Chris Gorgolewski
-* Ben Darwin
+* Benjamin C Darwin
 
 License reprise
 ===============

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -104,6 +104,7 @@ contributed code and discussion (in rough order of appearance):
 * Hao-Ting Wang
 * Dorota Jarecka
 * Chris Gorgolewski
+* Ben Darwin
 
 License reprise
 ===============

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -89,7 +89,7 @@ Requirements
 *  h5py_ (optional, for MINC2 support)
 *  PyDICOM_ 0.9.9 or greater (optional, for DICOM support)
 *  `Python Imaging Library`_ (optional, for PNG conversion in DICOMFS)
-*  nose_ 0.11 or greater (optional, to run the tests)
+*  nose_ 0.11 or greater and pytest_ (optional, to run the tests)
 *  sphinx_ (optional, to build the documentation)
 
 Get the development sources

--- a/doc/source/links_names.txt
+++ b/doc/source/links_names.txt
@@ -83,6 +83,7 @@
 .. _emacs_python_mode: http://www.emacswiki.org/cgi-bin/wiki/PythonMode
 .. _doctest-mode: http://ed.loper.org/projects/doctestmode/
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose
+.. _pytest: https://docs.pytest.org/
 .. _`python coverage tester`: http://nedbatchelder.com/code/coverage/
 .. _bitbucket: https://bitbucket.org
 .. _six: http://pythonhosted.org/six

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,9 @@ packages = find:
 [options.extras_require]
 dicom =
     pydicom >=0.9.9
+dicomfs =
+    %(dicom)s
+    pillow
 dev =
     gitpython
     twine
@@ -51,6 +54,8 @@ doc =
     texext
 minc2 =
     h5py
+spm =
+    scipy
 style =
     flake8
 test =
@@ -58,10 +63,11 @@ test =
     nose >=0.11
     pytest
 all =
-    %(dicom)s
+    %(dicomfs)s
     %(dev)s
     %(doc)s
     %(minc2)s
+    %(spm)s
     %(style)s
     %(test)s
 


### PR DESCRIPTION
Preparation for bug-fix release 3.0.1, targeting Monday, January 27.

Waiting on one small maintenance PR:

* [x] #866 (Submitter: @effigies)

Please comment to flag any other issues that should be addressed.

@bcdarwin I have added you to the author list and the `.zenodo.json`. Please let me know if you would prefer to be cited otherwise. If you have an affiliation and ORCID to add to the Zenodo entry, let me know that as well.

Pre-release checklist
--------
* [x] Review the open list of [nibabel issues](https://github.com/nipy/nibabel/issues). Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release. Label them!
* [x] Review and update the release notes. Review and update the [Changelog file](https://github.com/nipy/nibabel/blob/master/Changelog).
* [x] Look at [`doc/source/index.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/index.rst) and add any authors not yet acknowledged.
* [x] Use the opportunity to update the [`.mailmap file`](https://github.com/nipy/nibabel/blob/master/.mailmap) if there are any duplicate authors listed from `git shortlog -nse`.
* [x] Check the copyright year in [doc/source/conf.py](https://github.com/nipy/nibabel/blob/master/doc/source/conf.py)
* [x] Refresh the [README.rst](https://github.com/nipy/nibabel/blob/master/README.rst) text from the `LONG_DESCRIPTION` in [`info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) by running `make refresh-readme`.
* [x] Check the dependencies listed in [`setup.cfg`](https://github.com/nipy/nibabel/blob/master/setup.cfg) (e.g., `install_requires`, `options.extras_require`) and in [`doc/source/installation.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/installation.rst) and in [`requirements.txt`](https://github.com/nipy/nibabel/blob/master/requirements.txt) and [`.travis.yml`](https://github.com/nipy/nibabel/blob/master/.travis.yml). They should at least match. Do they still hold? Make sure nibabel on travis is testing the minimum dependencies specifically.
* [x] Make sure all tests pass (from the nibabel root directory): `nosetests --with-doctest nibabel`

Adapted from http://nipy.org/nibabel/devel/make_release.html#release-checklist