### PR TITLE
ENH: Add bytestring serialization to CIFTI-2

### DIFF
--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -12,6 +12,7 @@ from nibabel.cifti2.cifti2 import _float_01, _value_if_klass, Cifti2HeaderError
 import pytest
 
 from nibabel.tests.test_dataobj_images import TestDataobjAPI as _TDA
+from nibabel.tests.test_image_api import SerializeMixin
 
 
 def compare_xml_leaf(str1, str2):
@@ -406,7 +407,7 @@ def test_underscoring():
         assert ci.cifti2._underscore(camel) == underscored
 
 
-class TestCifti2ImageAPI(_TDA):
+class TestCifti2ImageAPI(_TDA, SerializeMixin):
     """ Basic validation for Cifti2Image instances
     """
     # A callable returning an image from ``image_maker(data, header)``


### PR DESCRIPTION
CIFTI-2 is serializable, so might as well add it in. This required making `Cifti2Header` comparable, and fixing a small bug where each attempt to save or serialize a CIFTI-2 image adds a `Cifti2Extension` without clearing out old ones.

@mgxd Would you mind reviewing this one?