### PR TITLE
MNT: Drop deprecated ndarray.tostring for tobytes

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -509,7 +509,7 @@ class AnalyzeHeader(LabeledWrapStruct):
         >>> str_io = BytesIO()
         >>> data = np.arange(6).reshape(1,2,3)
         >>> hdr.data_to_fileobj(data, str_io)
-        >>> data.astype(np.float64).tostring('F') == str_io.getvalue()
+        >>> data.astype(np.float64).tobytes('F') == str_io.getvalue()
         True
         '''
         data = np.asanyarray(data)

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -48,7 +48,7 @@ def run_slices(file_like, repeat=3, offset=0, order='F'):
     times_arr = np.zeros((n_dim, n_slicers))
     with ImageOpener(file_like, 'wb') as fobj:
         fobj.write(b'\0' * offset)
-        fobj.write(arr.tostring(order=order))
+        fobj.write(arr.tobytes(order=order))
     with ImageOpener(file_like, 'rb') as fobj:
         for i, L in enumerate(SHAPE):
             for j, slicer in enumerate(_slices_for_len(L)):

--- a/nibabel/dft.py
+++ b/nibabel/dft.py
@@ -144,8 +144,7 @@ class _Series(object):
             max = data.max()
             data = data * 255 / (max - min)
         data = data.astype(numpy.uint8)
-        im = frombytes('L', (self.rows, self.columns),
-                       data.tostring())
+        im = frombytes('L', (self.rows, self.columns), data.tobytes())
 
         s = BytesIO()
         im.save(s, 'PNG')
@@ -213,7 +212,7 @@ class _Series(object):
         s = BytesIO()
         hdr.write_to(s)
 
-        return s.getvalue() + data.tostring()
+        return s.getvalue() + data.tobytes()
 
     def nifti_size(self):
         return 352 + 2 * len(self.storage_instances) * self.columns * self.rows

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -981,7 +981,7 @@ class EcatImage(SpatialImage):
 
             # Write subheader
             subhdr = subheaders.subheaders[index]
-            imgf.write(subhdr.tostring())
+            imgf.write(subhdr.tobytes())
 
             # Seek to the next image block
             pos = imgf.tell()

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -421,7 +421,7 @@ class netcdf_file(object):
     def _write(self):
         self.fp.seek(0)
         self.fp.write(b'CDF')
-        self.fp.write(array(self.version_byte, '>b').tostring())
+        self.fp.write(array(self.version_byte, '>b').tobytes())
 
         # Write headers and data.
         self._write_numrecs()
@@ -531,7 +531,7 @@ class netcdf_file(object):
 
         # Write data.
         if not var.isrec:
-            self.fp.write(var.data.tostring())
+            self.fp.write(var.data.tobytes())
             count = var.data.size * var.data.itemsize
             self._write_var_padding(var, var._vsize - count)
         else:  # record variable
@@ -553,7 +553,7 @@ class netcdf_file(object):
                 if not rec.shape and (rec.dtype.byteorder == '<' or
                         (rec.dtype.byteorder == '=' and LITTLE_ENDIAN)):
                     rec = rec.byteswap()
-                self.fp.write(rec.tostring())
+                self.fp.write(rec.tobytes())
                 # Padding
                 count = rec.size * rec.itemsize
                 self._write_var_padding(var, var._vsize - count)
@@ -606,7 +606,7 @@ class netcdf_file(object):
         if not values.shape and (values.dtype.byteorder == '<' or
                 (values.dtype.byteorder == '=' and LITTLE_ENDIAN)):
             values = values.byteswap()
-        self.fp.write(values.tostring())
+        self.fp.write(values.tobytes())
         count = values.size * values.itemsize
         self.fp.write(b'\x00' * (-count % 4))  # pad
 
@@ -791,7 +791,7 @@ class netcdf_file(object):
             self._pack_int64(begin)
 
     def _pack_int(self, value):
-        self.fp.write(array(value, '>i').tostring())
+        self.fp.write(array(value, '>i').tobytes())
     _pack_int32 = _pack_int
 
     def _unpack_int(self):
@@ -799,7 +799,7 @@ class netcdf_file(object):
     _unpack_int32 = _unpack_int
 
     def _pack_int64(self, value):
-        self.fp.write(array(value, '>q').tostring())
+        self.fp.write(array(value, '>q').tobytes())
 
     def _unpack_int64(self):
         return frombuffer(self.fp.read(8), '>q')[0]
@@ -1045,7 +1045,7 @@ class netcdf_variable(object):
         """
         if '_FillValue' in self._attributes:
             fill_value = np.array(self._attributes['_FillValue'],
-                                  dtype=self.data.dtype).tostring()
+                                  dtype=self.data.dtype).tobytes()
             if len(fill_value) == self.itemsize():
                 return fill_value
             else:

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -613,7 +613,7 @@ def _serialize_volume_info(volume_info):
             if not (np.array_equal(volume_info[key], [20]) or np.array_equal(
                     volume_info[key], [2, 0, 20])):
                 warnings.warn("Unknown extension code.")
-            strings.append(np.array(volume_info[key], dtype='>i4').tostring())
+            strings.append(np.array(volume_info[key], dtype='>i4').tobytes())
         elif key in ('valid', 'filename'):
             val = volume_info[key]
             strings.append('{0} = {1}\n'.format(key, val).encode('utf-8'))

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -407,7 +407,7 @@ class MGHHeader(LabeledWrapStruct):
                                   buffer=self.binaryblock)
         # goto the very beginning of the file-like obj
         fileobj.seek(0)
-        fileobj.write(hdr_nofooter.tostring())
+        fileobj.write(hdr_nofooter.tobytes())
 
     def writeftr_to(self, fileobj):
         ''' Write footer to fileobj
