### PR TITLE
FIX: Return error codes in dicomfs, rather than raise

### DIFF
--- a/nibabel/cmdline/dicomfs.py
+++ b/nibabel/cmdline/dicomfs.py
@@ -172,9 +172,9 @@ class DICOMFS(fuse.Fuse):
                 elif isinstance(matched_path, tuple):
                     self.fhs[i] = matched_path[1]()
                 else:
-                    raise -errno.EFTYPE
+                    return -errno.EFTYPE
                 return FileHandle(i)
-        raise -errno.ENFILE
+        return -errno.ENFILE
 
     # not done
     def read(self, path, size, offset, fh):


### PR DESCRIPTION
> Illegal raise
> 
> Illegal class '`int`' raised; will result in a `TypeError` being raised instead.

I believe the intent was to `return`, not to `raise`. @chrispycheng Can you confirm?