### PR TITLE
FIX: Use seconds as time units when converting PARRECHeader to Nifti1Header

### DIFF
--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -775,7 +775,8 @@ class PARRECHeader(SpatialHeader):
                     self.general_info['exam_date'].replace(' ', ''),
                     self.general_info['protocol_name']))[:80]  # max len
         is_fmri = (self.general_info['max_dynamics'] > 1)
-        t = 'msec' if is_fmri else 'unknown'
+        # PAR/REC uses msec, but in _calc_zooms we convert to sec
+        t = 'sec' if is_fmri else 'unknown'
         xyzt_units = unit_codes['mm'] + unit_codes[t]
         return dict(descr=descr, xyzt_units=xyzt_units)  # , pixdim=pixdim)
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import array as npa
 
 from .. import load as top_load
-from ..nifti1 import Nifti1Image, Nifti1Extension
+from ..nifti1 import Nifti1Image, Nifti1Extension, Nifti1Header
 from .. import parrec
 from ..parrec import (parse_PAR_header, PARRECHeader, PARRECError, vol_numbers,
                       vol_is_full, PARRECImage, PARRECArrayProxy, exts2pars)
@@ -547,6 +547,18 @@ def test_epi_params():
             epi_hdr = PARRECHeader.from_fileobj(fobj)
         assert len(epi_hdr.get_data_shape()) == 4
         assert_almost_equal(epi_hdr.get_zooms()[-1], 2.0)
+
+
+def test_xyzt_unit_conversion():
+    # Check conversion to NIfTI-like has sensible units
+    for par_root in ('T2_-interleaved', 'T2_', 'phantom_EPI_asc_CLEAR_2_1'):
+        epi_par = pjoin(DATA_PATH, par_root + '.PAR')
+        with open(epi_par, 'rt') as fobj:
+            epi_hdr = PARRECHeader.from_fileobj(fobj)
+        nifti_hdr = Nifti1Header.from_header(epi_hdr)
+        assert len(nifti_hdr.get_data_shape()) == 4
+        assert_almost_equal(nifti_hdr.get_zooms()[-1], 2.0)
+        assert nifti_hdr.get_xyzt_units() == ('mm', 'sec')
 
 
 def test_truncations():


### PR DESCRIPTION
parrec2nii produces NIfTI files with TRs in seconds but records the units as msec

#692 proposed retaining the PAR/REC msec units by removing a division by `1000.`. This PR instead proposes keeping things in seconds.

cc @Roosted7 @epongpipat

Replaces #692. 