### PR TITLE
NF: Add zstd compression support

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -95,6 +95,7 @@ from .spatialimages import (HeaderDataError, HeaderTypeError,
 from .fileholders import copy_file_map
 from .batteryrunners import Report
 from .arrayproxy import ArrayProxy
+from .openers import HAVE_ZSTD
 
 # Sub-parts of standard analyze header from
 # Mayo dbh.h file
@@ -907,11 +908,8 @@ class AnalyzeImage(SpatialImage):
     files_types = (('image', '.img'), ('header', '.hdr'))
     valid_exts = ('.img', '.hdr')
     _compressed_suffixes = ('.gz', '.bz2')
-    try: # If pyzstd installed., add .zst suffix
-        import pyzstd
+    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
         _compressed_suffixes = (*_compressed_suffixes, '.zst')
-    except ImportError:
-        pass
 
     makeable = True
     rw = True

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -95,7 +95,6 @@ from .spatialimages import (HeaderDataError, HeaderTypeError,
 from .fileholders import copy_file_map
 from .batteryrunners import Report
 from .arrayproxy import ArrayProxy
-from .openers import HAVE_ZSTD
 
 # Sub-parts of standard analyze header from
 # Mayo dbh.h file
@@ -907,9 +906,7 @@ class AnalyzeImage(SpatialImage):
     _meta_sniff_len = header_class.sizeof_hdr
     files_types = (('image', '.img'), ('header', '.hdr'))
     valid_exts = ('.img', '.hdr')
-    _compressed_suffixes = ('.gz', '.bz2')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
     makeable = True
     rw = True

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -907,6 +907,11 @@ class AnalyzeImage(SpatialImage):
     files_types = (('image', '.img'), ('header', '.hdr'))
     valid_exts = ('.img', '.hdr')
     _compressed_suffixes = ('.gz', '.bz2')
+    try: # If pyzstd installed., add .zst suffix
+        import pyzstd
+        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    except ImportError:
+        pass
 
     makeable = True
     rw = True

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -19,6 +19,12 @@ from ..fileslice import fileslice
 from ..rstutils import rst_table
 from ..tmpdirs import InTemporaryDirectory
 
+try:
+    import pyzstd
+    ZSTD_INSTALLED = True
+except ImportError:
+    ZSTD_INSTALLED = False
+
 SHAPE = (64, 64, 32, 100)
 ROW_NAMES = [f'axis {i}, len {dim}' for i, dim in enumerate(SHAPE)]
 COL_NAMES = ['mid int',
@@ -70,7 +76,8 @@ def run_slices(file_like, repeat=3, offset=0, order='F'):
 def bench_fileslice(bytes=True,
                     file_=True,
                     gz=True,
-                    bz2=False):
+                    bz2=False,
+                    zst=True):
     sys.stdout.flush()
     repeat = 2
 
@@ -103,4 +110,11 @@ def bench_fileslice(bytes=True,
         my_table('bz2 slice - raw (ratio)',
                  np.dstack((bz2_times, bz2_times / bz2_base)),
                  bz2_base)
+    if ZSTD_INSTALLED:
+        if zst:
+            with InTemporaryDirectory():
+                zst_times, zst_base = run_slices('data.zst', repeat)
+            my_table('zst slice - raw (ratio)',
+                    np.dstack((zst_times, zst_times / zst_base)),
+                    zst_base)
     sys.stdout.flush()

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -14,16 +14,10 @@ from timeit import timeit
 import numpy as np
 
 from io import BytesIO
-from ..openers import ImageOpener
+from ..openers import ImageOpener, HAVE_ZSTD
 from ..fileslice import fileslice
 from ..rstutils import rst_table
 from ..tmpdirs import InTemporaryDirectory
-
-try:
-    import pyzstd
-    ZSTD_INSTALLED = True
-except ImportError:
-    ZSTD_INSTALLED = False
 
 SHAPE = (64, 64, 32, 100)
 ROW_NAMES = [f'axis {i}, len {dim}' for i, dim in enumerate(SHAPE)]
@@ -110,7 +104,7 @@ def bench_fileslice(bytes=True,
         my_table('bz2 slice - raw (ratio)',
                  np.dstack((bz2_times, bz2_times / bz2_base)),
                  bz2_base)
-    if ZSTD_INSTALLED:
+    if HAVE_ZSTD:
         if zst:
             with InTemporaryDirectory():
                 zst_times, zst_base = run_slices('data.zst', repeat)

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -109,6 +109,6 @@ def bench_fileslice(bytes=True,
             with InTemporaryDirectory():
                 zst_times, zst_base = run_slices('data.zst', repeat)
             my_table('zst slice - raw (ratio)',
-                    np.dstack((zst_times, zst_times / zst_base)),
-                    zst_base)
+                     np.dstack((zst_times, zst_times / zst_base)),
+                     zst_base)
     sys.stdout.flush()

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -14,10 +14,11 @@ from timeit import timeit
 import numpy as np
 
 from io import BytesIO
-from ..openers import ImageOpener, HAVE_ZSTD
+from ..openers import ImageOpener
 from ..fileslice import fileslice
 from ..rstutils import rst_table
 from ..tmpdirs import InTemporaryDirectory
+from ..optpkg import optional_package
 
 SHAPE = (64, 64, 32, 100)
 ROW_NAMES = [f'axis {i}, len {dim}' for i, dim in enumerate(SHAPE)]
@@ -25,6 +26,7 @@ COL_NAMES = ['mid int',
              'step 1',
              'half step 1',
              'step mid int']
+HAVE_ZSTD = optional_package("pyzstd")[1]
 
 
 def _slices_for_len(L):
@@ -104,11 +106,10 @@ def bench_fileslice(bytes=True,
         my_table('bz2 slice - raw (ratio)',
                  np.dstack((bz2_times, bz2_times / bz2_base)),
                  bz2_base)
-    if HAVE_ZSTD:
-        if zst:
-            with InTemporaryDirectory():
-                zst_times, zst_base = run_slices('data.zst', repeat)
-            my_table('zst slice - raw (ratio)',
-                     np.dstack((zst_times, zst_times / zst_base)),
-                     zst_base)
+    if zst and HAVE_ZSTD:
+        with InTemporaryDirectory():
+            zst_times, zst_base = run_slices('data.zst', repeat)
+        my_table('zst slice - raw (ratio)',
+                 np.dstack((zst_times, zst_times / zst_base)),
+                 zst_base)
     sys.stdout.flush()

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -43,6 +43,7 @@ from .spatialimages import (
     ImageDataError
 )
 from .volumeutils import Recoder
+from .openers import HAVE_ZSTD
 
 # used for doc-tests
 filepath = os.path.dirname(os.path.realpath(__file__))
@@ -491,14 +492,11 @@ class AFNIImage(SpatialImage):
     valid_exts = ('.brik', '.head')
     files_types = (('image', '.brik'), ('header', '.head'))
     _compressed_suffixes = ('.gz', '.bz2', '.Z')
+    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
+        _compressed_suffixes = (*_compressed_suffixes, '.zst')
     makeable = False
     rw = False
     ImageArrayProxy = AFNIArrayProxy
-    try: # If pyzstd installed., add .zst suffix
-        import pyzstd
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
-    except ImportError:
-        pass
 
     @classmethod
     def from_file_map(klass, file_map, *, mmap=True, keep_file_open=None):

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -43,7 +43,6 @@ from .spatialimages import (
     ImageDataError
 )
 from .volumeutils import Recoder
-from .openers import HAVE_ZSTD
 
 # used for doc-tests
 filepath = os.path.dirname(os.path.realpath(__file__))
@@ -491,9 +490,7 @@ class AFNIImage(SpatialImage):
     header_class = AFNIHeader
     valid_exts = ('.brik', '.head')
     files_types = (('image', '.brik'), ('header', '.head'))
-    _compressed_suffixes = ('.gz', '.bz2', '.Z')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.Z', '.zst')
     makeable = False
     rw = False
     ImageArrayProxy = AFNIArrayProxy

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -494,6 +494,11 @@ class AFNIImage(SpatialImage):
     makeable = False
     rw = False
     ImageArrayProxy = AFNIArrayProxy
+    try: # If pyzstd installed., add .zst suffix
+        import pyzstd
+        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    except ImportError:
+        pass
 
     @classmethod
     def from_file_map(klass, file_map, *, mmap=True, keep_file_open=None):

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -13,18 +13,15 @@ import os
 import numpy as np
 
 from .filename_parser import splitext_addext, _stringify_path
-from .openers import ImageOpener
+from .openers import ImageOpener, HAVE_ZSTD
 from .filebasedimages import ImageFileError
 from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .deprecated import deprecate_with_version
 
 _compressed_suffixes = ('.gz', '.bz2')
-try: # If pyzstd installed., add .zst suffix
-    import pyzstd
+if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
     _compressed_suffixes = (*_compressed_suffixes, '.zst')
-except ImportError:
-    pass
 
 def load(filename, **kwargs):
     r""" Load file given filename, guessing at file type

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -23,6 +23,7 @@ _compressed_suffixes = ('.gz', '.bz2')
 if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
     _compressed_suffixes = (*_compressed_suffixes, '.zst')
 
+
 def load(filename, **kwargs):
     r""" Load file given filename, guessing at file type
 

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -13,15 +13,13 @@ import os
 import numpy as np
 
 from .filename_parser import splitext_addext, _stringify_path
-from .openers import ImageOpener, HAVE_ZSTD
+from .openers import ImageOpener
 from .filebasedimages import ImageFileError
 from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .deprecated import deprecate_with_version
 
-_compressed_suffixes = ('.gz', '.bz2')
-if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-    _compressed_suffixes = (*_compressed_suffixes, '.zst')
+_compressed_suffixes = ('.gz', '.bz2', '.zst')
 
 
 def load(filename, **kwargs):

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -19,6 +19,12 @@ from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .deprecated import deprecate_with_version
 
+_compressed_suffixes = ('.gz', '.bz2')
+try: # If pyzstd installed., add .zst suffix
+    import pyzstd
+    _compressed_suffixes = (*_compressed_suffixes, '.zst')
+except ImportError:
+    pass
 
 def load(filename, **kwargs):
     r""" Load file given filename, guessing at file type
@@ -103,7 +109,7 @@ def save(img, filename):
         return
 
     # Be nice to users by making common implicit conversions
-    froot, ext, trailing = splitext_addext(filename, ('.gz', '.bz2'))
+    froot, ext, trailing = splitext_addext(filename, _compressed_suffixes)
     lext = ext.lower()
 
     # Special-case Nifti singles and Pairs

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -317,6 +317,11 @@ class Minc1Image(SpatialImage):
     valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
     _compressed_suffixes = ('.gz', '.bz2')
+    try: # If pyzstd installed., add .zst suffix
+        import pyzstd
+        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    except ImportError:
+        pass
 
     makeable = True
     rw = False

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -16,6 +16,7 @@ from .externals.netcdf import netcdf_file
 
 from .spatialimages import SpatialHeader, SpatialImage
 from .fileslice import canonical_slicers
+from .openers import HAVE_ZSTD
 
 _dt_dict = {
     ('b', 'unsigned'): np.uint8,
@@ -317,11 +318,8 @@ class Minc1Image(SpatialImage):
     valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
     _compressed_suffixes = ('.gz', '.bz2')
-    try: # If pyzstd installed., add .zst suffix
-        import pyzstd
+    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
         _compressed_suffixes = (*_compressed_suffixes, '.zst')
-    except ImportError:
-        pass
 
     makeable = True
     rw = False

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -16,7 +16,6 @@ from .externals.netcdf import netcdf_file
 
 from .spatialimages import SpatialHeader, SpatialImage
 from .fileslice import canonical_slicers
-from .openers import HAVE_ZSTD
 
 _dt_dict = {
     ('b', 'unsigned'): np.uint8,
@@ -317,9 +316,7 @@ class Minc1Image(SpatialImage):
     _meta_sniff_len = 4
     valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
-    _compressed_suffixes = ('.gz', '.bz2')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
     makeable = True
     rw = False

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -42,8 +42,9 @@ except ImportError:
 # Enable .zst support if pyzstd installed.
 try:
     from pyzstd import ZstdFile
+    HAVE_ZSTD = True
 except ImportError:
-    pass
+    HAVE_ZSTD = False
 
 def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
 
@@ -82,19 +83,21 @@ class Opener(object):
     """
     gz_def = (_gzip_open, ('mode', 'compresslevel', 'keep_open'))
     bz2_def = (BZ2File, ('mode', 'buffering', 'compresslevel'))
-    zstd_def = (ZstdFile, ('mode', 'level_or_option'))
     compress_ext_map = {
         '.gz': gz_def,
         '.bz2': bz2_def,
-        '.zst': zstd_def,
         None: (open, ('mode', 'buffering'))  # default
     }
+    if HAVE_ZSTD:  # add zst to ext map, if library exists
+        zstd_def = (ZstdFile, ('mode', 'level_or_option'))
+        compress_ext_map['.zst'] = zstd_def
     #: default compression level when writing gz and bz2 files
     default_compresslevel = 1
     #: default option for zst files
     default_zst_compresslevel = 3
     default_level_or_option = {"rb": None, "r": None,
-        "wb": default_zst_compresslevel, "w": default_zst_compresslevel}
+                               "wb": default_zst_compresslevel,
+                               "w": default_zst_compresslevel}
     #: whether to ignore case looking for compression extensions
     compress_ext_icase = True
 

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -46,6 +46,7 @@ try:
 except ImportError:
     HAVE_ZSTD = False
 
+
 def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
 
     # use indexed_gzip if possible for faster read access.  If keep_open ==

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -30,6 +30,7 @@ from .. import imageglobals
 from ..casting import as_int
 from ..tmpdirs import InTemporaryDirectory
 from ..arraywriters import WriterError
+from ..openers import HAVE_ZSTD
 
 import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal)
@@ -788,6 +789,8 @@ class TestAnalyzeImage(tsi.TestSpatialImage, tsi.MmapImageMixin):
         aff = np.eye(4)
         img_ext = img_klass.files_types[0][1]
         compressed_exts = ['', '.gz', '.bz2']
+        if HAVE_ZSTD:
+            compressed_exts += ['.zst']
         with InTemporaryDirectory():
             for offset in (0, 2048):
                 # Set offset in in-memory image

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -30,7 +30,7 @@ from .. import imageglobals
 from ..casting import as_int
 from ..tmpdirs import InTemporaryDirectory
 from ..arraywriters import WriterError
-from ..openers import HAVE_ZSTD
+from ..optpkg import optional_package
 
 import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal)
@@ -40,6 +40,8 @@ from ..testing import (data_path, suppress_warnings, assert_dt_equal,
 
 from .test_wrapstruct import _TestLabeledWrapStruct
 from . import test_spatialimages as tsi
+
+HAVE_ZSTD = optional_package("pyzstd")[1]
 
 header_file = os.path.join(data_path, 'analyze.hdr')
 

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -22,7 +22,7 @@ from ..externals.netcdf import netcdf_file
 from ..deprecated import ModuleProxy
 from .. import minc1
 from ..minc1 import Minc1File, Minc1Image, MincHeader
-from ..openers import HAVE_ZSTD
+from ..optpkg import optional_package
 
 from ..tmpdirs import InTemporaryDirectory
 from ..deprecator import ExpiredDeprecationError
@@ -33,9 +33,7 @@ import pytest
 from . import test_spatialimages as tsi
 from .test_fileslice import slicer_samples
 
-# only import ZstdFile, if installed
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 EG_FNAME = pjoin(data_path, 'tiny.mnc')
 
@@ -178,7 +176,7 @@ class TestMinc1File(_TestMincFile):
             openers_exts = [(gzip.open, '.gz'),
                             (bz2.BZ2File, '.bz2')]
             if HAVE_ZSTD:  # add .zst to test if installed
-                openers_exts += [(ZstdFile, '.zst')]
+                openers_exts += [(pyzstd.ZstdFile, '.zst')]
             with InTemporaryDirectory():
                 for opener, ext in openers_exts:
                     fname = 'test.mnc' + ext

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -22,6 +22,7 @@ from ..externals.netcdf import netcdf_file
 from ..deprecated import ModuleProxy
 from .. import minc1
 from ..minc1 import Minc1File, Minc1Image, MincHeader
+from ..openers import HAVE_ZSTD
 
 from ..tmpdirs import InTemporaryDirectory
 from ..deprecator import ExpiredDeprecationError
@@ -31,6 +32,10 @@ import pytest
 
 from . import test_spatialimages as tsi
 from .test_fileslice import slicer_samples
+
+# only import ZstdFile, if installed
+if HAVE_ZSTD:
+    from ..openers import ZstdFile
 
 EG_FNAME = pjoin(data_path, 'tiny.mnc')
 
@@ -170,7 +175,10 @@ class TestMinc1File(_TestMincFile):
         # Not so for MINC2; hence this small sub-class
         for tp in self.test_files:
             content = open(tp['fname'], 'rb').read()
-            openers_exts = ((gzip.open, '.gz'), (bz2.BZ2File, '.bz2'))
+            openers_exts = [(gzip.open, '.gz'),
+                            (bz2.BZ2File, '.bz2')]
+            if HAVE_ZSTD:  # add .zst to test if installed
+                openers_exts += [(ZstdFile, '.zst')]
             with InTemporaryDirectory():
                 for opener, ext in openers_exts:
                     fname = 'test.mnc' + ext

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -14,7 +14,11 @@ from io import BytesIO, UnsupportedOperation
 from distutils.version import StrictVersion
 
 from numpy.compat.py3k import asstr, asbytes
-from ..openers import Opener, ImageOpener, HAVE_INDEXED_GZIP, BZ2File
+from ..openers import (Opener,
+                       ImageOpener,
+                       HAVE_INDEXED_GZIP,
+                       BZ2File,
+                       HAVE_ZSTD)
 from ..tmpdirs import InTemporaryDirectory
 from ..volumeutils import BinOpener
 
@@ -22,6 +26,9 @@ import unittest
 from unittest import mock
 import pytest
 from ..testing import error_warnings
+
+if HAVE_ZSTD:
+    from ..openers import ZstdFile
 
 
 class Lunk(object):
@@ -71,10 +78,13 @@ def test_Opener_various():
         import indexed_gzip as igzip
     with InTemporaryDirectory():
         sobj = BytesIO()
-        for input in ('test.txt',
-                      'test.txt.gz',
-                      'test.txt.bz2',
-                      sobj):
+        files_to_test = ['test.txt',
+                         'test.txt.gz',
+                         'test.txt.bz2',
+                         sobj]
+        if HAVE_ZSTD:
+            files_to_test += ['test.txt.zst']
+        for input in files_to_test:
             with Opener(input, 'wb') as fobj:
                 fobj.write(message)
                 assert fobj.tell() == len(message)
@@ -240,6 +250,8 @@ def test_compressed_ext_case():
     class StrictOpener(Opener):
         compress_ext_icase = False
     exts = ('gz', 'bz2', 'GZ', 'gZ', 'BZ2', 'Bz2')
+    if HAVE_ZSTD:
+        exts += ('zst', 'ZST', 'Zst')
     with InTemporaryDirectory():
         # Make a basic file to check type later
         with open(__file__, 'rb') as a_file:
@@ -264,6 +276,8 @@ def test_compressed_ext_case():
                 except ImportError:
                     IndexedGzipFile = GzipFile
                 assert isinstance(fobj.fobj, (GzipFile, IndexedGzipFile))
+            elif lext == 'zst':
+                assert isinstance(fobj.fobj, ZstdFile)
             else:
                 assert isinstance(fobj.fobj, BZ2File)
 
@@ -273,11 +287,14 @@ def test_name():
     sobj = BytesIO()
     lunk = Lunk('in ART')
     with InTemporaryDirectory():
-        for input in ('test.txt',
-                      'test.txt.gz',
-                      'test.txt.bz2',
-                      sobj,
-                      lunk):
+        files_to_test = ['test.txt',
+                         'test.txt.gz',
+                         'test.txt.bz2',
+                         sobj,
+                         lunk]
+        if HAVE_ZSTD:
+            files_to_test += ['test.txt.zst']
+        for input in files_to_test:
             exp_name = input if type(input) == type('') else None
             with Opener(input, 'wb') as fobj:
                 assert fobj.name == exp_name
@@ -329,10 +346,13 @@ virginia
 """.split('\n')
     with InTemporaryDirectory():
         sobj = BytesIO()
-        for input, does_t in (('test.txt', True),
-                              ('test.txt.gz', False),
-                              ('test.txt.bz2', False),
-                              (sobj, True)):
+        files_to_test = [('test.txt', True),
+                         ('test.txt.gz', False),
+                         ('test.txt.bz2', False),
+                         (sobj, True)]
+        if HAVE_ZSTD:
+            files_to_test += [('test.txt.zst', False)]
+        for input, does_t in files_to_test:
             with Opener(input, 'wb') as fobj:
                 for line in lines:
                     fobj.write(asbytes(line + os.linesep))

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -18,17 +18,17 @@ from ..openers import (Opener,
                        ImageOpener,
                        HAVE_INDEXED_GZIP,
                        BZ2File,
-                       HAVE_ZSTD)
+                       )
 from ..tmpdirs import InTemporaryDirectory
 from ..volumeutils import BinOpener
+from ..optpkg import optional_package
 
 import unittest
 from unittest import mock
 import pytest
 from ..testing import error_warnings
 
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 
 class Lunk(object):
@@ -277,7 +277,7 @@ def test_compressed_ext_case():
                     IndexedGzipFile = GzipFile
                 assert isinstance(fobj.fobj, (GzipFile, IndexedGzipFile))
             elif lext == 'zst':
-                assert isinstance(fobj.fobj, ZstdFile)
+                assert isinstance(fobj.fobj, pyzstd.ZstdFile)
             else:
                 assert isinstance(fobj.fobj, BZ2File)
 

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -45,10 +45,11 @@ from ..volumeutils import (array_from_file,
                            _write_data,
                            _ftype4scaled_finite,
                            )
-from ..openers import Opener, BZ2File, HAVE_ZSTD
+from ..openers import Opener, BZ2File
 from ..casting import (floor_log2, type_info, OK_FLOATS, shared_range)
 
 from ..deprecator import ExpiredDeprecationError
+from ..optpkg import optional_package
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
@@ -56,9 +57,7 @@ import pytest
 
 from nibabel.testing import nullcontext, assert_dt_equal, assert_allclose_safely, suppress_warnings
 
-# only import ZstdFile, if installed
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 #: convenience variables for numpy types
 FLOAT_TYPES = np.sctypes['float']
@@ -76,7 +75,7 @@ def test__is_compressed_fobj():
                         ('.gz', gzip.open, True),
                         ('.bz2', BZ2File, True)]
         if HAVE_ZSTD:
-            file_openers += [('.zst', ZstdFile, True)]
+            file_openers += [('.zst', pyzstd.ZstdFile, True)]
         for ext, opener, compressed in file_openers:
             fname = 'test.bin' + ext
             for mode in ('wb', 'rb'):
@@ -100,7 +99,7 @@ def test_fobj_string_assumptions():
     with InTemporaryDirectory():
         openers = [open, gzip.open, BZ2File]
         if HAVE_ZSTD:
-            openers += [ZstdFile]
+            openers += [pyzstd.ZstdFile]
         for n, opener in itertools.product(
                 (256, 1024, 2560, 25600),
                 openers):
@@ -266,7 +265,7 @@ def test_array_from_file_reread():
     with InTemporaryDirectory():
         openers = [open, gzip.open, bz2.BZ2File, BytesIO]
         if HAVE_ZSTD:
-            openers += [ZstdFile]
+            openers += [pyzstd.ZstdFile]
         for shape, opener, dtt, order in itertools.product(
                 ((64,), (64, 65), (64, 65, 66)),
                 openers,

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -19,9 +19,12 @@ from functools import reduce
 import numpy as np
 
 from .casting import shared_range, OK_FLOATS
-from .openers import Opener, BZ2File, IndexedGzipFile, HAVE_ZSTD
+from .openers import Opener, BZ2File, IndexedGzipFile
 from .deprecated import deprecate_with_version
 from .externals.oset import OrderedSet
+from .optpkg import optional_package
+
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 sys_is_le = sys.byteorder == 'little'
 native_code = sys_is_le and '<' or '>'
@@ -42,8 +45,7 @@ COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File, IndexedGzipFile)
 
 # Enable .zst support if pyzstd installed.
 if HAVE_ZSTD:
-    from .openers import ZstdFile
-    COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, ZstdFile)
+    COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, pyzstd.ZstdFile)
 
 
 class Recoder(object):

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -40,6 +40,12 @@ default_compresslevel = 1
 #: file-like classes known to hold compressed data
 COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File, IndexedGzipFile)
 
+# Enable .zst support if pyzstd installed.
+try:
+    from pyzstd import ZstdFile
+    COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, ZstdFile)
+except ImportError:
+    pass
 
 class Recoder(object):
     """ class to return canonical code(s) from code or aliases

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -19,7 +19,7 @@ from functools import reduce
 import numpy as np
 
 from .casting import shared_range, OK_FLOATS
-from .openers import Opener, BZ2File, IndexedGzipFile
+from .openers import Opener, BZ2File, IndexedGzipFile, HAVE_ZSTD
 from .deprecated import deprecate_with_version
 from .externals.oset import OrderedSet
 
@@ -41,11 +41,10 @@ default_compresslevel = 1
 COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File, IndexedGzipFile)
 
 # Enable .zst support if pyzstd installed.
-try:
-    from pyzstd import ZstdFile
+if HAVE_ZSTD:
+    from .openers import ZstdFile
     COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, ZstdFile)
-except ImportError:
-    pass
+
 
 class Recoder(object):
     """ class to return canonical code(s) from code or aliases

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ test =
     pytest !=5.3.4
     pytest-cov
     pytest-doctestplus
+zstd =
+    pyzstd >= 0.14.3
 all =
     %(dicomfs)s
     %(dev)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ all =
     %(spm)s
     %(style)s
     %(test)s
+    %(zstd)s
 
 [options.entry_points]
 console_scripts =

--- a/tools/ci/env.sh
+++ b/tools/ci/env.sh
@@ -5,7 +5,7 @@ REQUIREMENTS="-r requirements.txt"
 # Minimum versions of minimum requirements
 MIN_REQUIREMENTS="-r min-requirements.txt"
 
-DEFAULT_OPT_DEPENDS="scipy matplotlib pillow pydicom h5py indexed_gzip"
+DEFAULT_OPT_DEPENDS="scipy matplotlib pillow pydicom h5py indexed_gzip pyzstd"
 # pydicom has skipped some important pre-releases, so enable a check against master
 PYDICOM_MASTER="git+https://github.com/pydicom/pydicom.git@master"
 # Minimum versions of optional requirements


### PR DESCRIPTION
Some stuff I was playing around with... This PR adds zstd compression/decompression support for the `Opener` class.

[zstd (Zstandard)](https://facebook.github.io/zstd/) is a relatively new compression library that boasts significant improvements in compression/decompression speeds over zlib with minimal differences in compression ratios.

Results from `bench_fileslice.py`  with `zst` added:
```
*************************
Bytes slice - raw (ratio)
*************************

+-----------------+--------------+--------------+--------------+--------------+
|                 |   mid int    |    step 1    | half step 1  | step mid int |
+=================+==============+==============+==============+==============+
| axis 0, len 64  | 0.73 (4.40)  | 0.23 (1.38)  | 0.21 (1.25)  | 0.19 (1.15)  |
| axis 1, len 64  | 0.02 (0.12)  | 0.17 (1.01)  | 0.13 (0.81)  | 0.02 (0.14)  |
| axis 2, len 32  | 0.01 (0.04)  | 0.12 (0.73)  | 0.13 (0.77)  | 0.02 (0.14)  |
| axis 3, len 100 | 0.00 (0.00)  | 0.15 (0.90)  | 0.09 (0.56)  | 0.00 (0.03)  |
+-----------------+--------------+--------------+--------------+--------------+
Base time: 0.17

************************
File slice - raw (ratio)
************************

+-----------------+--------------+--------------+--------------+--------------+
|                 |   mid int    |    step 1    | half step 1  | step mid int |
+=================+==============+==============+==============+==============+
| axis 0, len 64  | 1.19 (10.13) | 0.16 (1.40)  | 0.16 (1.36)  | 0.11 (0.96)  |
| axis 1, len 64  | 0.03 (0.24)  | 0.12 (1.04)  | 0.17 (1.44)  | 0.07 (0.59)  |
| axis 2, len 32  | 0.01 (0.07)  | 0.17 (1.42)  | 0.15 (1.28)  | 0.02 (0.15)  |
| axis 3, len 100 | 0.00 (0.01)  | 0.15 (1.31)  | 0.07 (0.60)  | 0.01 (0.04)  |
+-----------------+--------------+--------------+--------------+--------------+
Base time: 0.12

**********************
gz slice - raw (ratio)
**********************

+-----------------+--------------+--------------+--------------+--------------+
|                 |   mid int    |    step 1    | half step 1  | step mid int |
+=================+==============+==============+==============+==============+
| axis 0, len 64  | 3.21 (2.41)  | 1.32 (0.99)  | 1.15 (0.86)  | 1.15 (0.86)  |
| axis 1, len 64  | 1.23 (0.92)  | 1.19 (0.89)  | 1.29 (0.96)  | 1.64 (1.23)  |
| axis 2, len 32  | 1.36 (1.02)  | 1.19 (0.89)  | 1.27 (0.95)  | 1.31 (0.98)  |
| axis 3, len 100 | 0.58 (0.43)  | 1.21 (0.91)  | 0.58 (0.43)  | 0.60 (0.45)  |
+-----------------+--------------+--------------+--------------+--------------+
Base time: 1.34

***********************
zst slice - raw (ratio)
***********************

+-----------------+--------------+--------------+--------------+--------------+
|                 |   mid int    |    step 1    | half step 1  | step mid int |
+=================+==============+==============+==============+==============+
| axis 0, len 64  | 2.09 (4.08)  | 0.65 (1.27)  | 0.51 (0.99)  | 0.48 (0.94)  |
| axis 1, len 64  | 0.80 (1.56)  | 0.50 (0.98)  | 0.57 (1.11)  | 0.46 (0.91)  |
| axis 2, len 32  | 0.36 (0.71)  | 0.52 (1.01)  | 0.45 (0.89)  | 0.37 (0.72)  |
| axis 3, len 100 | 0.17 (0.34)  | 0.46 (0.89)  | 0.19 (0.37)  | 0.18 (0.36)  |
+-----------------+--------------+--------------+--------------+--------------+
Base time: 0.51
```