### PR TITLE
RF: minc - delay import of h5py until needed.

### DIFF
--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -27,8 +27,6 @@ and compare against command line output of::
 """
 import numpy as np
 
-from ._h5py_compat import h5py
-
 from .minc1 import Minc1File, MincHeader, Minc1Image, MincError
 
 
@@ -158,6 +156,9 @@ class Minc2Image(Minc1Image):
 
     @classmethod
     def from_file_map(klass, file_map, *, mmap=True, keep_file_open=None):
+        # Import of h5py might take awhile for MPI-enabled builds
+        # So we are importing it here "on demand"
+        from ._h5py_compat import h5py
         holder = file_map['image']
         if holder.filename is None:
             raise MincError('MINC2 needs filename for load')


### PR DESCRIPTION
On Debian systems h5py comes with MPI enabled build.
I guess on some misconfigured systems, like my laptop, it might take awhile to import.

And since h5py here is imported upon import of `nibabel`, it makes
it long(er) to import it.  Here is timing on my laptop before the change:

    $> time python -c 'import nibabel'
    python -c 'import nibabel'  0.20s user 0.08s system 5% cpu 5.356 total

and here is after the change:

    $> time python -c 'import nibabel'
    python -c 'import nibabel'  0.13s user 0.02s system 100% cpu 0.150 total