### PR TITLE
ENH: Provide clear error message when files with zip extensions don't match file contents

### DIFF
--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -53,7 +53,7 @@ def _signature_matches_extension(filename):
     try:
         with open(filename, "rb") as fh:
             found_signature = fh.read(len(expected_signature))
-    except Exception:
+    except OSError:
         return False, f"Could not read file: {filename}"
     if found_signature == expected_signature:
         return True, ""

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -60,7 +60,7 @@ def _signature_matches_extension(filename, sniff):
                 sniff = fh.read(len(expected_signature))
         except OSError:
             return False, f"Could not read file: {filename}"
-    if not sniff.startswith(expected_signature):
+    if sniff.startswith(expected_signature):
         return True, ""
     format_name = signatures[ext]["format_name"]
     return False, f"File {filename} is not a {format_name} file"

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -46,7 +46,7 @@ def _signature_matches_extension(filename, sniff):
     """
     signatures = {
         ".gz": {"signature": b"\x1f\x8b", "format_name": "gzip"},
-        ".bz2": {"signature": b"\x42\x5a\x68", "format_name": "bzip2"}
+        ".bz2": {"signature": b"BZh", "format_name": "bzip2"}
     }
     filename = _stringify_path(filename)
     *_, ext = splitext_addext(filename)
@@ -54,15 +54,13 @@ def _signature_matches_extension(filename, sniff):
     if ext not in signatures:
         return True, ""
     expected_signature = signatures[ext]["signature"]
-    if sniff is not None and len(sniff) >= len(expected_signature):
-        found_signature = sniff[:len(expected_signature)]
-    else:
+    if sniff is None or len(sniff) < len(expected_signature):
         try:
             with open(filename, "rb") as fh:
-                found_signature = fh.read(len(expected_signature))
+                sniff = fh.read(len(expected_signature))
         except OSError:
             return False, f"Could not read file: {filename}"
-    if found_signature == expected_signature:
+    if not sniff.startswith(expected_signature):
         return True, ""
     format_name = signatures[ext]["format_name"]
     return False, f"File {filename} is not a {format_name} file"

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -76,6 +76,21 @@ def test_load_empty_image():
     assert str(err.value).startswith('Empty file: ')
 
 
+@pytest.mark.parametrize("extension", [".gz", ".bz2"])
+def test_load_bad_compressed_extension(tmp_path, extension):
+    file_path = tmp_path.joinpath(f"img.nii{extension}")
+    file_path.write_bytes(b"bad")
+    with pytest.raises(ImageFileError, match=".*is not a .* file"):
+        load(file_path)
+
+
+def test_load_file_that_cannot_be_read(tmp_path):
+    subdir = tmp_path.joinpath("img.nii.gz")
+    subdir.mkdir()
+    with pytest.raises(ImageFileError, match="Could not read"):
+        load(subdir)
+
+
 def test_read_img_data_nifti():
     shape = (2, 3, 4)
     data = np.random.normal(size=shape)

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -78,14 +78,14 @@ def test_load_empty_image():
 
 @pytest.mark.parametrize("extension", [".gz", ".bz2"])
 def test_load_bad_compressed_extension(tmp_path, extension):
-    file_path = tmp_path.joinpath(f"img.nii{extension}")
+    file_path = tmp_path / f"img.nii{extension}"
     file_path.write_bytes(b"bad")
     with pytest.raises(ImageFileError, match=".*is not a .* file"):
         load(file_path)
 
 
 def test_load_file_that_cannot_be_read(tmp_path):
-    subdir = tmp_path.joinpath("img.nii.gz")
+    subdir = tmp_path / "img.nii.gz"
     subdir.mkdir()
     with pytest.raises(ImageFileError, match="Could not read"):
         load(subdir)


### PR DESCRIPTION
fixes #966 
I added this check next to where `load` checks the file existence and size. please let me know if you would rather have it done some other way!

maybe another problem that could deserve a dedicated error message would be when the user doesn't have permissions to read the file?