### PR TITLE
MNT: Upgrade versioneer 0.19 → 0.20

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -926,7 +926,7 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for _ in cfg.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
         return {"version": "0+unknown", "full-revisionid": None,


### PR DESCRIPTION
This will fix an LGTM.com error:
https://lgtm.com/projects/g/nipy/nibabel/snapshot/3b1ecf4fb3674052ae0297863aca98c9f84624e4/files/nibabel/_version.py?sort=name&dir=ASC&mode=heatmap#x8eb1df6955196f9d:1