### PR TITLE
ENH: allow numpy integer scalars to index fileslice

### DIFF
--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -48,7 +48,7 @@ def is_fancy(sliceobj):
     if not isinstance(sliceobj, tuple):
         sliceobj = (sliceobj,)
     for slicer in sliceobj:
-        if hasattr(slicer, 'dtype') and slicer.ndim > 0:  # ndarray always fancy
+        if getattr(slicer, 'ndim', 0) > 0:  # ndarray always fancy, but scalars are safe
             return True
         # slice or Ellipsis or None OK for  basic
         if isinstance(slicer, slice) or slicer in (None, Ellipsis):

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -48,7 +48,7 @@ def is_fancy(sliceobj):
     if not isinstance(sliceobj, tuple):
         sliceobj = (sliceobj,)
     for slicer in sliceobj:
-        if hasattr(slicer, 'dtype'):  # ndarray always fancy
+        if hasattr(slicer, 'dtype') and slicer.ndim > 0:  # ndarray always fancy
             return True
         # slice or Ellipsis or None OK for  basic
         if isinstance(slicer, slice) or slicer in (None, Ellipsis):


### PR DESCRIPTION
This is done by allowing 0-dimensional numpy integer arrays to return true in the `is_fancy` function.

Tests are added to show identical behaviour as normal integers for canonical_slicers and fileslice (the two places where `is_fancy` is used).

The reason for this is that I often find myself trying to index like `dataobj[..., idx]`, where `idx` is an numpy integer scalar, and getting a `fancy indexing is not allowed` error. This can be easily fixed by casting the numpy integer to a python one like `dataobj[..., int(idx)]`. However, as the indexing rules are identical for scalar numpy integers and python built-in integers (except that the former returns a copy, while the latter returns a view), I feel this casting should not be necessary.

This is distinct from #531 as this focusses just on 0-dimensional scalars and still disallows indexing with 1- or higher dimensional arrays.