### PR TITLE
FIX: NumPy float deprecation

### DIFF
--- a/doc/source/old/ioimplementation.rst
+++ b/doc/source/old/ioimplementation.rst
@@ -101,10 +101,10 @@ By use case.
     >>> mod_data[0,0] = 99
     >>> np.all(img4.data = mod_data)
     True
-    
+
     Prepare image for later writing
 
-    >>> img5 = Image(np.zeros(2,3,4)) 
+    >>> img5 = Image(np.zeros(2,3,4))
     >>> fp, fname2 = tempfile.mkstemp('.nii')
     >>> img5.set_filespec(fname2)
     >>> # then do some things to the image
@@ -115,7 +115,7 @@ By use case.
     >>> from nibabel.ioimps import guessed_imp
     >>> fp, fname3 = tempfile.mkstemp('.nii')
     >>> ioimp = guessed_imp(fname3)
-    >>> ioimp.set_data_dtype(np.float)
+    >>> ioimp.set_data_dtype(np.float64)
     >>> ioimp.set_data_shape((2,3,4)) # set_data_shape method
     >>> slice_def = (slice(None), slice(None), 0)
     >>> ioimp.write_slice(data[slice_def], slice_def) # write_slice method
@@ -124,6 +124,3 @@ By use case.
     Traceback (most recent call last):
        ...
     ImageIOError: data write is not contiguous
-    
-    
-    

--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -517,28 +517,28 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             vertices = self.struct_state[-1]
-            vertices.extend(np.loadtxt(c, dtype=np.int, ndmin=1))
+            vertices.extend(np.loadtxt(c, dtype=int, ndmin=1))
             c.close()
 
         elif self.write_to == 'VoxelIndices':
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             parent = self.struct_state[-1]
-            parent.voxel_indices_ijk.extend(np.loadtxt(c, dtype=np.int).reshape(-1, 3))
+            parent.voxel_indices_ijk.extend(np.loadtxt(c, dtype=int).reshape(-1, 3))
             c.close()
 
         elif self.write_to == 'VertexIndices':
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             index = self.struct_state[-1]
-            index.extend(np.loadtxt(c, dtype=np.int, ndmin=1))
+            index.extend(np.loadtxt(c, dtype=int, ndmin=1))
             c.close()
 
         elif self.write_to == 'TransformMatrix':
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             transform = self.struct_state[-1]
-            transform.matrix = np.loadtxt(c, dtype=np.float)
+            transform.matrix = np.loadtxt(c, dtype=np.float64)
             c.close()
 
         elif self.write_to == 'Label':

--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -49,7 +49,7 @@ def _fread3_many(fobj, n):
         An array of 3 byte int
     """
     b1, b2, b3 = np.fromfile(fobj, ">u1", 3 * n).reshape(-1,
-                                                         3).astype(np.int).T
+                                                         3).astype(int).T
     return (b1 << 16) + (b2 << 8) + b3
 
 
@@ -148,14 +148,14 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
             nvert = _fread3(fobj)
             nquad = _fread3(fobj)
             (fmt, div) = (">i2", 100.) if magic == QUAD_MAGIC else (">f4", 1.)
-            coords = np.fromfile(fobj, fmt, nvert * 3).astype(np.float) / div
+            coords = np.fromfile(fobj, fmt, nvert * 3).astype(np.float64) / div
             coords = coords.reshape(-1, 3)
             quads = _fread3_many(fobj, nquad * 4)
             quads = quads.reshape(nquad, 4)
             #
             #   Face splitting follows
             #
-            faces = np.zeros((2 * nquad, 3), dtype=np.int)
+            faces = np.zeros((2 * nquad, 3), dtype=int)
             nface = 0
             for quad in quads:
                 if (quad[0] % 2) == 0:
@@ -182,7 +182,7 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
         else:
             raise ValueError("File does not appear to be a Freesurfer surface")
 
-    coords = coords.astype(np.float)  # XXX: due to mayavi bug on mac 32bits
+    coords = coords.astype(np.float64)  # XXX: due to mayavi bug on mac 32bits
 
     ret = (coords, faces)
     if read_metadata:
@@ -589,7 +589,7 @@ def read_label(filepath, read_scalars=False):
         Only returned if `read_scalars` is True.  Array of scalar data for each
         vertex.
     """
