### PR TITLE
CI: Submit coverage to codecov via pinned PyPI package

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Run tests
         run: tools/ci/check.sh
         if: ${{ matrix.check != 'skiptests' }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: for_testing/coverage.xml
+      - name: Submit coverage
+        run: tools/ci/submit_coverage.sh
         if: ${{ always() }}
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -74,9 +74,8 @@ jobs:
       - name: Run tests
         run: tools/ci/check.sh
         if: ${{ matrix.check != 'skiptests' }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: for_testing/coverage.xml
+      - name: Submit coverage
+        run: tools/ci/submit_coverage.sh
         if: ${{ always() }}
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -117,9 +117,8 @@ jobs:
       - name: Run tests
         run: tools/ci/check.sh
         if: ${{ matrix.check != 'skiptests' }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: for_testing/coverage.xml
+      - name: Submit coverage
+        run: tools/ci/submit_coverage.sh
         if: ${{ always() }}
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ test =
     coverage
     pytest !=5.3.4
     pytest-cov
-    pytest-doctestplus
+    pytest-doctestplus !=0.9.0
 all =
     %(dicomfs)s
     %(dev)s

--- a/tools/ci/submit_coverage.sh
+++ b/tools/ci/submit_coverage.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo Submitting coverage
+
+source tools/ci/activate.sh
+
+set -eu
+
+set -x
+
+COVERAGE_FILE="for_testing/coverage.xml"
+
+if [ -e "$COVERAGE_FILE" ]; then
+    # Pin codecov version to reduce scope for malicious updates
+    python -m pip install "codecov==2.1.11"
+    python -m codecov --file for_testing/coverage.xml
+fi
+
+set +eux
+
+echo Done submitting coverage


### PR DESCRIPTION
Following a security incident at Codecov, the GitHub action should be considered unsafe as it internally runs `curl | bash`.

Moving to our CI scripts.

xref #1007 https://github.com/codecov/codecov-action/issues/281