### PR TITLE
ENH: Update NIfTI header dimensions for CIFTI-2 compliance

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -19,6 +19,7 @@ Definition of the CIFTI-2 header format and file extensions can be found at:
 import re
 from collections.abc import MutableSequence, MutableMapping, Iterable
 from collections import OrderedDict
+import numpy as np
 from .. import xmlutils as xml
 from ..filebasedimages import FileBasedHeader
 from ..dataobj_images import DataobjImage
@@ -1484,8 +1485,14 @@ class Cifti2Image(DataobjImage):
         >>> img.update_headers()
         >>> img.nifti_header.get_data_shape() == (2, 3, 4)
         True
+        >>> np.array_equal(img.nifti_header['dim'], [7, 1, 1, 1, 1, 2, 3, 4])
+        True
         """
         self._nifti_header.set_data_shape(self._dataobj.shape)
+        _dims = np.ones((8), dtype=int)
+        _dims[0] = 7 if len(self._dataobj.shape) == 3 else 6
+        _dims[5:8] = (self._dataobj.shape + (1,))[:3]
+        self._nifti_header['dim'] = _dims
 
     def get_data_dtype(self):
         return self._nifti_header.get_data_dtype()


### PR DESCRIPTION
Updates the `CiftiImage.update_headers()` method to configure the NIfTI header's `dim` to CIFTI-2 standards brought up in https://github.com/poldracklab/fmriprep/issues/2205