### PR TITLE
FIX: Suggest `nibabel.save()` on calls to deprecated `giftiio.write()`

### DIFF
--- a/nibabel/gifti/giftiio.py
+++ b/nibabel/gifti/giftiio.py
@@ -34,7 +34,7 @@ def read(filename):
 
 
 @deprecate_with_version('giftiio.write function deprecated. '
-                        "Use nibabel.load() instead.",
+                        "Use nibabel.save() instead.",
                         '2.1', '4.0')
 def write(image, filename):
     """ Save the current image to a new file


### PR DESCRIPTION
Small adjustment to refer to correct function in deprecation notice.