### PR TITLE
FIX: LGTM error: Clear-text logging of sensitive information

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,3 @@
+# https://lgtm.com/rules/1510014536001/
+queries:
+  - exclude: py/clear-text-logging-sensitive-data


### PR DESCRIPTION
Disable false positives that cannot be fixed by LGTM, because their heuristic specifically flags string "`id`" which is common in DICOM, for example in "`UID`".