### PR TITLE
RF: Use np.flip instead of flip_axis

### DIFF
--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -165,7 +165,7 @@ def apply_orientation(arr, ornt):
     # apply ornt transformations
     for ax, flip in enumerate(ornt[:, 1]):
         if flip == -1:
-            t_arr = flip_axis(t_arr, axis=ax)
+            t_arr = np.flip(t_arr, axis=ax)
     full_transpose = np.arange(t_arr.ndim)
     # ornt indicates the transpose that has occurred - we reverse it
     full_transpose[:n] = np.argsort(ornt[:, 0])
@@ -230,20 +230,21 @@ def inv_ornt_aff(ornt, shape):
 
 
 @deprecate_with_version('orientation_affine deprecated. '
-                        'Please use inv_ornt_aff instead'
+                        'Please use inv_ornt_aff instead.',
                         '1.3',
                         '3.0')
 def orientation_affine(ornt, shape):
     return inv_ornt_aff(ornt, shape)
 
 
+@deprecate_with_version('flip_axis is deprecated. '
+                        'Please use numpy.flip instead.',
+                        '3.2',
+                        '5.0')
 def flip_axis(arr, axis=0):
-    ''' Flip contents of `axis` in array `arr`
+    """ Flip contents of `axis` in array `arr`
 
-    ``flip_axis`` is the same transform as ``np.flipud``, but for any
-    axis.  For example ``flip_axis(arr, axis=0)`` is the same transform
-    as ``np.flipud(arr)``, and ``flip_axis(arr, axis=1)`` is the same
-    transform as ``np.fliplr(arr)``
+    Equivalent to ``np.flip(arr, axis=0)``.
 
     Parameters
     ----------
@@ -255,24 +256,8 @@ def flip_axis(arr, axis=0):
     -------
     farr : array
        Array with axis `axis` flipped
-
-    Examples
-    --------
-    >>> a = np.arange(6).reshape((2,3))
-    >>> a
-    array([[0, 1, 2],
-           [3, 4, 5]])
-    >>> flip_axis(a, axis=0)
-    array([[3, 4, 5],
-           [0, 1, 2]])
-    >>> flip_axis(a, axis=1)
-    array([[2, 1, 0],
-           [5, 4, 3]])
-    '''
-    arr = np.asanyarray(arr)
-    arr = arr.swapaxes(0, axis)
-    arr = np.flipud(arr)
-    return arr.swapaxes(axis, 0)
+    """
+    return np.flip(arr, axis)
 
 
 def ornt2axcodes(ornt, labels=None):

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -244,7 +244,7 @@ def orientation_affine(ornt, shape):
 def flip_axis(arr, axis=0):
     """ Flip contents of `axis` in array `arr`
 
-    Equivalent to ``np.flip(arr, axis=0)``.
+    Equivalent to ``np.flip(arr, axis)``.
 
     Parameters
     ----------

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -232,7 +232,7 @@ def inv_ornt_aff(ornt, shape):
 @deprecate_with_version('orientation_affine deprecated. '
                         'Please use inv_ornt_aff instead.',
                         '1.3',
-                        '3.0')
+                        '4.0')
 def orientation_affine(ornt, shape):
     return inv_ornt_aff(ornt, shape)
 

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -231,7 +231,7 @@ def inv_ornt_aff(ornt, shape):
 
 @deprecate_with_version('orientation_affine deprecated. '
                         'Please use inv_ornt_aff instead.',
-                        '1.3',
+                        '3.0',
                         '4.0')
 def orientation_affine(ornt, shape):
     return inv_ornt_aff(ornt, shape)

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -140,28 +140,6 @@ def test_apply():
         assert_array_equal(a.shape, np.array(t_arr.shape)[np.array(ornt)[:, 0]])
 
 
-def test_flip_axis():
-    a = np.arange(24).reshape((2, 3, 4))
-    assert_array_equal(
-        flip_axis(a),
-        np.flipud(a))
-    assert_array_equal(
-        flip_axis(a, axis=0),
-        np.flipud(a))
-    assert_array_equal(
-        flip_axis(a, axis=1),
-        np.fliplr(a))
-    # check accepts array-like
-    assert_array_equal(
-        flip_axis(a.tolist(), axis=0),
-        np.flipud(a))
-    # third dimension
-    b = a.transpose()
-    b = np.flipud(b)
-    b = b.transpose()
-    assert_array_equal(flip_axis(a, axis=2), b)
-
-
 def test_io_orientation():
     for shape in ((2, 3, 4), (20, 15, 7)):
         for in_arr, out_ornt in zip(IN_ARRS, OUT_ORNTS):