@@ -427,7 +427,7 @@ class MGHHeader(LabeledWrapStruct):
         ftr_nd = np.ndarray((), dtype=self._ftrdtype,
                             buffer=self.binaryblock, offset=ftr_loc_in_hdr)
         fileobj.seek(self.get_footer_offset())
-        fileobj.write(ftr_nd.tostring())
+        fileobj.write(ftr_nd.tobytes())
 
     def copy(self):
         ''' Return copy of structure '''

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -309,7 +309,7 @@ def test_read_annot_old_format():
         # number of vertices
         fbytes += struct.pack(dt, nverts)
         # vertices + annotation values
-        fbytes += bytes(vdata.astype(dt).tostring())
+        fbytes += vdata.astype(dt).tobytes()
         # is there a colour table?
         fbytes += struct.pack(dt, 1)
         # number of entries in colour table
@@ -321,7 +321,7 @@ def test_read_annot_old_format():
             # length of entry name (+1 for terminating byte)
             fbytes += struct.pack(dt, len(names[i]) + 1)
             fbytes += names[i].encode('ascii') + b'\x00'
-            fbytes += bytes(rgba[i, :].astype(dt).tostring())
+            fbytes += rgba[i, :].astype(dt).tobytes()
         with open(fpath, 'wb') as f:
             f.write(fbytes)
     with InTemporaryDirectory():

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -281,7 +281,7 @@ def _data_tag_element(dataarray, encoding, dtype, ordering):
         # XXX Accommodating data_tag API - don't try to fix dtype
         if isinstance(dtype, str):
             dtype = dataarray.dtype
-        out = np.asanyarray(dataarray, dtype).tostring(order)
+        out = np.asanyarray(dataarray, dtype).tobytes(order)
         if enclabel == 'B64GZ':
             out = zlib.compress(out)
         da = base64.b64encode(out).decode()

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -618,7 +618,7 @@ class TestMultiFrameWrapper(TestCase):
         # data hash depends on the endianness
         if endian_codes[data.dtype.byteorder] == '>':
             data = data.byteswap()
-        dat_str = data.tostring()
+        dat_str = data.tobytes()
         assert_equal(sha1(dat_str).hexdigest(),
                      '149323269b0af92baa7508e19ca315240f77fa8c')
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -376,7 +376,7 @@ class Nifti1Extension(object):
         extinfo = np.array((rawsize, self._code), dtype=np.int32)
         if byteswap:
             extinfo = extinfo.byteswap()
