### PR TITLE
TEST: Suppress expected warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ script:
           mkdir for_testing
           cd for_testing
           cp ../.coveragerc .
-          pytest --doctest-modules --cov nibabel -v --pyargs nibabel
+          pytest --doctest-modules --doctest-plus --cov nibabel -v --pyargs nibabel
       else
           false
       fi

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -4,6 +4,7 @@ Most routines work round some numpy oddities in floating point precision and
 casting.  Others work round numpy casting to and from python ints
 """
 
+import warnings
 from numbers import Integral
 from platform import processor, machine
 
@@ -349,8 +350,9 @@ def _check_maxexp(np_type, maxexp):
     dt = np.dtype(np_type)
     np_type = dt.type
     two = np_type(2).reshape((1,))  # to avoid upcasting
-    return (np.isfinite(two ** (maxexp - 1)) and
-            not np.isfinite(two ** maxexp))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # Expected overflow warning
+        return np.isfinite(two ** (maxexp - 1)) and not np.isfinite(two ** maxexp)
 
 
 def as_int(x, check=True):

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -1492,7 +1492,7 @@ class Cifti2Image(DataobjImage, SerializableImage):
 
         >>> import numpy as np
         >>> data = np.zeros((2,3,4))
-        >>> img = Cifti2Image(data)
+        >>> img = Cifti2Image(data)  # doctest: +IGNORE_WARNINGS
         >>> img.shape == (2, 3, 4)
         True
         >>> img.update_headers()

--- a/nibabel/conftest.py
+++ b/nibabel/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+# Pre-load deprecated modules to avoid cluttering warnings
+with pytest.deprecated_call():
+    import nibabel.keywordonly
+with pytest.deprecated_call():
+    import nibabel.trackvis
+with pytest.warns(FutureWarning):
+    import nibabel.py3k
+
+# Ignore warning requesting help with nicom
+with pytest.warns(UserWarning):
+    import nibabel.nicom

--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -7,6 +7,26 @@ import re
 
 _LEADING_WHITE = re.compile(r'^(\s*)')
 
+TESTSETUP = """
+
+.. testsetup::
+
+    >>> import pytest
+    >>> import warnings
+    >>> _suppress_warnings = pytest.deprecated_call()
+    >>> _ = _suppress_warnings.__enter__()
+
+"""
+
+TESTCLEANUP = """
+
+.. testcleanup::
+
+    >>> warnings.warn("Avoid error if no doctests to run...", DeprecationWarning)
+    >>> _ = _suppress_warnings.__exit__(None, None, None)
+
+"""
+
 
 class ExpiredDeprecationError(RuntimeError):
     """ Error for expired deprecation
@@ -25,7 +45,7 @@ def _ensure_cr(text):
     return text.rstrip() + '\n'
 
 
-def _add_dep_doc(old_doc, dep_doc):
+def _add_dep_doc(old_doc, dep_doc, setup='', cleanup=''):
     """ Add deprecation message `dep_doc` to docstring in `old_doc`
 
     Parameters
@@ -56,8 +76,11 @@ def _add_dep_doc(old_doc, dep_doc):
         # nothing following first paragraph, just append message
         return old_doc + '\n' + dep_doc
     indent = _LEADING_WHITE.match(old_lines[next_line]).group()
+    setup_lines = [indent + L for L in setup.splitlines()]
     dep_lines = [indent + L for L in [''] + dep_doc.splitlines() + ['']]
-    return '\n'.join(new_lines + dep_lines + old_lines[next_line:]) + '\n'
+    cleanup_lines = [indent + L for L in cleanup.splitlines()]
+    return '\n'.join(new_lines + dep_lines + setup_lines +
+                     old_lines[next_line:] + cleanup_lines + [''])
 
 
 class Deprecator(object):
@@ -160,7 +183,7 @@ class Deprecator(object):
                 return func(*args, **kwargs)
 
             deprecated_func.__doc__ = _add_dep_doc(deprecated_func.__doc__,
-                                                   message)
+                                                   message, TESTSETUP, TESTCLEANUP)
             return deprecated_func
 
         return deprecator

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -86,14 +86,14 @@ def test_geometry():
 
         # now write an incomplete file
         write_geometry(surf_path, coords, faces)
-        with clear_and_catch_warnings() as w:
+        with pytest.warns(Warning) as w:
             warnings.filterwarnings('always', category=DeprecationWarning)
             read_geometry(surf_path, read_metadata=True)
 
         assert any('volume information contained' in str(ww.message) for ww in w)
         assert any('extension code' in str(ww.message) for ww in w)
         volume_info['head'] = [1, 2]
-        with clear_and_catch_warnings() as w:
+        with pytest.warns(Warning) as w:
             write_geometry(surf_path, coords, faces, create_stamp, volume_info)
         assert any('Unknown extension' in str(ww.message) for ww in w)
         volume_info['a'] = 0
@@ -266,7 +266,7 @@ def test_write_annot_fill_ctab():
         # values back.
         badannot = (10 * np.arange(nlabels, dtype=np.int32)).reshape(-1, 1)
         rgbal = np.hstack((rgba, badannot))
-        with clear_and_catch_warnings() as w:
+        with pytest.warns(Warning) as w:
             write_annot(annot_path, labels, rgbal, names, fill_ctab=False)
         assert any(f'Annotation values in {annot_path} will be incorrect' == str(ww.message)
                    for ww in w)

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -86,16 +86,15 @@ def test_geometry():
 
         # now write an incomplete file
         write_geometry(surf_path, coords, faces)
-        with pytest.warns(Warning) as w:
-            warnings.filterwarnings('always', category=DeprecationWarning)
+        with pytest.warns(UserWarning) as w:
             read_geometry(surf_path, read_metadata=True)
-
         assert any('volume information contained' in str(ww.message) for ww in w)
         assert any('extension code' in str(ww.message) for ww in w)
+
         volume_info['head'] = [1, 2]
-        with pytest.warns(Warning) as w:
+        with pytest.warns(UserWarning, match="Unknown extension"):
             write_geometry(surf_path, coords, faces, create_stamp, volume_info)
-        assert any('Unknown extension' in str(ww.message) for ww in w)
+
         volume_info['a'] = 0
         with pytest.raises(ValueError):
             write_geometry(surf_path, coords, faces, create_stamp, volume_info)
@@ -266,10 +265,9 @@ def test_write_annot_fill_ctab():
         # values back.
         badannot = (10 * np.arange(nlabels, dtype=np.int32)).reshape(-1, 1)
         rgbal = np.hstack((rgba, badannot))
-        with pytest.warns(Warning) as w:
+        with pytest.warns(UserWarning,
+                          match=f'Annotation values in {annot_path} will be incorrect'):
             write_annot(annot_path, labels, rgbal, names, fill_ctab=False)
-        assert any(f'Annotation values in {annot_path} will be incorrect' == str(ww.message)
-                   for ww in w)
         labels2, rgbal2, names2 = read_annot(annot_path, orig_ids=True)
         names2 = [n.decode('ascii') for n in names2]
         assert np.all(np.isclose(rgbal2[:, :4], rgba))

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -345,13 +345,13 @@ def test_deprecated_fields():
 
     # mrparams is the only deprecated field at the moment
     # Accessing hdr_data is equivalent to accessing hdr, so double all checks
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="from version: 2.3"):
         assert_array_equal(hdr['mrparams'], 0)
     assert_array_equal(hdr_data['mrparams'], 0)
 
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="from version: 2.3"):
         hdr['mrparams'] = [1, 2, 3, 4]
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="from version: 2.3"):
         assert_array_almost_equal(hdr['mrparams'], [1, 2, 3, 4])
     assert hdr['tr'] == 1
     assert hdr['flip_angle'] == 2
@@ -369,7 +369,7 @@ def test_deprecated_fields():
     hdr['flip_angle'] = 6
     hdr['te'] = 7
     hdr['ti'] = 8
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="from version: 2.3"):
         assert_array_almost_equal(hdr['mrparams'], [5, 6, 7, 8])
     assert_array_almost_equal(hdr_data['mrparams'], [5, 6, 7, 8])
 
@@ -377,7 +377,7 @@ def test_deprecated_fields():
     hdr_data['flip_angle'] = 10
     hdr_data['te'] = 11
     hdr_data['ti'] = 12
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="from version: 2.3"):
         assert_array_almost_equal(hdr['mrparams'], [9, 10, 11, 12])
     assert_array_almost_equal(hdr_data['mrparams'], [9, 10, 11, 12])
 

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -345,11 +345,14 @@ def test_deprecated_fields():
 
     # mrparams is the only deprecated field at the moment
     # Accessing hdr_data is equivalent to accessing hdr, so double all checks
-    assert_array_equal(hdr['mrparams'], 0)
+    with pytest.deprecated_call():
+        assert_array_equal(hdr['mrparams'], 0)
     assert_array_equal(hdr_data['mrparams'], 0)
 
-    hdr['mrparams'] = [1, 2, 3, 4]
-    assert_array_almost_equal(hdr['mrparams'], [1, 2, 3, 4])
+    with pytest.deprecated_call():
+        hdr['mrparams'] = [1, 2, 3, 4]
+    with pytest.deprecated_call():
+        assert_array_almost_equal(hdr['mrparams'], [1, 2, 3, 4])
     assert hdr['tr'] == 1
     assert hdr['flip_angle'] == 2
     assert hdr['te'] == 3
@@ -366,14 +369,16 @@ def test_deprecated_fields():
     hdr['flip_angle'] = 6
     hdr['te'] = 7
     hdr['ti'] = 8
-    assert_array_almost_equal(hdr['mrparams'], [5, 6, 7, 8])
+    with pytest.deprecated_call():
+        assert_array_almost_equal(hdr['mrparams'], [5, 6, 7, 8])
     assert_array_almost_equal(hdr_data['mrparams'], [5, 6, 7, 8])
 
     hdr_data['tr'] = 9
     hdr_data['flip_angle'] = 10
     hdr_data['te'] = 11
     hdr_data['ti'] = 12
-    assert_array_almost_equal(hdr['mrparams'], [9, 10, 11, 12])
+    with pytest.deprecated_call():
+        assert_array_almost_equal(hdr['mrparams'], [9, 10, 11, 12])
     assert_array_almost_equal(hdr_data['mrparams'], [9, 10, 11, 12])
 
 

--- a/nibabel/keywordonly.py
+++ b/nibabel/keywordonly.py
@@ -4,7 +4,7 @@
 from functools import wraps
 import warnings
 
-warnings.warn("We will remove this module from nibabel 5.0. "
+warnings.warn("We will remove the 'keywordonly' module from nibabel 5.0. "
               "Please use the built-in Python `*` argument to ensure "
               "keyword-only parameters (see PEP 3102).",
               DeprecationWarning,

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -55,9 +55,7 @@ def load(filename, **kwargs):
     raise ImageFileError(f'Cannot work out file type of "{filename}"')
 
 
-@deprecate_with_version('guessed_image_type deprecated.'
-                        '2.1',
-                        '4.0')
+@deprecate_with_version('guessed_image_type deprecated.', '2.1', '4.0')
 def guessed_image_type(filename):
     """ Guess image type from file `filename`
 
