### PR TITLE
FIX: Detect IndexedGzipFile as compressed file type

### DIFF
--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -35,6 +35,9 @@ try:
     del igzip, version
 
 except ImportError:
+    # nibabel.openers.IndexedGzipFile is imported by nibabel.volumeutils
+    # to detect compressed file types, so we give a fallback value here.
+    IndexedGzipFile = gzip.GzipFile
     HAVE_INDEXED_GZIP = False
 
 

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -19,7 +19,7 @@ from functools import reduce
 import numpy as np
 
 from .casting import (shared_range, type_info, OK_FLOATS)
-from .openers import Opener, BZ2File
+from .openers import Opener, BZ2File, IndexedGzipFile
 from .deprecated import deprecate_with_version
 from .externals.oset import OrderedSet
 
@@ -38,7 +38,7 @@ endian_codes = (  # numpy code, aliases
 default_compresslevel = 1
 
 #: file-like classes known to hold compressed data
-COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File)
+COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File, IndexedGzipFile)
 
 
 class Recoder(object):


### PR DESCRIPTION
This PR updates `nibabel.volumeutils` so that it recognises `IndexedGzipFile` objects as compressed files, and does not attempt to memory-map them.

Background at pauldmccarthy/indexed_gzip#38.
