### PR TITLE
MNT/FIX: Bump minimum matplotlib to 1.5.2 to match available wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # Absolute minimum dependencies plus oldest MPL
     - python: 3.5
       env:
-        - DEPENDS="-r min-requirements.txt matplotlib==1.5.2"
+        - DEPENDS="-r min-requirements.txt matplotlib==1.5.3"
     # Minimum pydicom dependency
     - python: 3.5
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ env:
         - DEPENDS="numpy scipy matplotlib h5py pillow pydicom indexed_gzip"
         - INSTALL_TYPE="setup"
         - CHECK_TYPE="test"
-        - OLD_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
         - EXTRA_WHEELS="https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com"
         - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-        - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS --find-links=$OLD_WHEELS"
+        - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
         - PRE_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
 
 python:
@@ -45,7 +44,7 @@ matrix:
     # Absolute minimum dependencies plus oldest MPL
     - python: 3.5
       env:
-        - DEPENDS="-r min-requirements.txt matplotlib==1.3.1"
+        - DEPENDS="-r min-requirements.txt matplotlib==1.5.2"
     # Minimum pydicom dependency
     - python: 3.5
       env:

--- a/nibabel/tests/test_viewers.py
+++ b/nibabel/tests/test_viewers.py
@@ -20,7 +20,8 @@ from numpy.testing import assert_array_equal, assert_equal
 from nose.tools import assert_raises, assert_true
 
 # Need at least MPL 1.3 for viewer tests.
-matplotlib, has_mpl, _ = optional_package('matplotlib', min_version='1.3')
+# 2020.02.11 - 1.3 wheels are no longer distributed, so the minimum we test with is 1.5
+matplotlib, has_mpl, _ = optional_package('matplotlib', min_version='1.5')
 
 needs_mpl = skipif(not has_mpl, 'These tests need matplotlib')
 if has_mpl:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ dev =
     gitpython
     twine
 doc =
-    matplotlib >= 1.3.1
+    matplotlib >= 1.5.2
     numpydoc
     sphinx >=0.3
     texext

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ dev =
     gitpython
     twine
 doc =
-    matplotlib >= 1.5.2
+    matplotlib >= 1.5.3
     numpydoc
     sphinx >=0.3
     texext


### PR DESCRIPTION
Per https://github.com/nipy/nibabel/issues/886#issuecomment-584536704, ancient wheels are no longer being hosted for free. The only affected minimum dependency we have is matplotlib, which we can bump to 1.5 without likely affecting users.

The oldest wheel for Python 3.6 is 1.5.3, so I'm going with that to avoid doing this again in a couple months.