-    label_array = np.loadtxt(filepath, dtype=np.int, skiprows=2, usecols=[0])
+    label_array = np.loadtxt(filepath, dtype=int, skiprows=2, usecols=[0])
     if read_scalars:
         scalar_array = np.loadtxt(filepath, skiprows=2, usecols=[-1])
         return label_array, scalar_array

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -157,7 +157,7 @@ def test_write_morph_data():
         with pytest.raises(ValueError):
             write_morph_data('test.curv', np.zeros(shape), big_num)
         # Windows 32-bit overflows Python int
-        if np.dtype(np.int) != np.dtype(np.int32):
+        if np.dtype(int) != np.dtype(np.int32):
             with pytest.raises(ValueError):
                 write_morph_data('test.curv',  strided_scalar((big_num,)))
         for shape in bad_shapes:

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -137,7 +137,7 @@ class Minc1File(object):
         if valid_range[0] < info.min or valid_range[1] > info.max:
             raise ValueError('Valid range outside input '
                              'data type range')
-        return np.asarray(valid_range, dtype=np.float)
+        return np.asarray(valid_range, dtype=np.float64)
 
     def _get_scalar(self, var):
         """ Get scalar value from NetCDF scalar """

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -101,7 +101,7 @@ class Minc2File(Minc1File):
             if valid_range[0] < info.min or valid_range[1] > info.max:
                 raise ValueError('Valid range outside input '
                                  'data type range')
-        return np.asarray(valid_range, dtype=np.float)
+        return np.asarray(valid_range, dtype=np.float64)
 
     def _get_scalar(self, var):
         """ Get scalar value from HDF5 scalar """

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -28,8 +28,8 @@ they are applied on the left of the vector.  For example:
 import math
 import numpy as np
 
-MAX_FLOAT = np.maximum_sctype(np.float)
-FLOAT_EPS = np.finfo(np.float).eps
+MAX_FLOAT = np.maximum_sctype(float)
+FLOAT_EPS = np.finfo(float).eps
 
 
 def fillpositive(xyz, w2_thresh=None):
@@ -43,7 +43,7 @@ def fillpositive(xyz, w2_thresh=None):
        threshold to determine if w squared is really negative.
        If None (default) then w2_thresh set equal to
        ``-np.finfo(xyz.dtype).eps``, if possible, otherwise
-       ``-np.finfo(np.float).eps``
+       ``-np.finfo(np.float64).eps``
 
     Returns
     -------

--- a/nibabel/tests/test_arraywriters.py
+++ b/nibabel/tests/test_arraywriters.py
@@ -468,7 +468,7 @@ def test_io_scaling():
 
 def test_input_ranges():
     # Test we get good precision for a range of input data
-    arr = np.arange(-500, 501, 10, dtype=np.float)
+    arr = np.arange(-500, 501, 10, dtype=np.float64)
     bio = BytesIO()
     working_type = np.float32
     work_eps = np.finfo(working_type).eps
@@ -542,7 +542,7 @@ def test_nan2zero():
 def test_byte_orders():
     arr = np.arange(10, dtype=np.int32)
     # Test endian read/write of types not requiring scaling
-    for tp in (np.uint64, np.float, np.complex):
+    for tp in (np.uint64, np.float64, np.complex128):
         dt = np.dtype(tp)
         for code in '<>':
             ndt = dt.newbyteorder(code)
@@ -554,7 +554,7 @@ def test_byte_orders():
 
 
 def test_writers_roundtrip():
-    ndt = np.dtype(np.float)
+    ndt = np.dtype(np.float64)
     arr = np.arange(3, dtype=ndt)
     # intercept
     aw = SlopeInterArrayWriter(arr, ndt, calc_scale=False)
@@ -831,7 +831,7 @@ def test_finite_range_nan():
         ([np.inf, 1], (1, 1)),  # only look at finite values
         ([-np.inf, 1], (1, 1)),
         ([[], []], (np.inf, -np.inf)),  # empty array
-        (np.array([[-3, 0, 1], [2, -1, 4]], dtype=np.int), (-3, 4)),
+        (np.array([[-3, 0, 1], [2, -1, 4]], dtype=int), (-3, 4)),
         (np.array([[1, 0, 1], [2, 3, 4]], dtype=np.uint), (0, 4)),
         ([0., 1, 2, 3], (0, 3)),
         # Complex comparison works as if they are floats