-        fileobj.write(extinfo.tostring())
+        fileobj.write(extinfo.tobytes())
         # followed by the actual extension content
         # XXX if mangling upon load is implemented, it should be reverted here
         fileobj.write(self._mangle(self._content))

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -266,7 +266,7 @@ class SpatialHeader(FileBasedHeader):
         '''
         data = np.asarray(data)
         dtype = self.get_data_dtype()
-        fileobj.write(data.astype(dtype).tostring(order=self.data_layout))
+        fileobj.write(data.astype(dtype).tobytes(order=self.data_layout))
 
     def data_from_fileobj(self, fileobj):
         ''' Read binary image data from `fileobj` '''

--- a/nibabel/streamlines/tck.py
+++ b/nibabel/streamlines/tck.py
@@ -205,7 +205,7 @@ class TckFile(TractogramFile):
                 self._finalize_header(f, header, offset=beginning)
 
                 # Add the EOF_DELIMITER.
-                f.write(asbytes(self.EOF_DELIMITER.tostring()))
+                f.write(self.EOF_DELIMITER.tobytes())
                 return
 
             data_for_streamline = first_item.data_for_streamline
@@ -224,13 +224,13 @@ class TckFile(TractogramFile):
 
             for t in tractogram:
                 data = np.r_[t.streamline, self.FIBER_DELIMITER]
-                f.write(data.astype(dtype).tostring())
+                f.write(data.astype(dtype).tobytes())
                 nb_streamlines += 1
 
             header[Field.NB_STREAMLINES] = nb_streamlines
 
             # Add the EOF_DELIMITER.
-            f.write(asbytes(self.EOF_DELIMITER.tostring()))
+            f.write(asbytes(self.EOF_DELIMITER.tobytes()))
             self._finalize_header(f, header, offset=beginning)
 
     @staticmethod

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -129,8 +129,8 @@ class TestTCK(unittest.TestCase):
         assert_raises(HeaderError, TckFile.load, BytesIO(new_tck_file))
 
         # Simulate a TCK file which is missing a streamline delimiter.
-        eos = TckFile.FIBER_DELIMITER.tostring()
-        eof = TckFile.EOF_DELIMITER.tostring()
+        eos = TckFile.FIBER_DELIMITER.tobytes()
+        eof = TckFile.EOF_DELIMITER.tobytes()
         new_tck_file = tck_file[:-(len(eos) + len(eof))] + tck_file[-len(eof):]
 
         # Force TCK loading to use buffering.

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -438,7 +438,7 @@ class TrkFile(TractogramFile):
             beginning = f.tell()
 
             # Write temporary header that we will update at the end
-            f.write(header.tostring())
+            f.write(header.tobytes())
 
             i4_dtype = np.dtype("<i4")  # Always save in little-endian.
             f4_dtype = np.dtype("<f4")  # Always save in little-endian.
@@ -467,7 +467,7 @@ class TrkFile(TractogramFile):
                 header[Field.NB_PROPERTIES_PER_STREAMLINE] = 0
                 # Overwrite header with updated one.
                 f.seek(beginning, os.SEEK_SET)
-                f.write(header.tostring())
+                f.write(header.tobytes())
                 return
 
             # Update field 'property_name' using 'data_per_streamline'.
@@ -523,8 +523,8 @@ class TrkFile(TractogramFile):
                 data = struct.pack(i4_dtype.str[:-1], len(points))
                 pts_scalars = np.concatenate(
                     [points, scalars], axis=1).astype(f4_dtype)
-                data += pts_scalars.tostring()
-                data += properties.tostring()
+                data += pts_scalars.tobytes()
+                data += properties.tobytes()
                 f.write(data)
 
                 nb_streamlines += 1
@@ -552,7 +552,7 @@ class TrkFile(TractogramFile):
 
             # Overwrite header with updated one.
             f.seek(beginning, os.SEEK_SET)
-            f.write(header.tostring())
+            f.write(header.tobytes())
 
     @staticmethod
     def _read_header(fileobj):

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -67,7 +67,7 @@ def test_init():
     dtype = np.int32
     arr = np.arange(24, dtype=dtype).reshape(shape)
     bio.seek(16)
-    bio.write(arr.tostring(order='F'))
+    bio.write(arr.tobytes(order='F'))
     hdr = FunkyHeader(shape)
     ap = ArrayProxy(bio, hdr)
     assert_true(ap.file_like is bio)
@@ -84,7 +84,7 @@ def test_init():
     # C order also possible
     bio = BytesIO()
     bio.seek(16)
-    bio.write(arr.tostring(order='C'))
+    bio.write(arr.tobytes(order='C'))
     ap = CArrayProxy(bio, FunkyHeader((2, 3, 4)))
     assert_array_equal(np.asarray(ap), arr)
     # Illegal init
@@ -97,7 +97,7 @@ def test_tuplespec():
     dtype = np.int32
     arr = np.arange(24, dtype=dtype).reshape(shape)
     bio.seek(16)
-    bio.write(arr.tostring(order='F'))
+    bio.write(arr.tobytes(order='F'))
     # Create equivalent header and tuple specs
     hdr = FunkyHeader(shape)
     tuple_spec = (hdr.get_data_shape(), hdr.get_data_dtype(),
@@ -125,7 +125,7 @@ def write_raw_data(arr, hdr, fileobj):
     hdr.set_data_shape(arr.shape)
     hdr.set_data_dtype(arr.dtype)
     fileobj.write(b'\x00' * hdr.get_data_offset())
-    fileobj.write(arr.tostring(order='F'))
+    fileobj.write(arr.tobytes(order='F'))
 
 
 def test_nifti1_init():
@@ -163,7 +163,7 @@ def test_proxy_slicing():
             for order, klass in ('F', ArrayProxy), ('C', CArrayProxy):
                 fobj = BytesIO()
                 fobj.write(b'\0' * offset)
-                fobj.write(arr.tostring(order=order))
+                fobj.write(arr.tobytes(order=order))
                 prox = klass(fobj, hdr)
                 for sliceobj in slicer_samples(shape):
                     assert_array_equal(arr[sliceobj], prox[sliceobj])
@@ -171,7 +171,7 @@ def test_proxy_slicing():
     hdr.set_slope_inter(2.0, 1.0)
     fobj = BytesIO()
     fobj.write(b'\0' * offset)
-    fobj.write(arr.tostring(order='F'))
+    fobj.write(arr.tobytes(order='F'))
     prox = ArrayProxy(fobj, hdr)
     sliceobj = (None, slice(None), 1, -1)
     assert_array_equal(arr[sliceobj] * 2.0 + 1.0, prox[sliceobj])
@@ -199,7 +199,7 @@ def test_reshape_dataobj():
     bio = BytesIO()
     prox = ArrayProxy(bio, hdr)
     arr = np.arange(np.prod(shape), dtype=prox.dtype).reshape(shape)
-    bio.write(b'\x00' * prox.offset + arr.tostring(order='F'))
+    bio.write(b'\x00' * prox.offset + arr.tobytes(order='F'))
     assert_array_equal(prox, arr)
     assert_array_equal(reshape_dataobj(prox, (2, 3, 4)),
                        np.reshape(arr, (2, 3, 4)))
@@ -245,7 +245,7 @@ def test_get_unscaled():
     # Check standard read works
     arr = np.arange(24, dtype=np.int32).reshape(shape, order='F')
     bio.write(b'\x00' * hdr.get_data_offset())
-    bio.write(arr.tostring(order='F'))
+    bio.write(arr.tobytes(order='F'))
     prox = ArrayProxy(bio, hdr)
     assert_array_almost_equal(np.array(prox), arr * 2.1 + 3.14)
     # Check unscaled read works
@@ -294,7 +294,7 @@ def check_mmap(hdr, offset, proxy_class,
     with InTemporaryDirectory():
         with open(fname, 'wb') as fobj:
             fobj.write(b' ' * offset)
-            fobj.write(arr.tostring(order='F'))
+            fobj.write(arr.tobytes(order='F'))
         for mmap, expected_mode in (
                 # mmap value, expected memmap mode
                 # mmap=None -> no mmap value
@@ -405,10 +405,10 @@ def test_keep_file_open_true_false_invalid():
             # create the test data file
             if filetype == 'gz':
                 with gzip.open(fname, 'wb') as fobj:
-                    fobj.write(data.tostring(order='F'))
+                    fobj.write(data.tobytes(order='F'))
             else:
                 with open(fname, 'wb') as fobj:
-                    fobj.write(data.tostring(order='F'))
+                    fobj.write(data.tobytes(order='F'))
             # pass in a file name or open file handle. If the latter, we open
             # two file handles, because we're going to create two proxies
             # below.
@@ -459,7 +459,7 @@ def test_keep_file_open_true_false_invalid():
     with InTemporaryDirectory():
         fname = 'testdata'
         with open(fname, 'wb') as fobj:
-            fobj.write(data.tostring(order='F'))
+            fobj.write(data.tobytes(order='F'))
 
         for invalid_kfo in (55, 'auto', 'cauto'):
             with assert_raises(ValueError):

--- a/nibabel/tests/test_fileslice.py
+++ b/nibabel/tests/test_fileslice.py
@@ -661,7 +661,7 @@ def test_read_segments():
     # Test segment reading
     fobj = BytesIO()
     arr = np.arange(100, dtype=np.int16)
-    fobj.write(arr.tostring())
+    fobj.write(arr.tobytes())
     _check_bytes(read_segments(fobj, [(0, 200)], 200), arr)
     _check_bytes(read_segments(fobj, [(0, 100), (100, 100)], 200), arr)
     _check_bytes(read_segments(fobj, [(0, 50), (100, 50)], 100),
@@ -679,7 +679,7 @@ def test_read_segments_lock():
     # Test read_segment locking with multiple threads
     fobj = BytesIO()
     arr = np.array(np.random.randint(0, 256, 1000), dtype=np.uint8)
-    fobj.write(arr.tostring())
+    fobj.write(arr.tobytes())
 
     # Encourage the interpreter to switch threads between a seek/read pair
     def yielding_read(*args, **kwargs):
@@ -777,7 +777,7 @@ def test_fileslice():
             for offset in (0, 20):
                 fobj = BytesIO()
                 fobj.write(b'\0' * offset)
-                fobj.write(arr.tostring(order=order))
+                fobj.write(arr.tobytes(order=order))
                 for sliceobj in slicer_samples(shape):
                     _check_slicer(sliceobj, arr, fobj, offset, order)
 
@@ -787,7 +787,7 @@ def test_fileslice_dtype():
     sliceobj = (slice(None), slice(2))
     for dt in (np.dtype('int32'), np.int32, 'i4', 'int32', '>i4', '<i4'):
         arr = np.arange(24, dtype=dt).reshape((2, 3, 4))
-        fobj = BytesIO(arr.tostring())
+        fobj = BytesIO(arr.tobytes())
         new_slice = fileslice(fobj, sliceobj, arr.shape, dt)
         assert_array_equal(arr[sliceobj], new_slice)
 
@@ -795,7 +795,7 @@ def test_fileslice_dtype():
 def test_fileslice_errors():
     # Test fileslice causes error on fancy indexing
     arr = np.arange(24).reshape((2, 3, 4))
-    fobj = BytesIO(arr.tostring())
+    fobj = BytesIO(arr.tobytes())
     _check_slicer((1,), arr, fobj, 0, 'C')
     # Fancy indexing raises error
     assert_raises(ValueError,
@@ -809,7 +809,7 @@ def test_fileslice_heuristic():
     for heuristic in (_always, _never, _partial, threshold_heuristic):
         for order in 'FC':
             fobj = BytesIO()
-            fobj.write(arr.tostring(order=order))
+            fobj.write(arr.tobytes(order=order))
             sliceobj = (1, slice(0, 15, 2), slice(None))
             _check_slicer(sliceobj, arr, fobj, 0, order, heuristic)
             # Check _simple_fileslice while we're at it - si como no?

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -153,7 +153,9 @@ class GenericImageAPI(ValidateAPI):
           with InTemporaryDirectory():
               # Validate that saving or loading a file doesn't use deprecated methods internally
               with clear_and_catch_warnings() as w:
-                  warnings.simplefilter('error', DeprecationWarning)
+                  warnings.filterwarnings('error',
+                                          category=DeprecationWarning,
+                                          module=r"nibabel.*")
                   img.to_filename(path)
                   rt_img = img.__class__.from_filename(path)
               assert_array_equal(img.shape, rt_img.shape)

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1171,7 +1171,7 @@ def test_extension_io():
     start = np.zeros((1,), dtype=exp_dtype)
     start['esize'] = 24
     start['ecode'] = 6
-    bio.write(start.tostring())
+    bio.write(start.tobytes())
     bio.seek(24)
     ext2.write_to(bio, False)
     # Result should still be OK, but with a warning

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -248,7 +248,7 @@ class TestAnalyzeProxyAPI(_TestProxyAPI):
             n_els = np.prod(shape)
             dtype = np.dtype(dtype).newbyteorder(self.data_endian)
             arr = np.arange(n_els, dtype=dtype).reshape(shape)
-            data = arr.tostring(order=self.array_order)
+            data = arr.tobytes(order=self.array_order)
             hdr = self.header_class()
             hdr.set_data_dtype(dtype)
             hdr.set_data_shape(shape)

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -175,17 +175,17 @@ def test_read_data():
         data = np.arange(6).reshape((1, 2, 3))
         hdr.data_to_fileobj(data, fobj)
         assert_equal(fobj.getvalue(),
-                     data.astype(np.int32).tostring(order=order))
+                     data.astype(np.int32).tobytes(order=order))
         # data_to_fileobj accepts kwarg 'rescale', but no effect in this case
         fobj.seek(0)
         hdr.data_to_fileobj(data, fobj, rescale=True)
         assert_equal(fobj.getvalue(),
-                     data.astype(np.int32).tostring(order=order))
+                     data.astype(np.int32).tobytes(order=order))
         # data_to_fileobj can be a list
         fobj.seek(0)
         hdr.data_to_fileobj(data.tolist(), fobj, rescale=True)
         assert_equal(fobj.getvalue(),
-                     data.astype(np.int32).tostring(order=order))
+                     data.astype(np.int32).tobytes(order=order))
         # Read data back again
         fobj.seek(0)
         data2 = hdr.data_from_fileobj(fobj)

--- a/nibabel/tests/test_trackvis.py
+++ b/nibabel/tests/test_trackvis.py
@@ -18,7 +18,7 @@ def test_write():
     streams = []
     out_f = BytesIO()
     tv.write(out_f, [], {})
-    assert_equal(out_f.getvalue(), tv.empty_header().tostring())
+    assert_equal(out_f.getvalue(), tv.empty_header().tobytes())
     out_f.truncate(0)
     out_f.seek(0)
     # Write something not-default
@@ -474,7 +474,7 @@ def test_tv_class():
     assert_equal(tvf.filename, None)
     out_f = BytesIO()
     tvf.to_file(out_f)
-    assert_equal(out_f.getvalue(), tv.empty_header().tostring())
+    assert_equal(out_f.getvalue(), tv.empty_header().tobytes())
     out_f.truncate(0)
     out_f.seek(0)
     # Write something not-default
@@ -604,12 +604,12 @@ def test_read_truncated():
     again_hdr = hdr.copy()
     assert_equal(again_hdr['n_count'], 2)
     again_hdr['n_count'] = 0
-    again_bytes = again_hdr.tostring() + value[again_hdr.itemsize:]
+    again_bytes = again_hdr.tobytes() + value[again_hdr.itemsize:]
     again_f = BytesIO(again_bytes)
     streams2, _ = tv.read(again_f, strict=False)
     assert_true(streamlist_equal(streams2, short_streams))
     # Set count to one above actual number of tracks, always raise error
     again_hdr['n_count'] = 3
-    again_bytes = again_hdr.tostring() + value[again_hdr.itemsize:]
+    again_bytes = again_hdr.tobytes() + value[again_hdr.itemsize:]
     again_f = BytesIO(again_bytes)
     assert_raises(tv.DataError, tv.read, again_f, strict=False)

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -112,7 +112,7 @@ def test_fobj_string_assumptions():
             in_arr = np.arange(n, dtype=dtype)
             # Write array to file
             fobj_w = opener(fname, 'wb')
-            fobj_w.write(in_arr.tostring())
+            fobj_w.write(in_arr.tobytes())
             fobj_w.close()
             # Read back from file
             fobj_r = opener(fname, 'rb')
@@ -188,7 +188,7 @@ def test_array_from_file_mmap():
         for dt in (np.int16, np.float):
             arr = np.arange(np.prod(shape), dtype=dt).reshape(shape)
             with open('test.bin', 'wb') as fobj:
-                fobj.write(arr.tostring(order='F'))
+                fobj.write(arr.tobytes(order='F'))
             with open('test.bin', 'rb') as fobj:
                 res = array_from_file(shape, dt, fobj)
                 assert_array_equal(res, arr)
@@ -225,7 +225,7 @@ def test_array_from_file_mmap():
 
 def buf_chk(in_arr, out_buf, in_buf, offset):
     ''' Write contents of in_arr into fileobj, read back, check same '''
-    instr = b' ' * offset + in_arr.tostring(order='F')
+    instr = b' ' * offset + in_arr.tobytes(order='F')
     out_buf.write(instr)
     out_buf.flush()
     if in_buf is None:  # we're using in_buf from out_buf
@@ -251,7 +251,7 @@ def test_array_from_file_openers():
             with Opener(fname, 'wb') as out_buf:
                 if offset != 0:  # avoid https://bugs.python.org/issue16828
                     out_buf.write(b' ' * offset)
-                out_buf.write(in_arr.tostring(order='F'))
+                out_buf.write(in_arr.tobytes(order='F'))
             with Opener(fname, 'rb') as in_buf:
                 out_arr = array_from_file(shape, dtype, in_buf, offset)
                 assert_array_almost_equal(in_arr, out_arr)
@@ -277,7 +277,7 @@ def test_array_from_file_reread():
             # Write array to file
             fobj_w = opener() if is_bio else opener(fname, 'wb')
             fobj_w.write(b' ' * offset)
-            fobj_w.write(in_arr.tostring(order=order))
+            fobj_w.write(in_arr.tobytes(order=order))
             if is_bio:
                 fobj_r = fobj_w
             else:

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -211,7 +211,7 @@ class _TestWrapStructBase(TestCase):
         assert_equal(eh.endianness, native_code)
         hdr_data = eh.structarr.copy()
         hdr_data = hdr_data.byteswap(swapped_code)
-        eh_swapped = self.header_class(hdr_data.tostring())
+        eh_swapped = self.header_class(hdr_data.tobytes())
         assert_equal(eh_swapped.endianness, swapped_code)
 
     def test_binblock_is_file(self):

--- a/nibabel/trackvis.py
+++ b/nibabel/trackvis.py
@@ -364,7 +364,7 @@ def write(fileobj, streamlines, hdr_mapping=None, endianness=None,
         # write header without streams
         hdr = _hdr_from_mapping(None, hdr_mapping, endianness)
         with ImageOpener(fileobj, 'wb') as fileobj:
-            fileobj.write(hdr.tostring())
+            fileobj.write(hdr.tobytes())
         return
     if endianness is None:
         endianness = endian_codes[streams0[0].dtype.byteorder]
@@ -405,7 +405,7 @@ def write(fileobj, streamlines, hdr_mapping=None, endianness=None,
         mm2tv = np.dot(vx2tv, mm2vx).astype('f4')
     # write header
     fileobj = ImageOpener(fileobj, mode='wb')
-    fileobj.write(hdr.tostring())
+    fileobj.write(hdr.tobytes())
     # track preliminaries
     f4dt = np.dtype(endianness + 'f4')
     i_fmt = endianness + 'i'
@@ -433,7 +433,7 @@ def write(fileobj, streamlines, hdr_mapping=None, endianness=None,
             if scalars.dtype != f4dt:
                 scalars = scalars.astype(f4dt)
             pts = np.c_[pts, scalars]
-        fileobj.write(pts.tostring())
+        fileobj.write(pts.tobytes())
         if n_p == 0:
             if not (props is None or len(props) == 0):
                 raise DataError('Expecting 0 properties per point')
@@ -442,7 +442,7 @@ def write(fileobj, streamlines, hdr_mapping=None, endianness=None,
                 raise DataError('Properties should be size %s' % n_p)
             if props.dtype != f4dt:
                 props = props.astype(f4dt)
-            fileobj.write(props.tostring())
+            fileobj.write(props.tobytes())
     fileobj.close_if_mine()
 
 

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -479,13 +479,13 @@ def array_from_file(shape, in_dtype, infile, offset=0, order='F', mmap=True):
     >>> from io import BytesIO
     >>> bio = BytesIO()
     >>> arr = np.arange(6).reshape(1,2,3)
-    >>> _ = bio.write(arr.tostring('F'))  # outputs int
+    >>> _ = bio.write(arr.tobytes('F'))  # outputs int
     >>> arr2 = array_from_file((1,2,3), arr.dtype, bio)
     >>> np.all(arr == arr2)
     True
     >>> bio = BytesIO()
     >>> _ = bio.write(b' ' * 10)
-    >>> _ = bio.write(arr.tostring('F'))
+    >>> _ = bio.write(arr.tobytes('F'))
     >>> arr2 = array_from_file((1,2,3), arr.dtype, bio, 10)
     >>> np.all(arr == arr2)
     True
@@ -607,19 +607,19 @@ def array_to_file(data, fileobj, out_dtype=None, offset=0,
     >>> sio = BytesIO()
     >>> data = np.arange(10, dtype=np.float)
     >>> array_to_file(data, sio, np.float)
-    >>> sio.getvalue() == data.tostring('F')
+    >>> sio.getvalue() == data.tobytes('F')
     True
     >>> _ = sio.truncate(0); _ = sio.seek(0)  # outputs 0
     >>> array_to_file(data, sio, np.int16)
-    >>> sio.getvalue() == data.astype(np.int16).tostring()
+    >>> sio.getvalue() == data.astype(np.int16).tobytes()
     True
     >>> _ = sio.truncate(0); _ = sio.seek(0)
     >>> array_to_file(data.byteswap(), sio, np.float)
-    >>> sio.getvalue() == data.byteswap().tostring('F')
+    >>> sio.getvalue() == data.byteswap().tobytes('F')
     True
     >>> _ = sio.truncate(0); _ = sio.seek(0)
     >>> array_to_file(data, sio, np.float, order='C')
-    >>> sio.getvalue() == data.tostring('C')
+    >>> sio.getvalue() == data.tobytes('C')
     True
     '''
     # Shield special case
