### PR TITLE
BUG: Use manager to set title

### DIFF
--- a/nibabel/viewers.py
+++ b/nibabel/viewers.py
@@ -119,7 +119,7 @@ class OrthoSlicer3D(object):
                 fig.delaxes(self._axes[3])
                 self._axes.pop(-1)
             if self._title is not None:
-                fig.canvas.set_window_title(str(title))
+                fig.canvas.manager.set_window_title(str(title))
         else:
             self._axes = [axes[0], axes[1], axes[2]]
             if len(axes) > 3:


### PR DESCRIPTION
Deal with mpl deprecation:
```
  File "/home/larsoner/python/nibabel/nibabel/viewers.py", line 122, in __init__
    fig.canvas.set_window_title(str(title))
  File "/home/larsoner/python/matplotlib/lib/matplotlib/cbook/deprecation.py", line 233, in wrapper
    _warn_external(warning)
  File "/home/larsoner/python/matplotlib/lib/matplotlib/cbook/__init__.py", line 2120, in _warn_external
    warnings.warn(message, category, stacklevel)
matplotlib.cbook.deprecation.MatplotlibDeprecationWarning: 
The set_window_title function was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Use manager.set_window_title or GUI-specific methods instead.
```