@@ -859,7 +859,7 @@ def test_finite_range_nan():
                 # Check float types work as complex
                 in_arr = np.array(in_arr)
                 if in_arr.dtype.kind == 'f':
-                    c_arr = in_arr.astype(np.complex)
+                    c_arr = in_arr.astype(np.complex128)
                     try:
                         aw = awt(c_arr, out_type, **kwargs)
                     except WriterError:

--- a/nibabel/tests/test_euler.py
+++ b/nibabel/tests/test_euler.py
@@ -18,7 +18,7 @@ from .. import quaternions as nq
 import pytest
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-FLOAT_EPS = np.finfo(np.float).eps
+FLOAT_EPS = np.finfo(np.float64).eps
 
 # Example rotations """
 eg_rots = []

--- a/nibabel/tests/test_proxy_api.py
+++ b/nibabel/tests/test_proxy_api.py
@@ -66,7 +66,7 @@ from .test_parrec import EG_REC, VARY_REC
 
 def _some_slicers(shape):
     ndim = len(shape)
-    slicers = np.eye(ndim).astype(np.int).astype(object)
+    slicers = np.eye(ndim).astype(int).astype(object)
     slicers[slicers == 0] = slice(None)
     for i in range(ndim):
         if i % 2:

--- a/nibabel/tests/test_scaling.py
+++ b/nibabel/tests/test_scaling.py
@@ -43,7 +43,7 @@ DEBUG = True
     ([np.inf, 1], (1, 1)),  # only look at finite values
     ([-np.inf, 1], (1, 1)),
     ([[], []], (np.inf, -np.inf)),  # empty array
-    (np.array([[-3, 0, 1], [2, -1, 4]], dtype=np.int), (-3, 4)),
+    (np.array([[-3, 0, 1], [2, -1, 4]], dtype=int), (-3, 4)),
     (np.array([[1, 0, 1], [2, 3, 4]], dtype=np.uint), (0, 4)),
     ([0., 1, 2, 3], (0, 3)),
     # Complex comparison works as if they are floats
@@ -64,7 +64,7 @@ def test_finite_range(in_arr, res):
     assert finite_range(flat_arr, True) == res + (has_nan,)
     # Check float types work as complex
     if in_arr.dtype.kind == 'f':
-        c_arr = in_arr.astype(np.complex)
+        c_arr = in_arr.astype(np.complex128)
         assert finite_range(c_arr) == res
         assert finite_range(c_arr, True) == res + (has_nan,)
 
@@ -181,7 +181,7 @@ def test_scaling_in_abstract(category0, category1, overflow):
 
 def check_int_a2f(in_type, out_type):
     # Check that array to / from file returns roughly the same as input
-    big_floater = np.maximum_sctype(np.float)
+    big_floater = np.maximum_sctype(np.float64)
     info = type_info(in_type)
     this_min, this_max = info['min'], info['max']
     if not in_type in np.sctypes['complex']:

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -23,7 +23,7 @@ def test_assert_allclose_safely():
     # Broadcastable matrices
     a = np.ones((2, 3))
     b = np.ones((3, 2, 3))
-    eps = np.finfo(np.float).eps
+    eps = np.finfo(np.float64).eps
     a[0, 0] = 1 + eps
     assert_allclose_safely(a, b)
     a[0, 0] = 1 + 1.1e-5

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -182,7 +182,7 @@ def test_array_from_file_mmap():
     # Test memory mapping
     shape = (2, 21)
     with InTemporaryDirectory():
-        for dt in (np.int16, np.float):
+        for dt in (np.int16, np.float64):
             arr = np.arange(np.prod(shape), dtype=dt).reshape(shape)
             with open('test.bin', 'wb') as fobj:
                 fobj.write(arr.tobytes(order='F'))
@@ -299,7 +299,7 @@ def test_array_from_file_reread():
 def test_array_to_file():
     arr = np.arange(10).reshape(5, 2)
     str_io = BytesIO()
-    for tp in (np.uint64, np.float, np.complex):
+    for tp in (np.uint64, np.float64, np.complex128):
         dt = np.dtype(tp)
         for code in '<>':
             ndt = dt.newbyteorder(code)
@@ -365,10 +365,10 @@ def test_a2f_min_max():
             assert_array_equal(data_back, [1, 1, 2, 2])
     # Check that works OK with scaling and intercept
     arr = np.arange(4, dtype=np.float32)
