### PR TITLE
FIX: Change reader to also support tck files from mrtrix3-dev tckedit

### DIFF
--- a/nibabel/streamlines/tck.py
+++ b/nibabel/streamlines/tck.py
@@ -319,7 +319,8 @@ class TckFile(TractogramFile):
             offset_data = f.tell()
 
         # Build header dictionary from the buffer.
-        hdr = dict(item.split(': ') for item in buf.rstrip().split('\n')[:-1])
+        hdr = dict(item.split(': ') for item in buf.rstrip().split('\n')
+                   if ': ' in item)
         hdr[Field.MAGIC_NUMBER] = magic_number
 
         # Check integrity of TCK header.


### PR DESCRIPTION
The mrtrix3-dev and 3Tissue versions added a new `"END"` string to the header of tck files that come out of `tckedit`. This was causing an error in the tck reader. This fix will be compatible with new and old versions of the tck file format.