@@ -149,8 +147,8 @@ def save(img, filename):
     converted.to_filename(filename)
 
 
-@deprecate_with_version('read_img_data deprecated.'
-                        'Please use ``img.dataobj.get_unscaled()`` instead.'
+@deprecate_with_version('read_img_data deprecated. '
+                        'Please use ``img.dataobj.get_unscaled()`` instead.',
                         '2.0.1',
                         '4.0')
 def read_img_data(img, prefer='scaled'):
@@ -236,9 +234,7 @@ def read_img_data(img, prefer='scaled'):
         return hdr.raw_data_from_fileobj(fileobj)
 
 
-@deprecate_with_version('which_analyze_type deprecated.'
-                        '2.1',
-                        '4.0')
+@deprecate_with_version('which_analyze_type deprecated.', '2.1', '4.0')
 def which_analyze_type(binaryblock):
     """ Is `binaryblock` from NIfTI1, NIfTI2 or Analyze header?
 

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -55,7 +55,7 @@ def load(filename, **kwargs):
     raise ImageFileError(f'Cannot work out file type of "{filename}"')
 
 
-@deprecate_with_version('guessed_image_type deprecated.', '2.1', '4.0')
+@deprecate_with_version('guessed_image_type deprecated.', '3.2', '5.0')
 def guessed_image_type(filename):
     """ Guess image type from file `filename`
 
@@ -149,8 +149,8 @@ def save(img, filename):
 
 @deprecate_with_version('read_img_data deprecated. '
                         'Please use ``img.dataobj.get_unscaled()`` instead.',
-                        '2.0.1',
-                        '4.0')
+                        '3.2',
+                        '5.0')
 def read_img_data(img, prefer='scaled'):
     """ Read data from image associated with files
 
@@ -234,7 +234,7 @@ def read_img_data(img, prefer='scaled'):
         return hdr.raw_data_from_fileobj(fileobj)
 
 
-@deprecate_with_version('which_analyze_type deprecated.', '2.1', '4.0')
+@deprecate_with_version('which_analyze_type deprecated.', '3.2', '4.0')
 def which_analyze_type(binaryblock):
     """ Is `binaryblock` from NIfTI1, NIfTI2 or Analyze header?
 

--- a/nibabel/nicom/ascconv.py
+++ b/nibabel/nicom/ascconv.py
@@ -205,7 +205,7 @@ def parse_ascconv(ascconv_str, str_delim='"'):
     attrs, content = ASCCONV_RE.match(ascconv_str).groups()
     attrs = OrderedDict((tuple(x.split('=')) for x in attrs.split()))
     # Normalize string start / end markers to something Python understands
-    content = content.replace(str_delim, '"""')
+    content = content.replace(str_delim, '"""').replace("\\", "\\\\")
     # Use Python's own parser to parse modified ASCCONV assignments
     tree = ast.parse(content)
 

--- a/nibabel/nicom/dicomreaders.py
+++ b/nibabel/nicom/dicomreaders.py
@@ -32,7 +32,7 @@ def mosaic_to_nii(dcm_data):
     if not dcm_w.is_mosaic:
         raise DicomReadError('data does not appear to be in mosaic format')
     data = dcm_w.get_data()
-    aff = np.dot(DPCS_TO_TAL, dcm_w.get_affine())
+    aff = np.dot(DPCS_TO_TAL, dcm_w.affine)
     return Nifti1Image(data, aff)
 
 
