### PR TITLE
TEST: Use more constrained mock when testing optpkg

### DIFF
--- a/nibabel/tests/test_optpkg.py
+++ b/nibabel/tests/test_optpkg.py
@@ -39,14 +39,14 @@ def test_basic():
     # We never have package _not_a_package
     assert_bad('_not_a_package')
 
-    # setup_module imports unittest, so make sure we don't disrupt that
+    # Only disrupt imports for "nottriedbefore" package
     orig_import = builtins.__import__
     def raise_Exception(*args, **kwargs):
-        if args[0] == 'unittest':
-            return orig_import(*args, **kwargs)
-        raise Exception(
-            "non ImportError could be thrown by some malfunctioning module "
-            "upon import, and optional_package should catch it too")
+        if args[0] == 'nottriedbefore':
+            raise Exception(
+                "non ImportError could be thrown by some malfunctioning module "
+                "upon import, and optional_package should catch it too")
+        return orig_import(*args, **kwargs)
     with mock.patch.object(builtins, '__import__', side_effect=raise_Exception):
         assert_bad('nottriedbefore')
 


### PR DESCRIPTION
The existing mock raised errors on any import except a whitelisted unittest. Because old versions of pytest monkeypatched the Python interpreter and then performed imports within the patched functions, this breaks in Pytest 3.10. Move to an import that blacklists the specific module we're testing, which should be more resilient to test runner interference.

Fixes #982.