### PR TITLE
ENH: Create gzip header deterministically by default

### DIFF
--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -40,6 +40,21 @@ except ImportError:
     HAVE_INDEXED_GZIP = False
 
 
+class DeterministicGzipFile(gzip.GzipFile):
+    """ Deterministic variant of GzipFile
+
+    This writer does not add filename information to the header, and defaults
+    to a modification time (``mtime``) of 0 seconds.
+    """
+    def __init__(self, filename=None, mode=None, compresslevel=9, fileobj=None, mtime=0):
+        if mode and 'b' not in mode:
+            mode += 'b'
+        if filename:
+            fileobj = self.myfileobj = open(filename, mode or 'rb')
+        return super().__init__(filename="", mode=mode, compresslevel=compresslevel,
+                                fileobj=fileobj, mtime=mtime)
+
+
 def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
 
     # use indexed_gzip if possible for faster read access.  If keep_open ==

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -55,7 +55,7 @@ class DeterministicGzipFile(gzip.GzipFile):
                                 fileobj=fileobj, mtime=mtime)
 
 
-def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
+def _gzip_open(filename, mode='rb', compresslevel=9, mtime=0, keep_open=False):
 
     # use indexed_gzip if possible for faster read access.  If keep_open ==
     # True, we tell IndexedGzipFile to keep the file handle open. Otherwise
@@ -65,7 +65,7 @@ def _gzip_open(filename, mode='rb', compresslevel=9, keep_open=False):
 
     # Fall-back to built-in GzipFile
     else:
-        gzip_file = gzip.GzipFile(filename, mode, compresslevel)
+        gzip_file = DeterministicGzipFile(filename, mode, compresslevel, mtime=mtime)
 
     return gzip_file
 
@@ -90,7 +90,7 @@ class Opener(object):
         passed to opening method when `fileish` is str.  Change of defaults as
         for \*args
     """
-    gz_def = (_gzip_open, ('mode', 'compresslevel', 'keep_open'))
+    gz_def = (_gzip_open, ('mode', 'compresslevel', 'mtime', 'keep_open'))
     bz2_def = (BZ2File, ('mode', 'buffering', 'compresslevel'))
     compress_ext_map = {
         '.gz': gz_def,

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -47,9 +47,11 @@ class DeterministicGzipFile(gzip.GzipFile):
     to a modification time (``mtime``) of 0 seconds.
     """
     def __init__(self, filename=None, mode=None, compresslevel=9, fileobj=None, mtime=0):
+        # These two guards are copied from
+        # https://github.com/python/cpython/blob/6ab65c6/Lib/gzip.py#L171-L174
         if mode and 'b' not in mode:
             mode += 'b'
-        if filename:
+        if fileobj is None:
             fileobj = self.myfileobj = open(filename, mode or 'rb')
         return super().__init__(filename="", mode=mode, compresslevel=compresslevel,
                                 fileobj=fileobj, mtime=mtime)

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -158,10 +158,7 @@ class Opener(object):
         self._name will be None if object was created with a fileobj, otherwise
         it will be the filename.
         """
-        try:
-            return self.fobj.name
-        except AttributeError:
-            return self._name
+        return self._name
 
     @property
     def mode(self):

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -440,3 +440,12 @@ def test_bitwise_determinism():
 
         assert md5sum("a.gz") == anon_chksum
         assert md5sum("b.gz") == anon_chksum
+
+        # Users can still set mtime, but filenames will not be embedded
+        with Opener("filenameA.gz", "wb", mtime=0xCAFE10C0) as fobj:
+            fobj.write(msg)
+        with Opener("filenameB.gz", "wb", mtime=0xCAFE10C0) as fobj:
+            fobj.write(msg)
+        fnameA_chksum = md5sum("filenameA.gz")
+        fnameB_chksum = md5sum("filenameB.gz")
+        assert fnameA_chksum == fnameB_chksum != anon_chksum

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -415,6 +415,29 @@ def test_DeterministicGzipFile():
         assert md5sum("filenameA.gz") == anon_chksum
 
 
+def test_DeterministicGzipFile_fileobj():
+    with InTemporaryDirectory():
+        msg = b"Hello, I'd like to have an argument."
+        with open("ref.gz", "wb") as fobj:
+            with GzipFile(filename="", mode="wb", fileobj=fobj, mtime=0) as gzobj:
+                gzobj.write(msg)
+        ref_chksum = md5sum("ref.gz")
+
+        with open("test.gz", "wb") as fobj:
+            with DeterministicGzipFile(filename="", mode="wb", fileobj=fobj) as gzobj:
+                gzobj.write(msg)
+        md5sum("test.gz") == ref_chksum
+
+        with open("test.gz", "wb") as fobj:
+            with DeterministicGzipFile(fileobj=fobj, mode="wb") as gzobj:
+                gzobj.write(msg)
+        md5sum("test.gz") == ref_chksum
+
+        with open("test.gz", "wb") as fobj:
+            with DeterministicGzipFile(filename="test.gz", mode="wb", fileobj=fobj) as gzobj:
+                gzobj.write(msg)
+        md5sum("test.gz") == ref_chksum
+
 
 def test_bitwise_determinism():
     with InTemporaryDirectory():


### PR DESCRIPTION
As discussed in #1023, we currently allow `gzip.GzipFile` to set the gzip header as it will, including filename and mtime fields. This means that files with identical unzipped contents and compression levels have different gzipped representations, which is not ideal for verifying sources of non-determinism in a complex workflow.

This PR attempts to balance sensible default behaviors with user control. It changes the default `mtime` from `time.time()` to `0`, while allowing users to set the `mtime` as an argument to `Opener()`.

It *removes* the behavior of setting the original filename in the gzip header. In a medical imaging context, the original filenames may include PHI (e.g., subject name, scan date, etc) that will follow the file through renames unless the file is rewritten entirely. A flag to preserve the old behavior does not seem worth the effort.

Fixes #1023.