### PR TITLE
DOC: Remove to_filename from Getting started

### DIFF
--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -114,11 +114,7 @@ and all other values are set to resonable defaults.
 Saving this new image to a file is trivial.  We won't do it here, but it looks
 like::
 
-    img.to_filename(os.path.join('build','test4d.nii.gz'))
-
-or::
-
-    nib.save(img, os.path.join('build','test4d.nii.gz'))
+    nib.save(img, os.path.join('build', 'test4d.nii.gz'))
 
 This short introduction only gave a quick overview of NiBabel's capabilities.
 Please have a look at the :ref:`api` for more details about supported file

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -113,7 +113,7 @@ and all other values are set to resonable defaults.
 
 Saving this new image to a file is trivial:
 
-    nib.save(img, os.path.join('build', 'test4d.nii.gz'))
+>>> nib.save(img, os.path.join('build', 'test4d.nii.gz'))  # doctest: +SKIP
 
 This short introduction only gave a quick overview of NiBabel's capabilities.
 Please have a look at the :ref:`api` for more details about supported file

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -86,8 +86,8 @@ e.g.
 Corresponding "setter" methods allow modifying a header, while ensuring its
 compliance with the file format specifications.
 
-In some situations we need even more flexibility, and for with great courage,
-NiBabel also offers access to the raw header information
+In some situations we need even more flexibility and, for those with great
+courage, NiBabel also offers access to the raw header information
 
 >>> raw = hdr.structarr
 >>> raw['xyzt_units']

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -111,8 +111,7 @@ In this case, we used the identity matrix as the affine transformation. The
 image header is initialized from the provided data array (i.e. shape, dtype)
 and all other values are set to resonable defaults.
 
-Saving this new image to a file is trivial.  We won't do it here, but it looks
-like::
+Saving this new image to a file is trivial:
 
     nib.save(img, os.path.join('build', 'test4d.nii.gz'))
 


### PR DESCRIPTION
As suggested by @matthew-brett in #945.