### PR TITLE
ENH: Add option to infer CIFTI-2 intent codes

### DIFF
--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -427,3 +427,18 @@ class TestCifti2ImageAPI(_TDA, SerializeMixin):
             )
             header.matrix.append(mim)
         return lambda: self.image_maker(arr.copy(), header, ni_header)
+
+    def validate_filenames(self, imaker, params, validate=False):
+        super().validate_filenames(imaker, params, validate=validate)
+
+    def validate_mmap_parameter(self, imaker, params, validate=False):
+        super().validate_mmap_parameter(imaker, params, validate=validate)
+
+    def validate_to_bytes(self, imaker, params, validate=False):
+        super().validate_to_bytes(imaker, params, validate=validate)
+
+    def validate_from_bytes(self, imaker, params, validate=False):
+        super().validate_from_bytes(imaker, params, validate=validate)
+
+    def validate_to_from_bytes(self, imaker, params, validate=False):
+        super().validate_to_from_bytes(imaker, params, validate=validate)

--- a/nibabel/cifti2/tests/test_cifti2io_axes.py
+++ b/nibabel/cifti2/tests/test_cifti2io_axes.py
@@ -91,7 +91,7 @@ def check_rewrite(arr, axes, extension='.nii'):
         custom extension to use
     """
     (fd, name) = tempfile.mkstemp(extension)
-    cifti2.Cifti2Image(arr, header=axes).to_filename(name)
+    cifti2.Cifti2Image(arr, header=axes).to_filename(name, validate=False)
     img = nib.load(name)
     arr2 = img.get_fdata()
     assert np.allclose(arr, arr2)

--- a/nibabel/cifti2/tests/test_cifti2io_header.py
+++ b/nibabel/cifti2/tests/test_cifti2io_header.py
@@ -83,7 +83,7 @@ def test_readwritedata():
     with InTemporaryDirectory():
         for name in datafiles:
             img = ci.load(name)
-            ci.save(img, 'test.nii')
+            ci.save(img, 'test.nii', validate=False)
             img2 = ci.load('test.nii')
             assert len(img.header.matrix) == len(img2.header.matrix)
             # Order should be preserved in load/save
@@ -109,7 +109,7 @@ def test_nibabel_readwritedata():
     with InTemporaryDirectory():
         for name in datafiles:
             img = nib.load(name)
-            nib.save(img, 'test.nii')
+            nib.save(img, 'test.nii', validate=False)
             img2 = nib.load('test.nii')
             assert len(img.header.matrix) == len(img2.header.matrix)
             # Order should be preserved in load/save

--- a/nibabel/cifti2/tests/test_new_cifti2.py
+++ b/nibabel/cifti2/tests/test_new_cifti2.py
@@ -406,7 +406,7 @@ def test_plabel():
     img = ci.Cifti2Image(data, hdr)
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.plabel.nii')
+        ci.save(img, 'test.plabel.nii', validate=False)
         img2 = ci.load('test.plabel.nii')
         assert img.nifti_header.get_intent()[0] == 'ConnUnknown'
         assert isinstance(img2, ci.Cifti2Image)

--- a/nibabel/cifti2/tests/test_new_cifti2.py
+++ b/nibabel/cifti2/tests/test_new_cifti2.py
@@ -237,10 +237,9 @@ def test_dtseries():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(13, 10)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_SERIES')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.dtseries.nii')
+        ci.save(img, 'test.dtseries.nii', infer_intent=True)
         img2 = nib.load('test.dtseries.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnDenseSeries'
         assert isinstance(img2, ci.Cifti2Image)
@@ -281,10 +280,9 @@ def test_dlabel():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(2, 10)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_LABELS')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.dlabel.nii')
+        ci.save(img, 'test.dlabel.nii', infer_intent=True)
         img2 = nib.load('test.dlabel.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnDenseLabel'
         assert isinstance(img2, ci.Cifti2Image)
@@ -301,10 +299,9 @@ def test_dconn():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(10, 10)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.dconn.nii')
+        ci.save(img, 'test.dconn.nii', infer_intent=True)
         img2 = nib.load('test.dconn.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnDense'
         assert isinstance(img2, ci.Cifti2Image)
@@ -323,10 +320,9 @@ def test_ptseries():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(13, 4)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED_SERIES')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.ptseries.nii')
+        ci.save(img, 'test.ptseries.nii', infer_intent=True)
         img2 = nib.load('test.ptseries.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnParcelSries'
         assert isinstance(img2, ci.Cifti2Image)
@@ -345,10 +341,9 @@ def test_pscalar():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(2, 4)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED_SCALAR')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.pscalar.nii')
+        ci.save(img, 'test.pscalar.nii', infer_intent=True)
         img2 = nib.load('test.pscalar.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnParcelScalr'
         assert isinstance(img2, ci.Cifti2Image)
@@ -367,10 +362,9 @@ def test_pdconn():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(10, 4)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED_DENSE')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.pdconn.nii')
+        ci.save(img, 'test.pdconn.nii', infer_intent=True)
         img2 = ci.load('test.pdconn.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnParcelDense'
         assert isinstance(img2, ci.Cifti2Image)
@@ -389,10 +383,9 @@ def test_dpconn():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(4, 10)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_PARCELLATED')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.dpconn.nii')
+        ci.save(img, 'test.dpconn.nii', infer_intent=True)
         img2 = ci.load('test.dpconn.nii')
         assert img2.nifti_header.get_intent()[0] == 'ConnDenseParcel'
         assert isinstance(img2, ci.Cifti2Image)
@@ -430,10 +423,9 @@ def test_pconn():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(4, 4)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.pconn.nii')
+        ci.save(img, 'test.pconn.nii', infer_intent=True)
         img2 = ci.load('test.pconn.nii')
         assert img.nifti_header.get_intent()[0] == 'ConnParcels'
         assert isinstance(img2, ci.Cifti2Image)
@@ -453,11 +445,9 @@ def test_pconnseries():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(4, 4, 13)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED_'
-                                'PARCELLATED_SERIES')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.pconnseries.nii')
+        ci.save(img, 'test.pconnseries.nii', infer_intent=True)
         img2 = ci.load('test.pconnseries.nii')
         assert img.nifti_header.get_intent()[0] == 'ConnPPSr'
         assert isinstance(img2, ci.Cifti2Image)
@@ -478,11 +468,9 @@ def test_pconnscalar():
     hdr = ci.Cifti2Header(matrix)
     data = np.random.randn(4, 4, 2)
     img = ci.Cifti2Image(data, hdr)
-    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_PARCELLATED_'
-                                'PARCELLATED_SCALAR')
 
     with InTemporaryDirectory():
-        ci.save(img, 'test.pconnscalar.nii')
+        ci.save(img, 'test.pconnscalar.nii', infer_intent=True)
         img2 = ci.load('test.pconnscalar.nii')
         assert img.nifti_header.get_intent()[0] == 'ConnPPSc'
         assert isinstance(img2, ci.Cifti2Image)
@@ -517,7 +505,7 @@ def test_wrong_shape():
                     ci.Cifti2Image(data, hdr)
         with suppress_warnings():
             img = ci.Cifti2Image(data, hdr)
-        
+
         with pytest.raises(ValueError):
             img.to_file_map()
 

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -315,7 +315,7 @@ class FileBasedImage(object):
     def filespec_to_files(klass, filespec):
         return klass.filespec_to_file_map(filespec)
 
-    def to_filename(self, filename):
+    def to_filename(self, filename, **kwargs):
         """ Write image to files implied by filename string
 
         Parameters
