### PR TITLE
CI: Test on Python 3.9 with numpy nightly wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - arch: arm64
       python: 3.6
       env:
-        - DEPENDS="numpy"
+        - DEPENDS="numpy scipy pillow pydicom"
         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     # Basic dependencies only
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ env:
         - DEPENDS="numpy scipy matplotlib h5py pillow pydicom indexed_gzip"
         - INSTALL_TYPE="setup"
         - CHECK_TYPE="test"
-        - EXTRA_WHEELS="https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com"
         - NIGHTLY_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
-        - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
-        - PRE_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --extra-index-url $NIGHTLY_WHEELS"
+        - PRE_PIP_FLAGS="--pre --extra-index-url $NIGHTLY_WHEELS"
 
 python:
     - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,11 @@ jobs:
     - python: 3.8
       env:
         - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
+    # test 3.9 against pre-release builds of numpy
+    - python: 3.9
+      env:
+        - DEPENDS="numpy"
+        - EXTRA_PIP_FLAGS="$PRE_PIP_FLAGS"
     # OSX Python support is basically accidental. Take whatever version we can
     # get and test with full dependencies...
     - os: osx

--- a/nibabel/externals/netcdf.py
+++ b/nibabel/externals/netcdf.py
@@ -219,7 +219,7 @@ class netcdf_file(object):
 
         >>> data = time[:]
         >>> data.base.base  # doctest: +ELLIPSIS
-        <mmap.mmap object at 0x...>
+        <mmap.mmap ...>
 
     If the data is to be processed after the file is closed, it needs
     to be copied to main memory:

--- a/nibabel/nicom/ascconv.py
+++ b/nibabel/nicom/ascconv.py
@@ -89,7 +89,10 @@ def assign2atoms(assign_ast, default_class=int):
             target = target.value
             prev_target_type = OrderedDict
         elif isinstance(target, ast.Subscript):
-            index = target.slice.value.n
+            if isinstance(target.slice, ast.Constant):  # PY39
+                index = target.slice.n
+            else:  # PY38
+                index = target.slice.value.n
             atoms.append(Atom(target, prev_target_type, index))
             target = target.value
             prev_target_type = list


### PR DESCRIPTION
Still waiting on Python 3.9 on Travis and 3.9 wheels for most dependencies, but 3.9-dev is around and there are some nightly wheels on https://anaconda.org/scipy-wheels-nightly/. Might as well find out how we do with them.