-    data_back = write_return(arr, str_io, np.int, 0, -1, 0.5, 1, 2)
+    data_back = write_return(arr, str_io, int, 0, -1, 0.5, 1, 2)
     assert_array_equal(data_back * 0.5 - 1, [1, 1, 2, 2])
     # Even when scaling is negative
-    data_back = write_return(arr, str_io, np.int, 0, 1, -0.5, 1, 2)
+    data_back = write_return(arr, str_io, int, 0, 1, -0.5, 1, 2)
     assert_array_equal(data_back * -0.5 + 1, [1, 1, 2, 2])
     # Check complex numbers
     arr = np.arange(4, dtype=np.complex64) + 100j
@@ -378,7 +378,7 @@ def test_a2f_min_max():
 
 
 def test_a2f_order():
-    ndt = np.dtype(np.float)
+    ndt = np.dtype(np.float64)
     arr = np.array([0.0, 1.0, 2.0])
     str_io = BytesIO()
     # order makes no difference in 1D case
@@ -393,7 +393,7 @@ def test_a2f_order():
 
 
 def test_a2f_nan2zero():
-    ndt = np.dtype(np.float)
+    ndt = np.dtype(np.float64)
     str_io = BytesIO()
     # nans set to 0 for integer output case, not float
     arr = np.array([[np.nan, 0], [0, np.nan]])
@@ -448,15 +448,15 @@ def test_a2f_offset():
     arr = np.array([[0.0, 1.0], [2.0, 3.0]])
     str_io = BytesIO()
     str_io.write(b'a' * 42)
-    array_to_file(arr, str_io, np.float, 42)
-    data_back = array_from_file(arr.shape, np.float, str_io, 42)
-    assert_array_equal(data_back, arr.astype(np.float))
+    array_to_file(arr, str_io, np.float64, 42)
+    data_back = array_from_file(arr.shape, np.float64, str_io, 42)
+    assert_array_equal(data_back, arr.astype(np.float64))
     # And that offset=None respected
     str_io.truncate(22)
     str_io.seek(22)
-    array_to_file(arr, str_io, np.float, None)
-    data_back = array_from_file(arr.shape, np.float, str_io, 22)
-    assert_array_equal(data_back, arr.astype(np.float))
+    array_to_file(arr, str_io, np.float64, None)
+    data_back = array_from_file(arr.shape, np.float64, str_io, 22)
+    assert_array_equal(data_back, arr.astype(np.float64))
 
 
 def test_a2f_dtype_default():
@@ -1138,7 +1138,7 @@ def test_dtypes():
     dtr = make_dt_codes(dt_defs)
     assert dtr[np.dtype('f4').newbyteorder('S')] == 16
     assert dtr.value_set() == set((16,))
-    assert dtr.fields == ('code', 'label', 'type', 'niistring', 'dtype', 
+    assert dtr.fields == ('code', 'label', 'type', 'niistring', 'dtype',
                           'sw_dtype')
     assert dtr.niistring[16] == 'ASTRING'
     # And that unequal elements raises error

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -1386,7 +1386,7 @@ def finite_range(arr, check_nan=False):
     >>> a = np.array([[np.nan],[np.nan]])
     >>> finite_range(a) == (np.inf, -np.inf)
     True
-    >>> a = np.array([[-3, 0, 1],[2,-1,4]], dtype=np.int)
+    >>> a = np.array([[-3, 0, 1],[2,-1,4]], dtype=int)
     >>> finite_range(a)
     (-3, 4)
     >>> a = np.array([[1, 0, 1],[2,3,4]], dtype=np.uint)


### PR DESCRIPTION
Gets rid of these warnings:
```
../nibabel/nibabel/quaternions.py:32
  /home/larsoner/python/nibabel/nibabel/quaternions.py:32: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. Use `float` by itself, which is identical in behavior, to silence this warning. If you specifically wanted the numpy scalar type, use `np.float_` here.
    FLOAT_EPS = np.finfo(np.float).eps
```
A quick `git grep "np\.float[^_63]" | wc -l ` suggests there are ~41 others to change, and probably 21 for `np.int` (and none for `np.bool`). If this seems like the correct fix, I can go through and fix the others (unless someone else wants to!).

Closes #950