### PR TITLE
fix: parser handles lists in ASCCONV and raw CSA

### DIFF
--- a/nibabel/nicom/ascconv.py
+++ b/nibabel/nicom/ascconv.py
@@ -12,6 +12,8 @@ ASCCONV_RE = re.compile(
     r'### ASCCONV BEGIN((?:\s*[^=\s]+=[^=\s]+)*) ###\n(.*?)\n### ASCCONV END ###',
     flags=re.M | re.S)
 
+ATTRIBUTE_RE = re.compile(r'__attribute__\.size\s*=\s*')
+
 
 class AscconvParseError(Exception):
     """ Error parsing ascconv file """
@@ -205,10 +207,12 @@ def parse_ascconv(ascconv_str, str_delim='"'):
     AsconvParseError
         A line of the ASCCONV section could not be parsed.
     '''
-    attrs, content = ASCCONV_RE.match(ascconv_str).groups()
+    attrs, content = ASCCONV_RE.search(ascconv_str).groups()
     attrs = OrderedDict((tuple(x.split('=')) for x in attrs.split()))
     # Normalize string start / end markers to something Python understands
     content = content.replace(str_delim, '"""').replace("\\", "\\\\")
+    # Strip out lines with "__attribute__.size = " because ast tries to make a dict instead of a list
+    content = "\n".join([line for line in content.splitlines() if ATTRIBUTE_RE.search(line) is None])
     # Use Python's own parser to parse modified ASCCONV assignments
     tree = ast.parse(content)
 

--- a/nibabel/nicom/ascconv.py
+++ b/nibabel/nicom/ascconv.py
@@ -12,7 +12,7 @@ ASCCONV_RE = re.compile(
     r'### ASCCONV BEGIN((?:\s*[^=\s]+=[^=\s]+)*) ###\n(.*?)\n### ASCCONV END ###',
     flags=re.M | re.S)
 
-ATTRIBUTE_RE = re.compile(r'__attribute__\.size\s*=\s*')
+SIZE_RE = re.compile(r'__attribute__\.size\s*=\s*')
 
 
 class AscconvParseError(Exception):
@@ -206,13 +206,21 @@ def parse_ascconv(ascconv_str, str_delim='"'):
     ------
     AsconvParseError
         A line of the ASCCONV section could not be parsed.
+
+    Examples
+    --------
+    >>> dicom = pydicom.dcmread(fpath)
+    >>> with open(fpath, 'rt', encoding=dicom.__dict__["_parent_encoding"]) as fid:  # noqa : E501
+    ...     contents = fid.read()
+    >>> parse_ascconv(contents, '""')
+    (OrderedDict([( ...
     '''
     attrs, content = ASCCONV_RE.search(ascconv_str).groups()
     attrs = OrderedDict((tuple(x.split('=')) for x in attrs.split()))
     # Normalize string start / end markers to something Python understands
     content = content.replace(str_delim, '"""').replace("\\", "\\\\")
-    # Strip out lines with "__attribute__.size = " because ast tries to make a dict instead of a list
-    content = "\n".join([line for line in content.splitlines() if ATTRIBUTE_RE.search(line) is None])
+    # Strip out lines with "__attribute__.size = " because ast tries to make a dict instead of list
+    content = "\n".join([line for line in content.splitlines() if SIZE_RE.search(line) is None])
     # Use Python's own parser to parse modified ASCCONV assignments
     tree = ast.parse(content)
 

--- a/nibabel/nicom/tests/test_ascconv.py
+++ b/nibabel/nicom/tests/test_ascconv.py
@@ -61,3 +61,14 @@ def test_ascconv_w_attrs():
     assert attrs['version'] == '41340006'
     assert attrs['converter'] == '%MEASCONST%/ConverterList/Prot_Converter.txt'
     assert ascconv_dict['test'] == 'hello'
+
+
+def test_asconv_from_csa():
+    class SiemensMock:
+        csa_header = r"      <ParamBool.""save_orig"">  { ""true""  }\n    }\n  }\n}\n### ASCCONV BEGIN object=MrProtDataImpl@MrProtocolData version=51130001 converter=%MEASCONST%/ConverterList/Prot_Converter.txt ###\nsGRADSPEC.asGPAData.__attribute__.size\t = \t1\nsGRADSPEC.asGPAData[0].bEddyCompensationValid\t = \t1\n### ASCCONV END ### \n      }"
+    siemens = SiemensMock()
+    ascconv_dict, attrs = ascconv.parse_ascconv(siemens.csa_header, '""')
+    assert attrs['object'] == 'MrProtDataImpl@MrProtocolData'
+    assert attrs['version'] == '51130001'
+    assert attrs['converter'] == '%MEASCONST%/ConverterList/Prot_Converter.txt'
+    assert ascconv_dict['sGRADSPEC']['asGPAData'][0]['bEddyCompensationValid'] == 1


### PR DESCRIPTION
Hi team, 

I was trying to parse the ASCCONV section in some Siemens NX data and `ast.parse` cannot handle the `list` object attribute "size" that is being included in my header, e.g., 

> sGRADSPEC.bShimCurrentValid	 = 	1
> sGRADSPEC.ucNoiseReduction	 = 	1
> sGRADSPEC.asGPAData.\_\_attribute\_\_.size	 = 	1
> sGRADSPEC.asGPAData[0].bEddyCompensationValid	 = 	1
> sGRADSPEC.asGPAData[0].bB0CompensationValid	 = 	1
> sGRADSPEC.asGPAData[0].bCrossTermCompensationValid	 = 	1

I made a couple of fixes to the `parse_ascconv()` method that reflected my usage of it, which may not be the intended practice.  

```python
fpath = op.abspath("MR.1.3.12.2.1107.5.2.43.67026.2021092814503632248564553")
dicom = pydicom.dcmread(fpath)
with open(fpath, 'rt', encoding=dicom.__dict__["_parent_encoding"]) as fid:
     contents = fid.read()
x = ascconv.parse_ascconv(contents, '""')
```
🤷‍♂️ 

I'd like to follow this PR up with one that will integrate the `ascconv` functions with `dicomwrappers.SiemensWrapper` and provide a new attribute `ascconv_data` or something that would allow

```python
siemens = dicomwrappers.SiemensWrapper(dicom, fpath)
siemens.ascconv_data  # returns OrderedDict returned from parse_ascconv()
``` 