@@ -106,7 +106,7 @@ def read_mosaic_dir(dicom_path,
             g = dcm_w.b_vector
         b_values.append(b)
         gradients.append(g)
-    affine = np.dot(DPCS_TO_TAL, dcm_w.get_affine())
+    affine = np.dot(DPCS_TO_TAL, dcm_w.affine)
     return (np.concatenate(arrays, -1),
             affine,
             np.array(b_values),

--- a/nibabel/nicom/tests/test_dicomreaders.py
+++ b/nibabel/nicom/tests/test_dicomreaders.py
@@ -20,7 +20,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 @dicom_test
 def test_read_dwi():
     img = didr.mosaic_to_nii(DATA)
-    arr = img.get_data()
+    arr = img.get_fdata()
     assert arr.shape == (128, 128, 48)
     assert_array_almost_equal(img.affine, EXPECTED_AFFINE)
 

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -660,7 +660,8 @@ class TestMultiFrameWrapper(TestCase):
         # Test 4D diffusion data with an additional trace volume included
         # Excludes the trace volume and generates the correct shape
         dw = didw.wrapper_from_file(DATA_FILE_4D_DERIVED)
-        assert dw.image_shape == (96, 96, 60, 33)
+        with pytest.warns(UserWarning):
+            assert dw.image_shape == (96, 96, 60, 33)
 
     @dicom_test
     @needs_nibabel_data('nitest-dicom')

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -660,14 +660,14 @@ class TestMultiFrameWrapper(TestCase):
         # Test 4D diffusion data with an additional trace volume included
         # Excludes the trace volume and generates the correct shape
         dw = didw.wrapper_from_file(DATA_FILE_4D_DERIVED)
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Derived images found and removed"):
             assert dw.image_shape == (96, 96, 60, 33)
 
     @dicom_test
     @needs_nibabel_data('nitest-dicom')
     def test_data_unreadable_private_headers(self):
         # Test CT image with unreadable CSA tags
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Error while attempting to read CSA header"):
             dw = didw.wrapper_from_file(DATA_FILE_CT)
         assert dw.image_shape == (512, 571)
 

--- a/nibabel/processing.py
+++ b/nibabel/processing.py
@@ -300,8 +300,10 @@ def smooth_image(img,
         fwhm = np.zeros((n_dim,))
         fwhm[:3] = fwhm_scalar
     # Voxel sizes
-    RZS = img.affine[:-1, :n_dim]
+    RZS = img.affine[:, :n_dim]
     vox = np.sqrt(np.sum(RZS ** 2, 0))
+    # Avoid divisions by zero for 4+D images
+    vox[3:] = 1
     # Smoothing in terms of voxels
     vox_fwhm = fwhm / vox
     vox_sd = fwhm2sigma(vox_fwhm)

--- a/nibabel/processing.py
+++ b/nibabel/processing.py
@@ -302,8 +302,6 @@ def smooth_image(img,
     # Voxel sizes
     RZS = img.affine[:, :n_dim]
     vox = np.sqrt(np.sum(RZS ** 2, 0))
-    # Avoid divisions by zero for 4+D images
-    vox[3:] = 1
     # Smoothing in terms of voxels
     vox_fwhm = fwhm / vox
     vox_sd = fwhm2sigma(vox_fwhm)

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -100,7 +100,8 @@ class TestArraySequence(unittest.TestCase):
         seq_with_buffer = ArraySequence(gen_2, buffer_size=256)
 
         # Check buffer size effect
-        assert seq_with_buffer.data.shape == seq.data.shape
+        with pytest.warns(Warning):
+            assert seq_with_buffer.data.shape == seq.data.shape
         assert seq_with_buffer._buffer_size > seq._buffer_size
 
         # Check generator result

--- a/nibabel/streamlines/tests/test_array_sequence.py
+++ b/nibabel/streamlines/tests/test_array_sequence.py
@@ -94,14 +94,18 @@ class TestArraySequence(unittest.TestCase):
         check_arr_seq(ArraySequence(iter(SEQ_DATA['data']), buffer_size),
                       SEQ_DATA['data'])
 
+    def test_deprecated_data_attribute(self):
+        seq = ArraySequence(SEQ_DATA['data'])
+        with pytest.deprecated_call(match="from version: 3.0"):
+            seq.data
+
     def test_creating_arraysequence_from_generator(self):
         gen_1, gen_2 = itertools.tee((e for e in SEQ_DATA['data']))
         seq = ArraySequence(gen_1)
         seq_with_buffer = ArraySequence(gen_2, buffer_size=256)
 
         # Check buffer size effect
-        with pytest.warns(Warning):
-            assert seq_with_buffer.data.shape == seq.data.shape
+        assert seq_with_buffer.get_data().shape == seq.get_data().shape
         assert seq_with_buffer._buffer_size > seq._buffer_size
 
         # Check generator result

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -3,6 +3,8 @@ import unittest
 import tempfile
 import numpy as np
 
+import pytest
+
 from os.path import join as pjoin
 
 import nibabel as nib
@@ -140,8 +142,10 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                assert_tractogram_equal(tfile.tractogram,
-                                        DATA['empty_tractogram'])
+                with pytest.warns(None) as w:
+                    assert_tractogram_equal(tfile.tractogram,
+                                            DATA['empty_tractogram'])
+                assert len(w) == lazy_load
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
@@ -155,8 +159,10 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                assert_tractogram_equal(tfile.tractogram,
-                                        DATA['simple_tractogram'])
+                with pytest.warns(None) as w:
+                    assert_tractogram_equal(tfile.tractogram,
+                                            DATA['simple_tractogram'])
+                assert len(w) == lazy_load
 
     def test_load_complex_file(self):
         for lazy_load in [False, True]:
@@ -180,8 +186,10 @@ class TestLoadSave(unittest.TestCase):
                     data = DATA['data_per_streamline']
                     tractogram.data_per_streamline = data
 
-                assert_tractogram_equal(tfile.tractogram,
-                                        tractogram)
+                with pytest.warns(None) as w:
+                    assert_tractogram_equal(tfile.tractogram,
+                                            tractogram)
+                assert len(w) == lazy_load
 
     def test_save_tractogram_file(self):
         tractogram = Tractogram(DATA['streamlines'],
@@ -193,15 +201,14 @@ class TestLoadSave(unittest.TestCase):
             nib.streamlines.save(trk_file, "dummy.trk", header={})
 
         # Wrong extension.
-        with clear_and_catch_warnings(record=True,
-                                      modules=[nib.streamlines]) as w:
+        with pytest.warns(None) as w:
             trk_file = trk.TrkFile(tractogram)
             with self.assertRaises(ValueError):
                 nib.streamlines.save(trk_file, "dummy.tck", header={})
 
-            assert len(w) == 1
-            assert issubclass(w[0].category, ExtensionWarning)
-            assert "extension" in str(w[0].message)
+        assert len(w) == 1
+        assert issubclass(w[0].category, ExtensionWarning)
+        assert "extension" in str(w[0].message)
 
         with InTemporaryDirectory():
             nib.streamlines.save(trk_file, "dummy.trk")
@@ -237,33 +244,32 @@ class TestLoadSave(unittest.TestCase):
             with InTemporaryDirectory():
                 filename = 'streamlines' + ext
 
-                with clear_and_catch_warnings(record=True,
-                                              modules=[trk]) as w:
+                with pytest.warns(None) as w:
                     nib.streamlines.save(complex_tractogram, filename)
 
-                    # If streamlines format does not support saving data
-                    # per point or data per streamline, warning messages
-                    # should be issued.
-                    nb_expected_warnings = \
-                        ((not cls.SUPPORTS_DATA_PER_POINT) +
-                         (not cls.SUPPORTS_DATA_PER_STREAMLINE))
+                # If streamlines format does not support saving data
+                # per point or data per streamline, warning messages
+                # should be issued.
+                nb_expected_warnings = \
+                    ((not cls.SUPPORTS_DATA_PER_POINT) +
+                     (not cls.SUPPORTS_DATA_PER_STREAMLINE))
 
-                    assert len(w) == nb_expected_warnings
-                    for i in range(nb_expected_warnings):
-                        assert issubclass(w[i].category, Warning)
+                assert len(w) == nb_expected_warnings
+                for i in range(nb_expected_warnings):
+                    assert issubclass(w[i].category, Warning)
 
-                    tractogram = Tractogram(DATA['streamlines'],
-                                            affine_to_rasmm=np.eye(4))
+                tractogram = Tractogram(DATA['streamlines'],
+                                        affine_to_rasmm=np.eye(4))
 
-                    if cls.SUPPORTS_DATA_PER_POINT:
-                        tractogram.data_per_point = DATA['data_per_point']
+                if cls.SUPPORTS_DATA_PER_POINT:
+                    tractogram.data_per_point = DATA['data_per_point']
 
-                    if cls.SUPPORTS_DATA_PER_STREAMLINE:
-                        data = DATA['data_per_streamline']
-                        tractogram.data_per_streamline = data
+                if cls.SUPPORTS_DATA_PER_STREAMLINE:
+                    data = DATA['data_per_streamline']
+                    tractogram.data_per_streamline = data
 
-                    tfile = nib.streamlines.load(filename, lazy_load=False)
-                    assert_tractogram_equal(tfile.tractogram, tractogram)
+                tfile = nib.streamlines.load(filename, lazy_load=False)
+                assert_tractogram_equal(tfile.tractogram, tractogram)
 
     def test_save_sliced_tractogram(self):
         tractogram = Tractogram(DATA['streamlines'],

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -201,13 +201,10 @@ class TestLoadSave(unittest.TestCase):
             nib.streamlines.save(trk_file, "dummy.trk", header={})
 
         # Wrong extension.
-        with pytest.warns(ExtensionWarning) as w:
+        with pytest.warns(ExtensionWarning, match="extension"):
             trk_file = trk.TrkFile(tractogram)
             with self.assertRaises(ValueError):
                 nib.streamlines.save(trk_file, "dummy.tck", header={})
-
-        assert len(w) == 1
-        assert "extension" in str(w[0].message)
 
         with InTemporaryDirectory():
             nib.streamlines.save(trk_file, "dummy.trk")
@@ -243,9 +240,6 @@ class TestLoadSave(unittest.TestCase):
             with InTemporaryDirectory():
                 filename = 'streamlines' + ext
 
-                with pytest.warns(None) as w:
-                    nib.streamlines.save(complex_tractogram, filename)
-
                 # If streamlines format does not support saving data
                 # per point or data per streamline, warning messages
                 # should be issued.
@@ -253,9 +247,9 @@ class TestLoadSave(unittest.TestCase):
                     ((not cls.SUPPORTS_DATA_PER_POINT) +
                      (not cls.SUPPORTS_DATA_PER_STREAMLINE))
 
+                with pytest.warns(Warning if nb_expected_warnings else None) as w:
+                    nib.streamlines.save(complex_tractogram, filename)
                 assert len(w) == nb_expected_warnings
-                for i in range(nb_expected_warnings):
-                    assert issubclass(w[i].category, Warning)
 
                 tractogram = Tractogram(DATA['streamlines'],
                                         affine_to_rasmm=np.eye(4))

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.compat.py3k import asbytes
 
-from nibabel.testing import data_path, clear_and_catch_warnings
+from nibabel.testing import data_path
 
 from .test_tractogram import assert_tractogram_equal
 from ..tractogram import Tractogram, LazyTractogram

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -142,10 +142,9 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                with pytest.warns(None) as w:
+                with pytest.warns(Warning if lazy_load else None):
                     assert_tractogram_equal(tfile.tractogram,
                                             DATA['empty_tractogram'])
-                assert len(w) == lazy_load
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
@@ -159,10 +158,9 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                with pytest.warns(None) as w:
+                with pytest.warns(Warning if lazy_load else None):
                     assert_tractogram_equal(tfile.tractogram,
                                             DATA['simple_tractogram'])
-                assert len(w) == lazy_load
 
     def test_load_complex_file(self):
         for lazy_load in [False, True]:
@@ -186,10 +184,9 @@ class TestLoadSave(unittest.TestCase):
                     data = DATA['data_per_streamline']
                     tractogram.data_per_streamline = data
 
-                with pytest.warns(None) as w:
+                with pytest.warns(Warning if lazy_load else None):
                     assert_tractogram_equal(tfile.tractogram,
                                             tractogram)
-                assert len(w) == lazy_load
 
     def test_save_tractogram_file(self):
         tractogram = Tractogram(DATA['streamlines'],

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -201,13 +201,12 @@ class TestLoadSave(unittest.TestCase):
             nib.streamlines.save(trk_file, "dummy.trk", header={})
 
         # Wrong extension.
-        with pytest.warns(None) as w:
+        with pytest.warns(ExtensionWarning) as w:
             trk_file = trk.TrkFile(tractogram)
             with self.assertRaises(ValueError):
                 nib.streamlines.save(trk_file, "dummy.tck", header={})
 
         assert len(w) == 1
-        assert issubclass(w[0].category, ExtensionWarning)
         assert "extension" in str(w[0].message)
 
         with InTemporaryDirectory():

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -113,18 +113,14 @@ class TestTCK(unittest.TestCase):
         new_tck_file = tck_file.replace(b"datatype: Float32LE\n", b"")
         # Need to adjust data offset.
         new_tck_file = new_tck_file.replace(b"file: . 67\n", b"file: . 47\n")
-        with pytest.warns(HeaderWarning) as w:
+        with pytest.warns(HeaderWarning, match="Missing 'datatype'"):
             tck = TckFile.load(BytesIO(new_tck_file))
-        assert len(w) == 1
-        assert "Missing 'datatype'" in str(w[0].message)
         assert_array_equal(tck.header['datatype'], "Float32LE")
 
         # Simulate a TCK file with no `file` field.
         new_tck_file = tck_file.replace(b"\nfile: . 67", b"")
-        with pytest.warns(HeaderWarning) as w:
+        with pytest.warns(HeaderWarning, matches="Missing 'file'") as w:
             tck = TckFile.load(BytesIO(new_tck_file))
-        assert len(w) == 1
-        assert "Missing 'file'" in str(w[0].message)
         assert_array_equal(tck.header['file'], ". 56")
 
         # Simulate a TCK file with `file` field pointing to another file.

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -47,16 +47,14 @@ class TestTCK(unittest.TestCase):
     def test_load_empty_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['empty_tck_fname'], lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(tck.tractogram, DATA['empty_tractogram'])
-            assert len(w) == lazy_load
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_fname'], lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
-            assert len(w) == lazy_load
 
         # Force TCK loading to use buffering.
         buffer_size = 1. / 1024**2  # 1 bytes
@@ -90,9 +88,8 @@ class TestTCK(unittest.TestCase):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_big_endian_fname'],
                                lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
-            assert len(w) == lazy_load
             assert tck.header['datatype'] == 'Float32BE'
 
     def test_load_file_with_wrong_information(self):

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -15,7 +15,7 @@ from ..tck import TckFile
 
 import pytest
 from numpy.testing import assert_array_equal
-from ...testing import data_path, clear_and_catch_warnings
+from ...testing import data_path
 from .test_tractogram import assert_tractogram_equal
 
 DATA = {}

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -4,7 +4,6 @@ import numpy as np
 from os.path import join as pjoin
 
 from io import BytesIO
-from nibabel.py3k import asbytes
 
 from ..array_sequence import ArraySequence
 from ..tractogram import Tractogram
@@ -48,12 +47,16 @@ class TestTCK(unittest.TestCase):
     def test_load_empty_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['empty_tck_fname'], lazy_load=lazy_load)
-            assert_tractogram_equal(tck.tractogram, DATA['empty_tractogram'])
+            with pytest.warns(None) as w:
+                assert_tractogram_equal(tck.tractogram, DATA['empty_tractogram'])
+            assert len(w) == lazy_load
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_fname'], lazy_load=lazy_load)
-            assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
+            with pytest.warns(None) as w:
+                assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
+            assert len(w) == lazy_load
 
         # Force TCK loading to use buffering.
         buffer_size = 1. / 1024**2  # 1 bytes
@@ -87,22 +90,22 @@ class TestTCK(unittest.TestCase):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_big_endian_fname'],
                                lazy_load=lazy_load)
-            assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
+            with pytest.warns(None) as w:
+                assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
+            assert len(w) == lazy_load
             assert tck.header['datatype'] == 'Float32BE'
 
     def test_load_file_with_wrong_information(self):
         tck_file = open(DATA['simple_tck_fname'], 'rb').read()
 
         # Simulate a TCK file where `datatype` has not the right endianness.
-        new_tck_file = tck_file.replace(asbytes("Float32LE"),
-                                        asbytes("Float32BE"))
+        new_tck_file = tck_file.replace(b"Float32LE", b"Float32BE")
         
         with pytest.raises(DataError):
             TckFile.load(BytesIO(new_tck_file))
 
         # Simulate a TCK file with unsupported `datatype`.
-        new_tck_file = tck_file.replace(asbytes("Float32LE"),
-                                        asbytes("int32"))
+        new_tck_file = tck_file.replace(b"Float32LE", b"int32")
         with pytest.raises(HeaderError):
             TckFile.load(BytesIO(new_tck_file))
 
@@ -110,21 +113,19 @@ class TestTCK(unittest.TestCase):
         new_tck_file = tck_file.replace(b"datatype: Float32LE\n", b"")
         # Need to adjust data offset.
         new_tck_file = new_tck_file.replace(b"file: . 67\n", b"file: . 47\n")
-        with clear_and_catch_warnings(record=True, modules=[tck_module]) as w:
+        with pytest.warns(HeaderWarning) as w:
             tck = TckFile.load(BytesIO(new_tck_file))
-            assert len(w) == 1
-            assert issubclass(w[0].category, HeaderWarning)
-            assert "Missing 'datatype'" in str(w[0].message)
-            assert_array_equal(tck.header['datatype'], "Float32LE")
+        assert len(w) == 1
+        assert "Missing 'datatype'" in str(w[0].message)
+        assert_array_equal(tck.header['datatype'], "Float32LE")
 
         # Simulate a TCK file with no `file` field.
         new_tck_file = tck_file.replace(b"\nfile: . 67", b"")
-        with clear_and_catch_warnings(record=True, modules=[tck_module]) as w:
+        with pytest.warns(HeaderWarning) as w:
             tck = TckFile.load(BytesIO(new_tck_file))
-            assert len(w) == 1
-            assert issubclass(w[0].category, HeaderWarning)
-            assert "Missing 'file'" in str(w[0].message)
-            assert_array_equal(tck.header['file'], ". 56")
+        assert len(w) == 1
+        assert "Missing 'file'" in str(w[0].message)
+        assert_array_equal(tck.header['file'], ". 56")
 
         # Simulate a TCK file with `file` field pointing to another file.
         new_tck_file = tck_file.replace(b"file: . 67\n",

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -116,7 +116,7 @@ class TestTCK(unittest.TestCase):
 
         # Simulate a TCK file with no `file` field.
         new_tck_file = tck_file.replace(b"\nfile: . 67", b"")
-        with pytest.warns(HeaderWarning, matches="Missing 'file'") as w:
+        with pytest.warns(HeaderWarning, match="Missing 'file'") as w:
             tck = TckFile.load(BytesIO(new_tck_file))
         assert_array_equal(tck.header['file'], ". 56")
 

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -811,7 +811,8 @@ class TestLazyTractogram(unittest.TestCase):
 
         # Empty `LazyTractogram`
         tractogram = LazyTractogram()
-        check_tractogram(tractogram)
+        with pytest.warns(Warning):
+            check_tractogram(tractogram)
         assert tractogram.affine_to_rasmm is None
 
         # Create tractogram with streamlines and other data
@@ -832,7 +833,8 @@ class TestLazyTractogram(unittest.TestCase):
     def test_lazy_tractogram_from_data_func(self):
         # Create an empty `LazyTractogram` yielding nothing.
         tractogram = LazyTractogram.from_data_func(lambda: iter([]))
-        check_tractogram(tractogram)
+        with pytest.warns(Warning):
+            check_tractogram(tractogram)
 
         # Create `LazyTractogram` from a generator function yielding
         # TractogramItem.
@@ -852,7 +854,8 @@ class TestLazyTractogram(unittest.TestCase):
                                      data_for_points)
 
         tractogram = LazyTractogram.from_data_func(_data_gen)
-        assert_tractogram_equal(tractogram, DATA['tractogram'])
+        with pytest.warns(Warning):
+            assert_tractogram_equal(tractogram, DATA['tractogram'])
 
         # Creating a LazyTractogram from not a corouting should raise an error.
         with pytest.raises(TypeError):
@@ -921,10 +924,11 @@ class TestLazyTractogram(unittest.TestCase):
         assert_array_equal(transformed_tractogram._affine_to_apply, affine)
         assert_array_equal(transformed_tractogram.affine_to_rasmm,
                            np.dot(np.eye(4), np.linalg.inv(affine)))
-        check_tractogram(transformed_tractogram,
-                         streamlines=[s*scaling for s in DATA['streamlines']],
-                         data_per_streamline=DATA['data_per_streamline'],
-                         data_per_point=DATA['data_per_point'])
+        with pytest.warns(Warning):
+            check_tractogram(transformed_tractogram,
+                             streamlines=[s*scaling for s in DATA['streamlines']],
+                             data_per_streamline=DATA['data_per_streamline'],
+                             data_per_point=DATA['data_per_point'])
 
         # Apply affine again and check the affine_to_rasmm.
         transformed_tractogram = transformed_tractogram.apply_affine(affine)
@@ -946,10 +950,11 @@ class TestLazyTractogram(unittest.TestCase):
         transformed_tractogram = tractogram.apply_affine(affine)
         assert_array_equal(transformed_tractogram._affine_to_apply, affine)
         assert transformed_tractogram.affine_to_rasmm is None
-        check_tractogram(transformed_tractogram,
-                         streamlines=[s*scaling for s in DATA['streamlines']],
-                         data_per_streamline=DATA['data_per_streamline'],
-                         data_per_point=DATA['data_per_point'])
+        with pytest.warns(Warning):
+            check_tractogram(transformed_tractogram,
+                             streamlines=[s*scaling for s in DATA['streamlines']],
+                             data_per_streamline=DATA['data_per_streamline'],
+                             data_per_point=DATA['data_per_point'])
 
         # Calling apply_affine with lazy=False should fail for LazyTractogram.
         tractogram = DATA['lazy_tractogram'].copy()
@@ -1019,4 +1024,5 @@ class TestLazyTractogram(unittest.TestCase):
                            DATA['lazy_tractogram']._affine_to_apply)
 
         # Check the data are the equivalent.
-        assert_tractogram_equal(tractogram, DATA['tractogram'])
+        with pytest.warns(Warning):
+            assert_tractogram_equal(tractogram, DATA['tractogram'])

--- a/nibabel/streamlines/tests/test_tractogram.py
+++ b/nibabel/streamlines/tests/test_tractogram.py
@@ -811,7 +811,7 @@ class TestLazyTractogram(unittest.TestCase):
 
         # Empty `LazyTractogram`
         tractogram = LazyTractogram()
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             check_tractogram(tractogram)
         assert tractogram.affine_to_rasmm is None
 
@@ -833,7 +833,7 @@ class TestLazyTractogram(unittest.TestCase):
     def test_lazy_tractogram_from_data_func(self):
         # Create an empty `LazyTractogram` yielding nothing.
         tractogram = LazyTractogram.from_data_func(lambda: iter([]))
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             check_tractogram(tractogram)
 
         # Create `LazyTractogram` from a generator function yielding
@@ -854,7 +854,7 @@ class TestLazyTractogram(unittest.TestCase):
                                      data_for_points)
 
         tractogram = LazyTractogram.from_data_func(_data_gen)
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             assert_tractogram_equal(tractogram, DATA['tractogram'])
 
         # Creating a LazyTractogram from not a corouting should raise an error.
@@ -924,7 +924,7 @@ class TestLazyTractogram(unittest.TestCase):
         assert_array_equal(transformed_tractogram._affine_to_apply, affine)
         assert_array_equal(transformed_tractogram.affine_to_rasmm,
                            np.dot(np.eye(4), np.linalg.inv(affine)))
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             check_tractogram(transformed_tractogram,
                              streamlines=[s*scaling for s in DATA['streamlines']],
                              data_per_streamline=DATA['data_per_streamline'],
@@ -950,7 +950,7 @@ class TestLazyTractogram(unittest.TestCase):
         transformed_tractogram = tractogram.apply_affine(affine)
         assert_array_equal(transformed_tractogram._affine_to_apply, affine)
         assert transformed_tractogram.affine_to_rasmm is None
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             check_tractogram(transformed_tractogram,
                              streamlines=[s*scaling for s in DATA['streamlines']],
                              data_per_streamline=DATA['data_per_streamline'],
@@ -1024,5 +1024,5 @@ class TestLazyTractogram(unittest.TestCase):
                            DATA['lazy_tractogram']._affine_to_apply)
 
         # Check the data are the equivalent.
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match="Number of streamlines will be determined manually"):
             assert_tractogram_equal(tractogram, DATA['tractogram'])

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -87,23 +87,20 @@ class TestTRK(unittest.TestCase):
     def test_load_empty_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['empty_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(trk.tractogram, DATA['empty_tractogram'])
-            assert len(w) == lazy_load
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['simple_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(trk.tractogram, DATA['simple_tractogram'])
-            assert len(w) == lazy_load
 
     def test_load_complex_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['complex_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(trk.tractogram, DATA['complex_tractogram'])
-            assert len(w) == lazy_load
 
     def trk_with_bytes(self, trk_key='simple_trk_fname', endian='<'):
         """ Return example trk file bytes and struct view onto bytes """
@@ -202,9 +199,8 @@ class TestTRK(unittest.TestCase):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['complex_trk_big_endian_fname'],
                                lazy_load=lazy_load)
-            with pytest.warns(None) as w:
+            with pytest.warns(Warning if lazy_load else None):
                 assert_tractogram_equal(trk.tractogram, DATA['complex_tractogram'])
-            assert len(w) == lazy_load
 
     def test_tractogram_file_properties(self):
         trk = TrkFile.load(DATA['simple_trk_fname'])

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -135,10 +135,8 @@ class TestTRK(unittest.TestCase):
         # Simulate a TRK where `vox_to_ras` is not recorded (i.e. all zeros).
         trk_struct, trk_bytes = self.trk_with_bytes()
         trk_struct[Field.VOXEL_TO_RASMM] = np.zeros((4, 4))
-        with pytest.warns(HeaderWarning) as w:
+        with pytest.warns(HeaderWarning, match="identity"):
             trk = TrkFile.load(BytesIO(trk_bytes))
-        assert len(w) == 1
-        assert "identity" in str(w[0].message)
         assert_array_equal(trk.affine, np.eye(4))
 
         # Simulate a TRK where `vox_to_ras` is invalid.
@@ -151,17 +149,14 @@ class TestTRK(unittest.TestCase):
         # Simulate a TRK file where `voxel_order` was not provided.
         trk_struct, trk_bytes = self.trk_with_bytes()
         trk_struct[Field.VOXEL_ORDER] = b''
-        with pytest.warns(HeaderWarning) as w:
+        with pytest.warns(HeaderWarning, match="LPS"):
             TrkFile.load(BytesIO(trk_bytes))
-        assert len(w) == 1
-        assert "LPS" in str(w[0].message)
 
         # Simulate a TRK file with an unsupported version.
         trk_struct, trk_bytes = self.trk_with_bytes()
         trk_struct['version'] = 123
         with pytest.raises(HeaderError):
             TrkFile.load(BytesIO(trk_bytes))
-        
 
         # Simulate a TRK file with a wrong hdr_size.
         trk_struct, trk_bytes = self.trk_with_bytes()
@@ -190,10 +185,8 @@ class TestTRK(unittest.TestCase):
         assert_array_equal(trk.affine, np.diag([2, 3, 4, 1]))
         # Next check that affine assumed identity if version 1.
         trk_struct['version'] = 1
-        with pytest.warns(HeaderWarning) as w:
+        with pytest.warns(HeaderWarning, match="identity"):
             trk = TrkFile.load(BytesIO(trk_bytes))
-        assert len(w) == 1
-        assert "identity" in str(w[0].message)
         assert_array_equal(trk.affine, np.eye(4))
         assert_array_equal(trk.header['version'], 1)
 

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -24,6 +24,14 @@ from .helpers import bytesio_filemap, bytesio_round_trip, assert_data_similar
 
 from itertools import zip_longest
 
+try:
+    from contextlib import nullcontext
+except ImportError:  # PY36
+    from contextlib import contextmanager
+    @contextmanager
+    def nullcontext():
+        yield
+
 
 def test_data(subdir=None, fname=None):
     if subdir is None:

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -734,9 +734,11 @@ class TestAnalyzeImage(tsi.TestSpatialImage, tsi.MmapImageMixin):
         assert_array_equal(np.asanyarray(img2.dataobj), data)
         # now check read_img_data function - here we do see the changed
         # header
-        sc_data = read_img_data(img2)
+        with pytest.deprecated_call():
+            sc_data = read_img_data(img2)
         assert sc_data.shape == (3, 2, 2)
-        us_data = read_img_data(img2, prefer='unscaled')
+        with pytest.deprecated_call():
+            us_data = read_img_data(img2, prefer='unscaled')
         assert us_data.shape == (3, 2, 2)
 
     def test_affine_44(self):

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -734,10 +734,10 @@ class TestAnalyzeImage(tsi.TestSpatialImage, tsi.MmapImageMixin):
         assert_array_equal(np.asanyarray(img2.dataobj), data)
         # now check read_img_data function - here we do see the changed
         # header
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match="from version: 3.2"):
             sc_data = read_img_data(img2)
         assert sc_data.shape == (3, 2, 2)
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match="from version: 3.2"):
             us_data = read_img_data(img2, prefer='unscaled')
         assert us_data.shape == (3, 2, 2)
 

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -2,6 +2,7 @@
 """
 
 import warnings
+import pytest
 
 from nibabel import pkg_info
 from nibabel.deprecated import (ModuleProxy, FutureWarningMixin,
@@ -77,6 +78,7 @@ def test_dev_version():
     try:
         pkg_info.cmp_pkg_version.__defaults__ = ('2.0dev',)
         # No error, even though version is dev version of current
-        assert func() == 99
+        with pytest.deprecated_call():
+            assert func() == 99
     finally:
         pkg_info.cmp_pkg_version.__defaults__ = ('2.0',)

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -4,11 +4,13 @@
 import sys
 import warnings
 from functools import partial
+from textwrap import indent
 
 import pytest
 
 from nibabel.deprecator import (_ensure_cr, _add_dep_doc,
-                                ExpiredDeprecationError, Deprecator)
+                                ExpiredDeprecationError, Deprecator,
+                                TESTSETUP, TESTCLEANUP)
 
 from ..testing import clear_and_catch_warnings
 
@@ -81,7 +83,9 @@ class TestDeprecatorFunc(object):
         with pytest.deprecated_call() as w:
             assert func(1, 2) is None
             assert len(w) == 1
-        assert func.__doc__ == 'A docstring\n   \n   foo\n   \n   Some text\n'
+        assert (func.__doc__ ==
+                f'A docstring\n   \n   foo\n   \n{indent(TESTSETUP, "   ", lambda x: True)}'
+                f'   Some text\n{indent(TESTCLEANUP, "   ", lambda x: True)}')
 
         # Try some since and until versions
         func = dec('foo', '1.1')(func_no_doc)
@@ -110,7 +114,8 @@ class TestDeprecatorFunc(object):
         assert (func.__doc__ ==
                 'A docstring\n   \n   foo\n   \n   * deprecated from version: 1.2\n   '
                 f'* Raises {ExpiredDeprecationError} as of version: 1.8\n   \n'
-                '   Some text\n')
+                f'{indent(TESTSETUP, "   ", lambda x: True)}'
+                f'   Some text\n{indent(TESTCLEANUP, "   ", lambda x: True)}')
         with pytest.raises(ExpiredDeprecationError):
             func()
 

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -239,6 +239,11 @@ class TestEcatImage(TestCase):
         aff[0, 0] = 99
         assert not np.all(img.affine == aff)
 
+    def test_get_affine_deprecated(self):
+        with pytest.deprecated_call():
+            aff = self.img.get_affine()
+        assert np.array_equal(aff, self.img.affine)
+
     def test_float_affine(self):
         # Check affines get converted to float
         img_klass = self.image_class
@@ -248,9 +253,9 @@ class TestEcatImage(TestCase):
                                          self.img.get_subheaders(),
                                          self.img.get_mlist())
         img = img_klass(arr, aff.astype(np.float32), hdr, sub_hdr, mlist)
-        assert img.get_affine().dtype == np.dtype(np.float64)
+        assert img.affine.dtype == np.dtype(np.float64)
         img = img_klass(arr, aff.astype(np.int16), hdr, sub_hdr, mlist)
-        assert img.get_affine().dtype == np.dtype(np.float64)
+        assert img.affine.dtype == np.dtype(np.float64)
 
     def test_data_regression(self):
         # Test whether data read has changed since 1.3.0

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -240,7 +240,7 @@ class TestEcatImage(TestCase):
         assert not np.all(img.affine == aff)
 
     def test_get_affine_deprecated(self):
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match="from version: 2.1"):
             aff = self.img.get_affine()
         assert np.array_equal(aff, self.img.affine)
 

--- a/nibabel/tests/test_filehandles.py
+++ b/nibabel/tests/test_filehandles.py
@@ -5,7 +5,7 @@ Check that loading an image does not use up filehandles.
 from os.path import join as pjoin
 import shutil
 from tempfile import mkdtemp
-from warnings import warn
+import unittest
 
 import numpy as np
 
@@ -21,13 +21,11 @@ from ..loadsave import load, save
 from ..nifti1 import Nifti1Image
 
 
+@unittest.skipIf(SOFT_LIMIT > 4900, "It would take too long to test filehandles")
 def test_multiload():
     # Make a tiny image, save, load many times.  If we are leaking filehandles,
     # this will cause us to run out and generate an error
     N = SOFT_LIMIT + 100
-    if N > 5000:
-        warn('It would take too long to test file handles, aborting')
-        return
     arr = np.arange(24).reshape((2, 3, 4))
     img = Nifti1Image(arr, np.eye(4))
     imgs = []

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -58,7 +58,7 @@ from .test_brikhead import EXAMPLE_IMAGES as AFNI_EXAMPLE_IMAGES
 
 
 def maybe_deprecated(meth_name):
-    return pytest.deprecated_call() if meth_name =='get_data' else nullcontext()
+    return pytest.deprecated_call() if meth_name == 'get_data' else nullcontext()
 
 
 class GenericImageAPI(ValidateAPI):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -26,6 +26,7 @@ What is the image API?
 import warnings
 from functools import partial
 from itertools import product
+from contextlib import nullcontext
 import pathlib
 
 import numpy as np
@@ -55,6 +56,11 @@ from .test_minc1 import EXAMPLE_IMAGES as MINC1_EXAMPLE_IMAGES
 from .test_minc2 import EXAMPLE_IMAGES as MINC2_EXAMPLE_IMAGES
 from .test_parrec import EXAMPLE_IMAGES as PARREC_EXAMPLE_IMAGES
 from .test_brikhead import EXAMPLE_IMAGES as AFNI_EXAMPLE_IMAGES
+
+
+def maybe_deprecated(meth_name):
+    return pytest.deprecated_call() if meth_name =='get_data' else nullcontext()
+
 
 class GenericImageAPI(ValidateAPI):
     """ General image validation API """
@@ -221,14 +227,17 @@ class DataInterfaceMixin(GetSetDtypeMixin):
                 self._check_proxy_interface(imaker, meth_name)
             else:  # Array image
                 self._check_array_interface(imaker, meth_name)
+            method = getattr(img, meth_name)
             # Data shape is same as image shape
-            assert img.shape == getattr(img, meth_name)().shape
+            with maybe_deprecated(meth_name):
+                assert img.shape == method().shape
             # Data ndim is same as image ndim
-            assert img.ndim == getattr(img, meth_name)().ndim
+            with maybe_deprecated(meth_name):
+                assert img.ndim == method().ndim
             # Values to get_data caching parameter must be 'fill' or
             # 'unchanged'
-            with pytest.raises(ValueError):
-                img.get_data(caching='something')
+            with maybe_deprecated(meth_name), pytest.raises(ValueError):
+                method(caching='something')
         # dataobj is read only
         fake_data = np.zeros(img.shape).astype(img.get_data_dtype())
         with pytest.raises(AttributeError):
@@ -251,11 +260,13 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         assert not img.in_memory
         # Load with caching='unchanged'
         method = getattr(img, meth_name)
-        data = method(caching='unchanged')
+        with maybe_deprecated(meth_name):
+            data = method(caching='unchanged')
         # Still not cached
         assert not img.in_memory
         # Default load, does caching
-        data = method()
+        with maybe_deprecated(meth_name):
+            data = method()
         # Data now cached. in_memory is True if either of the get_data
         # or get_fdata caches are not-None
         assert img.in_memory
@@ -267,10 +278,12 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         # integers, but lets assume that's not true here.
         assert_array_equal(proxy_data, data)
         # Now caching='unchanged' does nothing, returns cached version
-        data_again = method(caching='unchanged')
+        with maybe_deprecated(meth_name):
+            data_again = method(caching='unchanged')
         assert data is data_again
         # caching='fill' does nothing because the cache is already full
-        data_yet_again = method(caching='fill')
+        with maybe_deprecated(meth_name):
+            data_yet_again = method(caching='fill')
         assert data is data_yet_again
         # changing array data does not change proxy data, or reloaded
         # data
@@ -278,19 +291,23 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         assert_array_equal(proxy_data, proxy_copy)
         assert_array_equal(np.asarray(img.dataobj), proxy_copy)
         # It does change the result of get_data
-        assert_array_equal(method(), 42)
+        with maybe_deprecated(meth_name):
+            assert_array_equal(method(), 42)
         # until we uncache
         img.uncache()
         # Which unsets in_memory
         assert not img.in_memory
-        assert_array_equal(method(), proxy_copy)
+        with maybe_deprecated(meth_name):
+            assert_array_equal(method(), proxy_copy)
         # Check caching='fill' does cache data
         img = imaker()
         method = getattr(img, meth_name)
         assert not img.in_memory
-        data = method(caching='fill')
+        with maybe_deprecated(meth_name):
+            data = method(caching='fill')
         assert img.in_memory
-        data_again = method()
+        with maybe_deprecated(meth_name):
+            data_again = method()
         assert data is data_again
         # Check the interaction of caching with get_data, get_fdata.
         # Caching for `get_data` should have no effect on caching for
@@ -300,14 +317,17 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         # Load using the other data fetch method
         other_name = set(self.meth_names).difference({meth_name}).pop()
         other_method = getattr(img, other_name)
-        other_data = other_method()
+        with maybe_deprecated(other_name):
+            other_data = other_method()
         # We get the original data, not the modified cache
         assert_array_equal(proxy_data, other_data)
         assert not np.all(data == other_data)
         # We can modify the other cache, without affecting the first
         other_data[:] = 44
-        assert_array_equal(other_method(), 44)
-        assert not np.all(method() == other_method())
+        with maybe_deprecated(other_name):
+            assert_array_equal(other_method(), 44)
+        with pytest.deprecated_call():
+            assert not np.all(method() == other_method())
         if meth_name != 'get_fdata':
             return
         # Check that caching refreshes for new floating point type.
@@ -353,7 +373,8 @@ class DataInterfaceMixin(GetSetDtypeMixin):
                          partial(method, caching=caching))
         assert isinstance(img.dataobj, np.ndarray)
         assert img.in_memory
-        data = get_data_func()
+        with maybe_deprecated(meth_name):
+            data = get_data_func()
         # Returned data same object as underlying dataobj if using
         # old ``get_data`` method, or using newer ``get_fdata``
         # method, where original array was float64.
@@ -361,9 +382,9 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         dataobj_is_data = arr_dtype == np.float64 or method == img.get_data
         # Set something to the output array.
         data[:] = 42
-        get_result_changed = np.all(get_data_func() == 42)
-        assert (get_result_changed ==
-                     (dataobj_is_data or caching != 'unchanged'))
+        with maybe_deprecated(meth_name):
+            get_result_changed = np.all(get_data_func() == 42)
+        assert get_result_changed == (dataobj_is_data or caching != 'unchanged')
         if dataobj_is_data:
             assert data is img.dataobj
             # Changing array data changes
@@ -371,13 +392,15 @@ class DataInterfaceMixin(GetSetDtypeMixin):
             assert_array_equal(np.asarray(img.dataobj), 42)
             # Uncache has no effect
             img.uncache()
-            assert_array_equal(get_data_func(), 42)
+            with maybe_deprecated(meth_name):
+                assert_array_equal(get_data_func(), 42)
         else:
             assert not data is img.dataobj
             assert not np.all(np.asarray(img.dataobj) == 42)
             # Uncache does have an effect
             img.uncache()
-            assert not np.all(get_data_func() == 42)
+            with maybe_deprecated(meth_name):
+                assert not np.all(get_data_func() == 42)
         # in_memory is always true for array images, regardless of
         # cache state.
         img.uncache()
@@ -390,7 +413,8 @@ class DataInterfaceMixin(GetSetDtypeMixin):
         if arr_dtype not in float_types:
             return
         for float_type in float_types:
-            data = get_data_func(dtype=float_type)
+            with maybe_deprecated(meth_name):
+                data = get_data_func(dtype=float_type)
             assert (data is img.dataobj) == (arr_dtype == float_type)
 
     def validate_data_deprecated(self, imaker, params):
@@ -711,7 +735,7 @@ class TestMinc1API(ImageHeaderAPI):
 
 class TestMinc2API(TestMinc1API):
 
-    def __init__(self):
+    def setup(self):
         if not have_h5py:
             raise unittest.SkipTest('Need h5py for these tests')
 

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -26,7 +26,6 @@ What is the image API?
 import warnings
 from functools import partial
 from itertools import product
-from contextlib import nullcontext
 import pathlib
 
 import numpy as np
@@ -46,8 +45,8 @@ import unittest
 import pytest
 
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_warns, assert_allclose
-from ..testing import (bytesio_round_trip, bytesio_filemap,
-                       assert_data_similar, clear_and_catch_warnings)
+from nibabel.testing import (bytesio_round_trip, bytesio_filemap, assert_data_similar,
+                             clear_and_catch_warnings, nullcontext)
 from ..tmpdirs import InTemporaryDirectory
 from ..deprecator import ExpiredDeprecationError
 

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -42,13 +42,15 @@ def test_read_img_data():
             fpath = pathlib.Path(fpath)
         img = load(fpath)
         data = img.get_fdata()
-        data2 = read_img_data(img)
+        with pytest.deprecated_call():
+            data2 = read_img_data(img)
         assert_array_equal(data, data2)
         # These examples have null scaling - assert prefer=unscaled is the same
         dao = img.dataobj
         if hasattr(dao, 'slope') and hasattr(img.header, 'raw_data_from_fileobj'):
             assert (dao.slope, dao.inter) == (1, 0)
-            assert_array_equal(read_img_data(img, prefer='unscaled'), data)
+            with pytest.deprecated_call():
+                assert_array_equal(read_img_data(img, prefer='unscaled'), data)
         # Assert all caps filename works as well
         with TemporaryDirectory() as tmpdir:
             up_fpath = pjoin(tmpdir, str(fname).upper())
@@ -86,21 +88,22 @@ def test_read_img_data_nifti():
             img = img_class(data, np.eye(4))
             img.set_data_dtype(out_dtype)
             # No filemap => error
-            with pytest.raises(ImageFileError):
+            with pytest.deprecated_call(), pytest.raises(ImageFileError):
                 read_img_data(img)
             # Make a filemap
             froot = f'an_image_{i}'
             img.file_map = img.filespec_to_file_map(froot)
             # Trying to read from this filemap will generate an error because
             # we are going to read from files that do not exist
-            with pytest.raises(IOError):
+            with pytest.deprecated_call(), pytest.raises(IOError):
                 read_img_data(img)
             img.to_file_map()
             # Load - now the scaling and offset correctly applied
             img_fname = img.file_map['image'].filename
             img_back = load(img_fname)
             data_back = img_back.get_fdata()
-            assert_array_equal(data_back, read_img_data(img_back))
+            with pytest.deprecated_call():
+                assert_array_equal(data_back, read_img_data(img_back))
             # This is the same as if we loaded the image and header separately
             hdr_fname = (img.file_map['header'].filename
                          if 'header' in img.file_map else img_fname)
@@ -112,15 +115,17 @@ def test_read_img_data_nifti():
             # Unscaled is the same as returned from raw_data_from_fileobj
             with open(img_fname, 'rb') as fobj:
                 unscaled_back = hdr_back.raw_data_from_fileobj(fobj)
-            assert_array_equal(unscaled_back,
-                               read_img_data(img_back, prefer='unscaled'))
+            with pytest.deprecated_call():
+                assert_array_equal(unscaled_back, read_img_data(img_back, prefer='unscaled'))
             # If we futz with the scaling in the header, the result changes
-            assert_array_equal(data_back, read_img_data(img_back))
+            with pytest.deprecated_call():
+                assert_array_equal(data_back, read_img_data(img_back))
             has_inter = hdr_back.has_data_intercept
             old_slope = hdr_back['scl_slope']
             old_inter = hdr_back['scl_inter'] if has_inter else 0
             est_unscaled = (data_back - old_inter) / old_slope
-            actual_unscaled = read_img_data(img_back, prefer='unscaled')
+            with pytest.deprecated_call():
+                actual_unscaled = read_img_data(img_back, prefer='unscaled')
             assert_almost_equal(est_unscaled, actual_unscaled)
             img_back.header['scl_slope'] = 2.1
             if has_inter:
@@ -129,11 +134,13 @@ def test_read_img_data_nifti():
             else:
                 new_inter = 0
             # scaled scaling comes from new parameters in header
-            assert np.allclose(actual_unscaled * 2.1 + new_inter,
-                                    read_img_data(img_back))
+            with pytest.deprecated_call():
+                assert np.allclose(actual_unscaled * 2.1 + new_inter,
+                                   read_img_data(img_back))
             # Unscaled array didn't change
-            assert_array_equal(actual_unscaled,
-                               read_img_data(img_back, prefer='unscaled'))
+            with pytest.deprecated_call():
+                assert_array_equal(actual_unscaled,
+                                   read_img_data(img_back, prefer='unscaled'))
             # Check the offset too
             img.header.set_data_offset(1024)
             # Delete arrays still pointing to file, so Windows can re-use
@@ -144,12 +151,14 @@ def test_read_img_data_nifti():
                 fobj.write(b'\x00\x00')
             img_back = load(img_fname)
             data_back = img_back.get_fdata()
-            assert_array_equal(data_back, read_img_data(img_back))
+            with pytest.deprecated_call():
+                assert_array_equal(data_back, read_img_data(img_back))
             img_back.header.set_data_offset(1026)
             # Check we pick up new offset
             exp_offset = np.zeros((data.size,), data.dtype) + old_inter
             exp_offset[:-1] = np.ravel(data_back, order='F')[1:]
             exp_offset = np.reshape(exp_offset, shape, order='F')
-            assert_array_equal(exp_offset, read_img_data(img_back))
+            with pytest.deprecated_call():
+                assert_array_equal(exp_offset, read_img_data(img_back))
             # Delete stuff that might hold onto file references
             del img, img_back, data_back

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -134,6 +134,8 @@ class _TestMincFile(object):
             assert_array_equal(mnc.get_affine(), tp['affine'])
             data = mnc.get_scaled_data()
             assert data.shape == tp['shape']
+            # Can't close mmapped NetCDF with live mmap arrays
+            del mnc, data
 
     def test_mincfile_slicing(self):
         # Test slicing and scaling of mincfile data
@@ -151,6 +153,8 @@ class _TestMincFile(object):
                              ):
                 sliced_data = mnc.get_scaled_data(slicedef)
                 assert_array_equal(sliced_data, data[slicedef])
+            # Can't close mmapped NetCDF with live mmap arrays
+            del mnc, data
 
     def test_load(self):
         # Check highest level load of minc works

--- a/nibabel/tests/test_minc2_data.py
+++ b/nibabel/tests/test_minc2_data.py
@@ -71,8 +71,7 @@ class TestEPIFrame(object):
         assert_almost_equal(data.mean(), self.example_params['mean'], 4)
         # check if mnc can be converted to nifti
         ni_img = Nifti1Image.from_image(img)
-        assert_almost_equal(ni_img.get_affine(),
-                            self.example_params['affine'], 2)
+        assert_almost_equal(ni_img.affine, self.example_params['affine'], 2)
         assert_array_equal(ni_img.get_fdata(), data)
 
 

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -42,6 +42,8 @@ from ..testing import (
     bytesio_filemap,
     bytesio_round_trip
 )
+
+import unittest
 import pytest
 
 from . import test_analyze as tana
@@ -50,8 +52,8 @@ from . import test_spm99analyze as tspm
 header_file = os.path.join(data_path, 'nifti1.hdr')
 image_file = os.path.join(data_path, 'example4d.nii.gz')
 
-from ..pydicom_compat import pydicom
-from ..nicom.tests import dicom_test
+from ..pydicom_compat import pydicom, have_dicom
+dicom_test = unittest.skipUnless(have_dicom, "Could not import dicom or pydicom")
 
 
 # Example transformation matrix
@@ -591,14 +593,15 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         hdr2.set_dim_info(slice=2)
         hdr2.set_slice_duration(0.1)
         hdr2.set_data_shape((1, 1, 2))
-        with clear_and_catch_warnings() as w:
-            warnings.simplefilter("always")
+        with pytest.warns(UserWarning) as w:
             hdr2.set_slice_times([0.1, 0])
             assert len(w) == 1
         # but always must be choosing sequential one first
         assert hdr2.get_value_label('slice_code') == 'sequential decreasing'
         # and the other direction
-        hdr2.set_slice_times([0, 0.1])
+        with pytest.warns(UserWarning) as w:
+            hdr2.set_slice_times([0, 0.1])
+            assert len(w) == 1
         assert hdr2.get_value_label('slice_code') == 'sequential increasing'
 
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -670,9 +670,13 @@ def test_header_copy():
         with pytest.raises(PARRECError):
             PARRECHeader.from_fileobj(fobj)
     with open(TRUNC_PAR, 'rt') as fobj:
-        trunc_hdr = PARRECHeader.from_fileobj(fobj, True)
+        # Parse but warn on inconsistent header
+        with pytest.warns(UserWarning):
+            trunc_hdr = PARRECHeader.from_fileobj(fobj, True)
     assert trunc_hdr.permit_truncated
-    trunc_hdr2 = trunc_hdr.copy()
+    # Warn on inconsistent header when copying
+    with pytest.warns(UserWarning):
+        trunc_hdr2 = trunc_hdr.copy()
     assert_copy_ok(trunc_hdr, trunc_hdr2)
 
 
@@ -712,11 +716,14 @@ def test_image_creation():
             func(trunc_param)
         with pytest.raises(PARRECError):
             func(trunc_param, permit_truncated=False)
-        img = func(trunc_param, permit_truncated=True)
+        with pytest.warns(UserWarning):
+            img = func(trunc_param, permit_truncated=True)
         assert_array_equal(img.dataobj, arr_prox_dv)
-        img = func(trunc_param, permit_truncated=True, scaling='dv')
+        with pytest.warns(UserWarning):
+            img = func(trunc_param, permit_truncated=True, scaling='dv')
         assert_array_equal(img.dataobj, arr_prox_dv)
-        img = func(trunc_param, permit_truncated=True, scaling='fp')
+        with pytest.warns(UserWarning):
+            img = func(trunc_param, permit_truncated=True, scaling='fp')
         assert_array_equal(img.dataobj, arr_prox_fp)
 
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -671,11 +671,11 @@ def test_header_copy():
             PARRECHeader.from_fileobj(fobj)
     with open(TRUNC_PAR, 'rt') as fobj:
         # Parse but warn on inconsistent header
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Header inconsistency"):
             trunc_hdr = PARRECHeader.from_fileobj(fobj, True)
     assert trunc_hdr.permit_truncated
     # Warn on inconsistent header when copying
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match="Header inconsistency"):
         trunc_hdr2 = trunc_hdr.copy()
     assert_copy_ok(trunc_hdr, trunc_hdr2)
 
@@ -716,13 +716,13 @@ def test_image_creation():
             func(trunc_param)
         with pytest.raises(PARRECError):
             func(trunc_param, permit_truncated=False)
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Header inconsistency"):
             img = func(trunc_param, permit_truncated=True)
         assert_array_equal(img.dataobj, arr_prox_dv)
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Header inconsistency"):
             img = func(trunc_param, permit_truncated=True, scaling='dv')
         assert_array_equal(img.dataobj, arr_prox_dv)
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match="Header inconsistency"):
             img = func(trunc_param, permit_truncated=True, scaling='fp')
         assert_array_equal(img.dataobj, arr_prox_fp)
 

--- a/nibabel/tests/test_processing.py
+++ b/nibabel/tests/test_processing.py
@@ -148,7 +148,7 @@ def test_resample_from_to(caplog):
     exp_out[1:, :, :] = data[1, :, :]
     assert_almost_equal(out.dataobj, exp_out)
     out = resample_from_to(img, trans_p_25_img)
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # Suppress scipy warning
         exp_out = spnd.affine_transform(data, [1, 1, 1], [-0.25, 0, 0], order=3)
     assert_almost_equal(out.dataobj, exp_out)
     # Test cval
@@ -161,7 +161,7 @@ def test_resample_from_to(caplog):
     assert out.__class__ == Nifti1Image
     # By default, type of from_img makes no difference
     n1_img = Nifti2Image(data, affine)
-    with caplog.at_level(logging.CRITICAL):
+    with caplog.at_level(logging.CRITICAL):  # Here and below, suppress logs when changing classes
         out = resample_from_to(n1_img, trans_img)
     assert out.__class__ == Nifti1Image
     # Passed as keyword arg
@@ -254,7 +254,7 @@ def test_resample_to_output(caplog):
     assert_array_equal(out_img.dataobj, np.flipud(data))
     # Subsample voxels
     out_img = resample_to_output(Nifti1Image(data, np.diag([4, 5, 6, 1])))
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # Suppress scipy warning
         exp_out = spnd.affine_transform(data,
                                         [1/4, 1/5, 1/6],
                                         output_shape = (5, 11, 19))
@@ -293,7 +293,7 @@ def test_resample_to_output(caplog):
     img_ni1 = Nifti2Image(data, np.eye(4))
     img_ni2 = Nifti2Image(data, np.eye(4))
     # Default is Nifti1Image
-    with caplog.at_level(logging.CRITICAL):
+    with caplog.at_level(logging.CRITICAL):  # Here and below, suppress logs when changing classes
         assert resample_to_output(img_ni2).__class__ == Nifti1Image
     # Can be overriden
     with caplog.at_level(logging.CRITICAL):
@@ -349,7 +349,7 @@ def test_smooth_image(caplog):
     img_ni1 = Nifti1Image(data, np.eye(4))
     img_ni2 = Nifti2Image(data, np.eye(4))
     # Default is Nifti1Image
-    with caplog.at_level(logging.CRITICAL):
+    with caplog.at_level(logging.CRITICAL):  # Here and below, suppress logs when changing classes
         assert smooth_image(img_ni2, 0).__class__ == Nifti1Image
     # Can be overriden
     with caplog.at_level(logging.CRITICAL):
@@ -362,7 +362,7 @@ def test_smooth_image(caplog):
 def test_spatial_axes_check(caplog):
     for fname in MINC_3DS + OTHER_IMGS:
         img = nib.load(pjoin(DATA_DIR, fname))
-        with caplog.at_level(logging.CRITICAL):
+        with caplog.at_level(logging.CRITICAL):  # Suppress logs when changing classes
             s_img = smooth_image(img, 0)
         assert_array_equal(img.dataobj, s_img.dataobj)
         with caplog.at_level(logging.CRITICAL):
@@ -447,7 +447,7 @@ def test_conform(caplog):
     assert isinstance(c, Nifti1Image)
 
     # Test with non-default arguments.
-    with caplog.at_level(logging.CRITICAL):
+    with caplog.at_level(logging.CRITICAL):  # Suppress logs when changing classes
         c = conform(anat, out_shape=(100, 100, 200), voxel_size=(2, 2, 1.5),
                     orientation="LPI", out_class=Nifti2Image)
     assert c.shape == (100, 100, 200)

--- a/nibabel/tests/test_round_trip.py
+++ b/nibabel/tests/test_round_trip.py
@@ -13,7 +13,7 @@ from ..casting import best_float, ulp, type_info
 
 from numpy.testing import assert_array_equal
 
-DEBUG = True
+DEBUG = False
 
 
 def round_trip(arr, out_dtype):

--- a/nibabel/tests/test_scaling.py
+++ b/nibabel/tests/test_scaling.py
@@ -9,6 +9,7 @@
 """ Test for scaling / rounding in volumeutils module """
 
 import numpy as np
+import warnings
 
 from io import BytesIO
 from ..volumeutils import finite_range, apply_read_scaling, array_to_file, array_from_file
@@ -199,7 +200,7 @@ def check_int_a2f(in_type, out_type):
         scale, inter, mn, mx = _calculate_scale(data, out_type, True)
     except ValueError as e:
         if DEBUG:
-            print(in_type, out_type, e)
+            warnings.warn(str((in_type, out_type, e)))
         return
     array_to_file(data, str_io, out_type, 0, inter, scale, mn, mx)
     data_back = array_from_file(data.shape, out_type, str_io)

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -107,13 +107,13 @@ def check_nib_diff_examples():
 
 @pytest.mark.parametrize("args", [
     [],
-    [['-H', 'dim,bitpix'], " \[  4 128  96  24   2   1   1   1\] 16"],
+    [['-H', 'dim,bitpix'], r" \[  4 128  96  24   2   1   1   1\] 16"],
     [['-c'], "", " !1030 uniques. Use --all-counts"],
     [['-c', '--all-counts'], "", " 2:3 3:2 4:1 5:1.*"],
     # both stats and counts
-    [['-c', '-s', '--all-counts'], "", " \[229725\] \[2, 1.2e\+03\] 2:3 3:2 4:1 5:1.*"],
+    [['-c', '-s', '--all-counts'], "", r" \[229725\] \[2, 1.2e\+03\] 2:3 3:2 4:1 5:1.*"],
     # and must not error out if we allow for zeros
-    [['-c', '-s', '-z', '--all-counts'], "", " \[589824\] \[0, 1.2e\+03\] 0:360099 2:3 3:2 4:1 5:1.*"],
+    [['-c', '-s', '-z', '--all-counts'], "", r" \[589824\] \[0, 1.2e\+03\] 0:360099 2:3 3:2 4:1 5:1.*"],
 ])
 @script_test
 def test_nib_ls(args):
@@ -136,8 +136,8 @@ def test_nib_ls_multiple():
     # they should be indented correctly.  Since all files are int type -
     ln = max(len(f) for f in fnames)
     i_str = ' i' if sys.byteorder == 'little' else ' <i'
-    assert ([l[ln:ln + len(i_str)] for l in stdout_lines] == [i_str] * 4,
-            f"Type sub-string didn't start with '{i_str}'. Full output was: {stdout_lines}")
+    assert [l[ln:ln + len(i_str)] for l in stdout_lines] == [i_str] * 4, \
+            f"Type sub-string didn't start with '{i_str}'. Full output was: {stdout_lines}"
     # and if disregard type indicator which might vary
     assert (
         [l[l.index('['):] for l in stdout_lines] ==
@@ -436,7 +436,7 @@ def test_nib_trk2tck():
         assert os.path.isfile(simple_tck)
         trk = nib.streamlines.load(simple_trk)
         tck = nib.streamlines.load(simple_tck)
-        assert (tck.streamlines.data == trk.streamlines.data).all()
+        assert (tck.streamlines.get_data() == trk.streamlines.get_data()).all()
         assert isinstance(tck, nib.streamlines.TckFile)
 
         # Skip non TRK files.
@@ -455,7 +455,7 @@ def test_nib_trk2tck():
         assert len(stdout) == 0
         trk = nib.streamlines.load(standard_trk)
         tck = nib.streamlines.load(standard_tck)
-        assert (tck.streamlines.data == trk.streamlines.data).all()
+        assert (tck.streamlines.get_data() == trk.streamlines.get_data()).all()
 
 
 @script_test
@@ -482,7 +482,7 @@ def test_nib_tck2trk():
         assert os.path.isfile(standard_trk)
         tck = nib.streamlines.load(standard_tck)
         trk = nib.streamlines.load(standard_trk)
-        assert (trk.streamlines.data == tck.streamlines.data).all()
+        assert (trk.streamlines.get_data() == tck.streamlines.get_data()).all()
         assert isinstance(trk, nib.streamlines.TrkFile)
 
         # Skip non TCK files.
@@ -501,4 +501,4 @@ def test_nib_tck2trk():
         assert len(stdout) == 0
         tck = nib.streamlines.load(standard_tck)
         trk = nib.streamlines.load(standard_trk)
-        assert (tck.streamlines.data == trk.streamlines.data).all()
+        assert (tck.streamlines.get_data() == trk.streamlines.get_data()).all()

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -35,23 +35,23 @@ from .. import load as top_load
 
 def test_header_init():
     # test the basic header
-    hdr = Header()
+    hdr = SpatialHeader()
     assert hdr.get_data_dtype() == np.dtype(np.float32)
     assert hdr.get_data_shape() == (0,)
     assert hdr.get_zooms() == (1.0,)
-    hdr = Header(np.float64)
+    hdr = SpatialHeader(np.float64)
     assert hdr.get_data_dtype() == np.dtype(np.float64)
     assert hdr.get_data_shape() == (0,)
     assert hdr.get_zooms() == (1.0,)
-    hdr = Header(np.float64, shape=(1, 2, 3))
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3))
     assert hdr.get_data_dtype() == np.dtype(np.float64)
     assert hdr.get_data_shape() == (1, 2, 3)
     assert hdr.get_zooms() == (1.0, 1.0, 1.0)
-    hdr = Header(np.float64, shape=(1, 2, 3), zooms=None)
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3), zooms=None)
     assert hdr.get_data_dtype() == np.dtype(np.float64)
     assert hdr.get_data_shape() == (1, 2, 3)
     assert hdr.get_zooms() == (1.0, 1.0, 1.0)
-    hdr = Header(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
     assert hdr.get_data_dtype() == np.dtype(np.float64)
     assert hdr.get_data_shape() == (1, 2, 3)
     assert hdr.get_zooms() == (3.0, 2.0, 1.0)
@@ -60,12 +60,12 @@ def test_header_init():
 def test_from_header():
     # check from header class method.  Note equality checks below,
     # equality methods used here too.
-    empty = Header.from_header()
-    assert Header() == empty
-    empty = Header.from_header(None)
-    assert Header() == empty
-    hdr = Header(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
-    copy = Header.from_header(hdr)
+    empty = SpatialHeader.from_header()
+    assert SpatialHeader() == empty
+    empty = SpatialHeader.from_header(None)
+    assert SpatialHeader() == empty
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
+    copy = SpatialHeader.from_header(hdr)
     assert hdr == copy
     assert hdr is not copy
 
@@ -76,31 +76,31 @@ def test_from_header():
         def get_data_shape(self): return (5, 4, 3)
 
         def get_zooms(self): return (10.0, 9.0, 8.0)
-    converted = Header.from_header(C())
-    assert isinstance(converted, Header)
+    converted = SpatialHeader.from_header(C())
+    assert isinstance(converted, SpatialHeader)
     assert converted.get_data_dtype() == np.dtype('u2')
     assert converted.get_data_shape() == (5, 4, 3)
     assert converted.get_zooms() == (10.0, 9.0, 8.0)
 
 
 def test_eq():
-    hdr = Header()
-    other = Header()
+    hdr = SpatialHeader()
+    other = SpatialHeader()
     assert hdr == other
-    other = Header('u2')
+    other = SpatialHeader('u2')
     assert hdr != other
-    other = Header(shape=(1, 2, 3))
+    other = SpatialHeader(shape=(1, 2, 3))
     assert hdr != other
-    hdr = Header(shape=(1, 2))
-    other = Header(shape=(1, 2))
+    hdr = SpatialHeader(shape=(1, 2))
+    other = SpatialHeader(shape=(1, 2))
     assert hdr == other
-    other = Header(shape=(1, 2), zooms=(2.0, 3.0))
+    other = SpatialHeader(shape=(1, 2), zooms=(2.0, 3.0))
     assert hdr != other
 
 
 def test_copy():
     # test that copy makes independent copy
-    hdr = Header(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
     hdr_copy = hdr.copy()
     hdr.set_data_shape((4, 5, 6))
     assert hdr.get_data_shape() == (4, 5, 6)
@@ -114,7 +114,7 @@ def test_copy():
 
 
 def test_shape_zooms():
-    hdr = Header()
+    hdr = SpatialHeader()
     hdr.set_data_shape((1, 2, 3))
     assert hdr.get_data_shape() == (1, 2, 3)
     assert hdr.get_zooms() == (1.0, 1.0, 1.0)
@@ -141,7 +141,7 @@ def test_shape_zooms():
 
 
 def test_data_dtype():
-    hdr = Header()
+    hdr = SpatialHeader()
     assert hdr.get_data_dtype() == np.dtype(np.float32)
     hdr.set_data_dtype(np.float64)
     assert hdr.get_data_dtype() == np.dtype(np.float64)
@@ -150,7 +150,7 @@ def test_data_dtype():
 
 
 def test_affine():
-    hdr = Header(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
+    hdr = SpatialHeader(np.float64, shape=(1, 2, 3), zooms=(3.0, 2.0, 1.0))
     assert_array_almost_equal(hdr.get_best_affine(),
                               [[-3.0, 0, 0, 0],
                                [0, 2, 0, -1],

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -517,12 +517,11 @@ class TestSpatialImage(TestCase):
                 img.slicer[[0], [-1]]
 
             # Check data is consistent with slicing numpy arrays
-            slice_elems = (None, Ellipsis, 0, 1, -1, [0], [1], [-1],
-                           slice(None), slice(1), slice(-1), slice(1, -1))
+            slice_elems = np.array((None, Ellipsis, 0, 1, -1, [0], [1], [-1],
+                                    slice(None), slice(1), slice(-1), slice(1, -1)), dtype=object)
             for n_elems in range(6):
                 for _ in range(1 if n_elems == 0 else 10):
-                    sliceobj = tuple(
-                        np.random.choice(slice_elems, n_elems).tolist())
+                    sliceobj = tuple(np.random.choice(slice_elems, n_elems))
                     try:
                         sliced_img = img.slicer[sliceobj]
                     except (IndexError, ValueError):

--- a/nibabel/tests/test_trackvis.py
+++ b/nibabel/tests/test_trackvis.py
@@ -12,6 +12,13 @@ from ..volumeutils import native_code, swapped_code
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def module_deprecated():
+    with pytest.deprecated_call():
+        yield
+
+
 def test_write():
     streams = []
     out_f = BytesIO()

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -20,7 +20,6 @@ import gzip
 import bz2
 import threading
 import time
-from contextlib import nullcontext
 
 import numpy as np
 
@@ -58,7 +57,7 @@ from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
 import pytest
 
-from ..testing import assert_dt_equal, assert_allclose_safely, suppress_warnings
+from nibabel.testing import nullcontext, assert_dt_equal, assert_allclose_safely, suppress_warnings
 
 #: convenience variables for numpy types
 FLOAT_TYPES = np.sctypes['float']

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -20,6 +20,7 @@ import gzip
 import bz2
 import threading
 import time
+from contextlib import nullcontext
 
 import numpy as np
 
@@ -620,11 +621,16 @@ def test_a2f_bad_scaling():
             (0, np.nan, -np.inf, np.inf)):
         arr = np.ones((2,), dtype=in_type)
         fobj = BytesIO()
+        cm = nullcontext()
+        if (np.issubdtype(in_type, np.complexfloating) and
+                not np.issubdtype(out_type, np.complexfloating)):
+            cm = pytest.warns(np.ComplexWarning)
         if (slope, inter) == (1, 0):
-            assert_array_equal(arr,
-                               write_return(arr, fobj, out_type,
-                                            intercept=inter,
-                                            divslope=slope))
+            with cm:
+                assert_array_equal(arr,
+                                   write_return(arr, fobj, out_type,
+                                                intercept=inter,
+                                                divslope=slope))
         elif (slope, inter) == (None, 0):
             assert_array_equal(0,
                                write_return(arr, fobj, out_type,
@@ -663,34 +669,42 @@ def test_a2f_nan2zero_range():
         arr = np.array([-1, 0, 1, np.nan], dtype=dt)
         # Error occurs for arrays without nans too
         arr_no_nan = np.array([-1, 0, 1, 2], dtype=dt)
+        warn_type = np.ComplexWarning if np.issubdtype(dt, np.complexfloating) else None
         # No errors from explicit thresholding
         # mn thresholding excluding zero
-        assert_array_equal([1, 1, 1, 0],
-                           write_return(arr, fobj, np.int8, mn=1))
+        with pytest.warns(warn_type):
+            assert_array_equal([1, 1, 1, 0],
+                               write_return(arr, fobj, np.int8, mn=1))
         # mx thresholding excluding zero
-        assert_array_equal([-1, -1, -1, 0],
-                           write_return(arr, fobj, np.int8, mx=-1))
+        with pytest.warns(warn_type):
+            assert_array_equal([-1, -1, -1, 0],
+                               write_return(arr, fobj, np.int8, mx=-1))
         # Errors from datatype threshold after scaling
-        back_arr = write_return(arr, fobj, np.int8, intercept=128)
+        with pytest.warns(warn_type):
+            back_arr = write_return(arr, fobj, np.int8, intercept=128)
         assert_array_equal([-128, -128, -127, -128], back_arr)
         with pytest.raises(ValueError):
             write_return(arr, fobj, np.int8, intercept=129)
         with pytest.raises(ValueError):
             write_return(arr_no_nan, fobj, np.int8, intercept=129)
         # OK with nan2zero false, but we get whatever nan casts to
-        nan_cast = np.array(np.nan, dtype=dt).astype(np.int8)
-        back_arr = write_return(arr, fobj, np.int8, intercept=129, nan2zero=False)
+        with pytest.warns(warn_type):
+            nan_cast = np.array(np.nan, dtype=dt).astype(np.int8)
+        with pytest.warns(warn_type):
+            back_arr = write_return(arr, fobj, np.int8, intercept=129, nan2zero=False)
         assert_array_equal([-128, -128, -128, nan_cast], back_arr)
         # divslope
-        back_arr = write_return(arr, fobj, np.int8, intercept=256, divslope=2)
+        with pytest.warns(warn_type):
+            back_arr = write_return(arr, fobj, np.int8, intercept=256, divslope=2)
         assert_array_equal([-128, -128, -128, -128], back_arr)
         with pytest.raises(ValueError):
             write_return(arr, fobj, np.int8, intercept=257.1, divslope=2)
         with pytest.raises(ValueError):
             write_return(arr_no_nan, fobj, np.int8, intercept=257.1, divslope=2)
         # OK with nan2zero false
-        back_arr = write_return(arr, fobj, np.int8,
-                                intercept=257.1, divslope=2, nan2zero=False)
+        with pytest.warns(warn_type):
+            back_arr = write_return(arr, fobj, np.int8,
+                                    intercept=257.1, divslope=2, nan2zero=False)
         assert_array_equal([-128, -128, -128, nan_cast], back_arr)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ test =
     coverage
     pytest !=5.3.4
     pytest-cov
+    pytest-doctestplus
 all =
     %(dicomfs)s
     %(dev)s


### PR DESCRIPTION
Tests are currently generating a huge number of warnings, which makes outputs less informative than they could be.

Will add subdirectories soon, but want to get CI going to make sure I'm not breaking things.