@@ -829,7 +829,7 @@ def _write_data(data,
                 dslice[nans] = nan_fill
         if dslice.dtype != out_dtype:
             dslice = dslice.astype(out_dtype)
-        fileobj.write(dslice.tostring())
+        fileobj.write(dslice.tobytes())
 
 
 def _dt_min_max(dtype_like, mn=None, mx=None):

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -209,7 +209,7 @@ class WrapStruct(object):
         >>> len(wstr.binaryblock)
         2
         '''
-        return self._structarr.tostring()
+        return self._structarr.tobytes()
 
     def write_to(self, fileobj):
         ''' Write structure to fileobj
@@ -296,7 +296,7 @@ class WrapStruct(object):
             return False
         if this_end == other_end:
             return this_bb == other_bb
-        other_bb = other._structarr.byteswap().tostring()
+        other_bb = other._structarr.byteswap().tobytes()
         return this_bb == other_bb
 
     def __ne__(self, other):
@@ -480,9 +480,7 @@ class WrapStruct(object):
         if endianness == current:
             return self.copy()
         wstr_data = self._structarr.byteswap()
-        return self.__class__(wstr_data.tostring(),
-                              endianness,
-                              check=False)
+        return self.__class__(wstr_data.tobytes(), endianness, check=False)
 
     @classmethod
     def _get_checks(klass):

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ dev =
 doc =
     matplotlib >= 1.5.3
     numpydoc
-    sphinx >=0.3
+    sphinx >=0.3,<3
     texext
 minc2 =
     h5py


### PR DESCRIPTION
`tobytes` was added in numpy 1.9 and `tostring` is being deprecated in 1.19.