### PR TITLE
MNT: Drop uses of deprecated distutils

### DIFF
--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -7,10 +7,10 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from distutils.version import LooseVersion
-
 import numpy as np
 from io import BytesIO
+
+from packaging.version import Version, parse
 
 from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Label,
                      Cifti2LabelTable, Cifti2VertexIndices,
@@ -151,9 +151,9 @@ class Cifti2Parser(xml.XmlParser):
         if name == 'CIFTI':
             # create cifti2 image
             self.header = Cifti2Header()
-            self.header.version = attrs['Version']
-            if LooseVersion(self.header.version) < LooseVersion('2'):
-                raise ValueError('Only CIFTI-2 files are supported')
+            self.header.version = ver = attrs['Version']
+            if parse(ver) < Version("2"):
+                raise ValueError(f'Only CIFTI-2 files are supported; found version {ver}')
             self.fsm_state.append('CIFTI')
             self.struct_state.append(self.header)
 

--- a/nibabel/cifti2/tests/test_cifti2io_header.py
+++ b/nibabel/cifti2/tests/test_cifti2io_header.py
@@ -10,7 +10,7 @@
 from os.path import join as pjoin, dirname
 import io
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import nibabel as nib
 from nibabel import cifti2 as ci
@@ -80,7 +80,7 @@ def test_read_and_proxies():
 def test_version():
     for i, dat in enumerate(datafiles):
         img = nib.load(dat)
-        assert LooseVersion(img.header.version) == LooseVersion('2')
+        assert Version(img.header.version) == Version('2')
 
 
 @needs_nibabel_data('nitest-cifti2')

--- a/nibabel/data.py
+++ b/nibabel/data.py
@@ -9,7 +9,7 @@ from os.path import join as pjoin
 import glob
 import sys
 import configparser
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .environment import get_nipy_user_dir, get_nipy_system_dir
 
@@ -330,7 +330,7 @@ def datasource_or_bomber(pkg_def, **options):
     Parameters
     ----------
     pkg_def : dict
-       dict containing at least key 'relpath'. Can optioanlly have keys 'name'
+       dict containing at least key 'relpath'. Can optionally have keys 'name'
        (package name),  'install hint' (for helpful error messages) and 'min
        version' giving the minimum necessary version string for the package.
     data_path : sequence of strings or None, optional
@@ -349,8 +349,7 @@ def datasource_or_bomber(pkg_def, **options):
     except DataError as e:
         return Bomber(sys_relpath, str(e))
     # check version
-    if (version is None or
-            LooseVersion(ds.version) >= LooseVersion(version)):
+    if version is None or Version(ds.version) >= Version(version):
         return ds
     if 'name' in pkg_def:
         pkg_name = pkg_def['name']

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -13,7 +13,7 @@ from bz2 import BZ2File
 import gzip
 import warnings
 from os.path import splitext
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from nibabel.optpkg import optional_package
 
@@ -25,11 +25,11 @@ try:
     HAVE_INDEXED_GZIP = True
 
     # < 0.7 - no good
-    if StrictVersion(version) < StrictVersion('0.7.0'):
+    if Version(version) < Version('0.7.0'):
         warnings.warn(f'indexed_gzip is present, but too old (>= 0.7.0 required): {version})')
         HAVE_INDEXED_GZIP = False
     # >= 0.8 SafeIndexedGzipFile renamed to IndexedGzipFile
-    elif StrictVersion(version) < StrictVersion('0.8.0'):
+    elif Version(version) < Version('0.8.0'):
         IndexedGzipFile = igzip.SafeIndexedGzipFile
     else:
         IndexedGzipFile = igzip.IndexedGzipFile

--- a/nibabel/optpkg.py
+++ b/nibabel/optpkg.py
@@ -1,14 +1,14 @@
 """ Routines to support optional packages """
-from distutils.version import LooseVersion
+from packaging.version import Version
 from .tripwire import TripWire
 
 
 def _check_pkg_version(pkg, min_version):
     # Default version checking function
     if isinstance(min_version, str):
-        min_version = LooseVersion(min_version)
+        min_version = Version(min_version)
     try:
-        return min_version <= pkg.__version__
+        return min_version <= Version(pkg.__version__)
     except AttributeError:
         return False
 
@@ -24,9 +24,9 @@ def optional_package(name, trip_msg=None, min_version=None):
         message to give when someone tries to use the return package, but we
         could not import it at an acceptable version, and have returned a
         TripWire object instead. Default message if None.
-    min_version : None or str or LooseVersion or callable
+    min_version : None or str or Version or callable
         If None, do not specify a minimum version.  If str, convert to a
-        `distutils.version.LooseVersion`.  If str or LooseVersion` compare to
+        ``packaging.version.Version``.  If str or ``Version`` compare to
         version of package `name` with ``min_version <= pkg.__version__``.   If
         callable, accepts imported ``pkg`` as argument, and returns value of
         callable is True for acceptable package versions, False otherwise.

--- a/nibabel/tests/test_h5py_compat.py
+++ b/nibabel/tests/test_h5py_compat.py
@@ -5,7 +5,7 @@ well-defined cases
 """
 import sys
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 import numpy as np
 
 from ..optpkg import optional_package
@@ -25,7 +25,7 @@ def test_optpkg_equivalence():
     if not have_h5py:
         assert not compat.have_h5py
     # Available when version is high enough
-    elif LooseVersion(h5py.__version__) >= '2.10':
+    elif Version(h5py.__version__) >= Version('2.10'):
         assert compat.have_h5py
 
 
@@ -35,11 +35,11 @@ def test_disabled_h5py_cases():
         # Recapitulate min_h5py conditions from _h5py_compat
         assert os.name == 'nt'
         assert (3,) <= sys.version_info < (3, 6)
-        assert LooseVersion(h5py.__version__) < '2.10'
+        assert Version(h5py.__version__) < Version('2.10')
         # Verify that the root cause is present
         # If any tests fail, they will likely be these, so they may be
         # ill-advised...
-        if LooseVersion(np.__version__) < '1.18':
+        if Version(np.__version__) < Version('1.18'):
             assert str(np.longdouble) == str(np.float64)
         else:
             assert str(np.longdouble) != str(np.float64)

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -11,7 +11,7 @@ import os
 import contextlib
 from gzip import GzipFile
 from io import BytesIO, UnsupportedOperation
-from distutils.version import StrictVersion
+from packaging.version import Version
 import hashlib
 import time
 
@@ -106,7 +106,7 @@ def test_Opener_various():
                 # indexed gzip is used by default, and drops file
                 # handles by default, so we don't have a fileno.
                 elif input.endswith('gz') and HAVE_INDEXED_GZIP and \
-                     StrictVersion(igzip.__version__) >= StrictVersion('0.7.0'):
+                     Version(igzip.__version__) >= Version('0.7.0'):
                     with pytest.raises(igzip.NoHandleError):
                         fobj.fileno()
                 else:

--- a/nibabel/tests/test_optpkg.py
+++ b/nibabel/tests/test_optpkg.py
@@ -5,7 +5,7 @@ from unittest import mock
 import types
 import sys
 import builtins
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from unittest import SkipTest
 import pytest
@@ -67,10 +67,10 @@ def test_versions():
         # Now add a version
         fake_pkg.__version__ = '2.0'
         # We have fake_pkg > 1.0
-        for min_ver in (None, '1.0', LooseVersion('1.0'), lambda pkg: True):
+        for min_ver in (None, '1.0', Version('1.0'), lambda pkg: True):
             assert_good(fake_name, min_ver)
         # We never have fake_pkg > 100.0
-        for min_ver in ('100.0', LooseVersion('100.0'), lambda pkg: False):
+        for min_ver in ('100.0', Version('100.0'), lambda pkg: False):
             assert_bad(fake_name, min_ver)
         # Check error string for bad version
         pkg, _, _ = optional_package(fake_name, min_version='3.0')


### PR DESCRIPTION
CI is failing. None of these cases seemed to hinge on the exact semantics of `LooseVersion`. In most cases, `packaging.version.Version` works as well. For CIFTI-2, the spec says the string must be "2", so let's not parse that unless tests show we've been explicitly trying to be flexible there.