### PR TITLE
[2.5.x] MNT: Set maximum numpy to 1.16.x, update requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: python
 cache: pip
 env:
     global:
-        - DEPENDS="six numpy scipy matplotlib h5py pillow pydicom"
+        - DEPENDS="six numpy<1.17dev scipy<1.3dev matplotlib h5py pillow pydicom"
         - OPTIONAL_DEPENDS=""
         - INSTALL_TYPE="setup"
         - CHECK_TYPE="test"
@@ -52,7 +52,7 @@ matrix:
     # pydicom master branch
     - python: 3.5
       env:
-        - DEPENDS="numpy git+https://github.com/pydicom/pydicom.git@master"
+        - DEPENDS="numpy<1.17dev git+https://github.com/pydicom/pydicom.git@master"
     # test 2.7 against pre-release builds of everything
     - python: 2.7
       env:

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building docs
 -r requirements.txt
-sphinx
+sphinx<3
 numpydoc
 texext
 matplotlib>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@
 #   doc/source/installation.rst
 
 six>=1.3
-numpy>=1.8
+numpy>=1.8,<1.17dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ provides =
 [options]
 python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9dev
 install_requires =
-    numpy >=1.8,<1.19dev
+    numpy >=1.8,<1.17dev
     six >=1.3
     bz2file ; python_version < "3.0"
 tests_require =


### PR DESCRIPTION
d2cb9430f218e63aa41e75b12a3a681ecfb2560e wasn't enough to fix Travis builds for `maint/2.5.x`, so I'll do this via PR.