@@ -381,7 +381,7 @@ class FileBasedImage(object):
     load = from_filename
 
     @classmethod
-    def instance_to_filename(klass, img, filename):
+    def instance_to_filename(klass, img, filename, **kwargs):
         """ Save `img` in our own format, to name implied by `filename`
 
         This is a class method
@@ -394,7 +394,7 @@ class FileBasedImage(object):
            Filename, implying name to which to save image.
         """
         img = klass.from_image(img)
-        img.to_filename(filename)
+        img.to_filename(filename, **kwargs)
 
     @classmethod
     def from_image(klass, img):

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -78,7 +78,7 @@ def guessed_image_type(filename):
     raise ImageFileError(f'Cannot work out file type of "{filename}"')
 
 
-def save(img, filename):
+def save(img, filename, **kwargs):
     """ Save an image to file adapting format to `filename`
 
     Parameters
@@ -96,7 +96,7 @@ def save(img, filename):
 
     # Save the type as expected
     try:
-        img.to_filename(filename)
+        img.to_filename(filename, **kwargs)
     except ImageFileError:
         pass
     else:
@@ -144,7 +144,7 @@ def save(img, filename):
     # Here, we either have a klass or a converted image.
     if converted is None:
         converted = klass.from_image(img)
-    converted.to_filename(filename)
+    converted.to_filename(filename, **kwargs)
 
 
 @deprecate_with_version('read_img_data deprecated. '

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -123,7 +123,7 @@ class GenericImageAPI(ValidateAPI):
             hdr = img.get_header()
         assert hdr is img.header
 
-    def validate_filenames(self, imaker, params):
+    def validate_filenames(self, imaker, params, **kwargs):
         # Validate the filename, file_map interface
 
         if not self.can_save:
@@ -160,7 +160,7 @@ class GenericImageAPI(ValidateAPI):
                   warnings.filterwarnings('error',
                                           category=DeprecationWarning,
                                           module=r"nibabel.*")
-                  img.to_filename(path)
+                  img.to_filename(path, **kwargs)
                   rt_img = img.__class__.from_filename(path)
               assert_array_equal(img.shape, rt_img.shape)
               assert_almost_equal(img.get_fdata(), rt_img.get_fdata())
@@ -456,7 +456,7 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         with pytest.raises(ExpiredDeprecationError):
             img.get_shape()
 
-    def validate_mmap_parameter(self, imaker, params):
+    def validate_mmap_parameter(self, imaker, params, **kwargs):
         img = imaker()
         fname = img.get_filename()
         with InTemporaryDirectory():
@@ -468,7 +468,7 @@ class DataInterfaceMixin(GetSetDtypeMixin):
                 if not img.rw or not img.valid_exts:
                     return
                 fname = 'image' + img.valid_exts[0]
-                img.to_filename(fname)
+                img.to_filename(fname, **kwargs)
             rt_img = img.__class__.from_filename(fname, mmap=True)
             assert_almost_equal(img.get_fdata(), rt_img.get_fdata())
             rt_img = img.__class__.from_filename(fname, mmap=False)
@@ -533,22 +533,22 @@ class AffineMixin(object):
 
 
 class SerializeMixin(object):
-    def validate_to_bytes(self, imaker, params):
+    def validate_to_bytes(self, imaker, params, **kwargs):
         img = imaker()
         serialized = img.to_bytes()
         with InTemporaryDirectory():
             fname = 'img' + self.standard_extension
-            img.to_filename(fname)
+            img.to_filename(fname, **kwargs)
             with open(fname, 'rb') as fobj:
                 file_contents = fobj.read()
         assert serialized == file_contents
 
-    def validate_from_bytes(self, imaker, params):
+    def validate_from_bytes(self, imaker, params, **kwargs):
         img = imaker()
         klass = getattr(self, 'klass', img.__class__)
         with InTemporaryDirectory():
             fname = 'img' + self.standard_extension
-            img.to_filename(fname)
+            img.to_filename(fname, **kwargs)
 
             all_images = list(getattr(self, 'example_images', [])) + [{'fname': fname}]
             for img_params in all_images:
@@ -561,12 +561,12 @@ class SerializeMixin(object):
                 del img_a
                 del img_b
 
-    def validate_to_from_bytes(self, imaker, params):
+    def validate_to_from_bytes(self, imaker, params, **kwargs):
         img = imaker()
         klass = getattr(self, 'klass', img.__class__)
         with InTemporaryDirectory():
             fname = 'img' + self.standard_extension
-            img.to_filename(fname)
+            img.to_filename(fname, **kwargs)
 
             all_images = list(getattr(self, 'example_images', [])) + [{'fname': fname}]
             for img_params in all_images:


### PR DESCRIPTION
Adds support for `FileBasedImage` methods `to_filename` and `instance_to_filename` to support keyword args.

Adds keyword arg `validate` to CIFTI's `to_filename` and `instance_to_filename` methods.
- If `False` (default), the intent code will not be set (except when the intent code is `"none"`)
- If `True`, the first suffix of the output filename will be compared to valid suffixes from within the CIFTI-2 specification. If there is a match, the corresponding intent code will be set, and each IndexMap within the header matrix is checked.