@@ -381,3 +359,11 @@ def test_orientation_affine_deprecation():
     with pytest.deprecated_call():
         aff2 = orientation_affine([[0, 1], [1, -1], [2, 1]], (3, 4, 5))
     assert_array_equal(aff1, aff2)
+
+
+def test_flip_axis_deprecation():
+    a = np.arange(24).reshape((2, 3, 4))
+    axis = 1
+    with pytest.deprecated_call():
+        a_flipped = flip_axis(a, axis)
+    assert_array_equal(a_flipped, np.flip(a, axis))

--- a/nibabel/tests/test_processing.py
+++ b/nibabel/tests/test_processing.py
@@ -23,7 +23,7 @@ from nibabel.processing import (sigma2fwhm, fwhm2sigma, adapt_affine,
                                 conform)
 from nibabel.nifti1 import Nifti1Image
 from nibabel.nifti2 import Nifti2Image
-from nibabel.orientations import aff2axcodes, flip_axis, inv_ornt_aff
+from nibabel.orientations import aff2axcodes, inv_ornt_aff
 from nibabel.affines import (AffineError, from_matvec, to_matvec, apply_affine,
                              voxel_sizes)
 from nibabel.eulerangles import euler2mat
@@ -110,7 +110,7 @@ def test_resample_from_to():
         ax_flip_ornt = flip_ornt.copy()
         ax_flip_ornt[axis, 1] = -1
         aff_flip_i = inv_ornt_aff(ax_flip_ornt, (2, 3, 4))
-        flipped_img = Nifti1Image(flip_axis(data, axis),
+        flipped_img = Nifti1Image(np.flip(data, axis),
                                   np.dot(affine, aff_flip_i))
         out = resample_from_to(flipped_img, ((2, 3, 4), affine))
         assert_almost_equal(img.dataobj, out.dataobj)

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -18,7 +18,7 @@ import numpy as np
 import nibabel as nib
 from ..tmpdirs import InTemporaryDirectory
 from ..loadsave import load
-from ..orientations import flip_axis, aff2axcodes, inv_ornt_aff
+from ..orientations import aff2axcodes, inv_ornt_aff
 
 import unittest
 import pytest
@@ -273,7 +273,7 @@ def test_parrec2nii():
             assert code == 1
             # Default scaling is dv
             pr_img = load(fname)
-            flipped_data = flip_axis(pr_img.get_fdata(), 1)
+            flipped_data = np.flip(pr_img.get_fdata(), 1)
             base_cmd = ['parrec2nii', '--overwrite', fname]
             check_conversion(base_cmd, flipped_data, out_froot)
             check_conversion(base_cmd + ['--scaling=dv'],
@@ -281,12 +281,12 @@ def test_parrec2nii():
                              out_froot)
             # fp
             pr_img = load(fname, scaling='fp')
-            flipped_data = flip_axis(pr_img.get_fdata(), 1)
+            flipped_data = np.flip(pr_img.get_fdata(), 1)
             check_conversion(base_cmd + ['--scaling=fp'],
                              flipped_data,
                              out_froot)
             # no scaling
-            unscaled_flipped = flip_axis(pr_img.dataobj.get_unscaled(), 1)
+            unscaled_flipped = np.flip(pr_img.dataobj.get_unscaled(), 1)
             check_conversion(base_cmd + ['--scaling=off'],
                              unscaled_flipped,
                              out_froot)
@@ -335,7 +335,7 @@ def test_parrec2nii_with_data():
                 assert np.all(np.abs(aff_off / vox_sizes) <= 0.501)
                 # The data is very close, unless it's the fieldmap
                 if par_root != 'fieldmap':
-                    conved_data_lps = flip_axis(conved_img.dataobj, 1)
+                    conved_data_lps = np.flip(conved_img.dataobj, 1)
                     assert np.allclose(conved_data_lps, philips_img.dataobj)
     with InTemporaryDirectory():
         # Test some options


### PR DESCRIPTION
The package requires numpy >= 1.13, np.flip was added in 1.12
Add deprecation (from 3.2 until 5.0) + deprecation test
Remove flip_axis test