### PR TITLE
WIP: LGTM error: Missing call to `__init__` during object initialization

### DIFF
--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -802,25 +802,10 @@ class EcatImage(SpatialImage):
         >>> data4d.shape == (10, 10, 3, 1)
         True
         """
+        super(EcatImage, self).__init__(dataobj, affine, header=header,
+                                        extra=extra, file_map=file_map)
         self._subheader = subheader
         self._mlist = mlist
-        self._dataobj = dataobj
-        if affine is not None:
-            # Check that affine is array-like 4,4.  Maybe this is too strict at
-            # this abstract level, but so far I think all image formats we know
-            # do need 4,4.
-            affine = np.array(affine, dtype=np.float64, copy=True)
-            if not affine.shape == (4, 4):
-                raise ValueError('Affine should be shape 4,4')
-        self._affine = affine
-        if extra is None:
-            extra = {}
-        self.extra = extra
-        self._header = header
-        if file_map is None:
-            file_map = self.__class__.make_file_map()
-        self.file_map = file_map
-        self._data_cache = None
         self._fdata_cache = None
 
     @property

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -466,7 +466,6 @@ class SpatialImage(DataobjImage):
                 self._header.set_data_dtype(dataobj.dtype)
         # make header correspond with image and affine
         self.update_header()
-        self._data_cache = None
 
     @property
     def affine(self):


### PR DESCRIPTION
Class `EcatImage` may not be initialized properly as method `DataobjImage.__init__` is not called from its `__init__` method.
Class `EcatImage` may not be initialized properly as method `FileBasedImage.__init__` is not called from its `__init__` method.
Class `EcatImage` may not be initialized properly as method `SpatialImage.__init__` is not called from its `__init__` method.

The code is not exactly equivalent, so I need your input here. Method `SpatialImage.__init__` looks like this:
```python
        super(SpatialImage, self).__init__(dataobj, header=header, extra=extra,
                                           file_map=file_map)
        if affine is not None:
            # Check that affine is array-like 4,4.  Maybe this is too strict at
            # this abstract level, but so far I think all image formats we know
            # do need 4,4.
            # Copy affine to isolate from environment.  Specify float type to
            # avoid surprising integer rounding when setting values into affine
            affine = np.array(affine, dtype=np.float64, copy=True)
            if not affine.shape == (4, 4):
                raise ValueError('Affine should be shape 4,4')
        self._affine = affine

        # if header not specified, get data type from input array
        if header is None:
            if hasattr(dataobj, 'dtype'):
                self._header.set_data_dtype(dataobj.dtype)
        # make header correspond with image and affine
        self.update_header()
```
and `DataobjImage.__init__`:
```python
        super(DataobjImage, self).__init__(header=header, extra=extra,
                                           file_map=file_map)
        self._dataobj = dataobj
        self._fdata_cache = None
        self._data_cache = None
```
and finally `FileBasedImage.__init__`:
```python
        self._header = self.header_class.from_header(header)
        if extra is None:
            extra = {}
        self.extra = extra

        if file_map is None:
            file_map = self.__class__.make_file_map()
        self.file_map = file_map

```
Compare with the old `EcatImage.__init__` which differs in the initialisation of `self._header` and ` self.file_map`:
```python
        self._subheader = subheader
        self._mlist = mlist
        self._dataobj = dataobj
        if affine is not None:
            # Check that affine is array-like 4,4.  Maybe this is too strict at
            # this abstract level, but so far I think all image formats we know
            # do need 4,4.
            affine = np.array(affine, dtype=np.float64, copy=True)
            if not affine.shape == (4, 4):
                raise ValueError('Affine should be shape 4,4')
        self._affine = affine
        if extra is None:
            extra = {}
        self.extra = extra
        self._header = header
        if file_map is None:
            file_map = self.__class__.make_file_map()
        self.file_map = file_map
        self._data_cache = None
        self._fdata_cache = None
```
Was this on purpose.?