### PR TITLE
REL: 4.0.0rc0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -37,10 +37,13 @@ Gael Varoquaux <gael.varoquaux@normalesup.org> GaelVaroquaux <gael.varoquaux@nor
 Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
 Ian Nimmo-Smith <iannimmosmith@gmail.com> Ian Nimmo-Smith <ian.nimmo-smith@mrc-cbu.cam.ac.uk>
 Jaakko Leppäkangas <jaeilepp@student.jyu.fi> jaeilepp <jaeilepp@student.jyu.fi>
+Jacob Roberts <jacobdr@gmail.com>
+Jacob Roberts <jacobdr@gmail.com> <jacob.roberts@o8t.com>
 Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>
 Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com> <jakubk@mit.edu>
 Jasper J.F. van den Bosch <japsai@gmail.com> Jasper <japsai@gmail.com>
 Jean-Baptiste Poline <jbpoline@gmail.com> jbpoline <jbpoline@gmail.com>
+Jérôme Dockès <jerome@dockes.org>
 Jon Haitz Legarreta <jon.haitz.legarreta@gmail.com> Jon Haitz Legarreta Gorroño <jon.haitz.legarreta@gmail.com>
 Jonathan Daniel <jonathand655@gmail.com>
 Jonathan Daniel <jonathand655@gmail.com> <36337649+jond01@users.noreply.github.com>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -93,10 +93,10 @@
       "orcid": "0000-0002-0807-6005"
     },
     {
-      "name": "Duek, Or"
+      "name": "Daniel, Jonathan"
     },
     {
-      "name": "Daniel, Jonathan"
+      "name": "Duek, Or"
     },
     {
       "affiliation": "The University of Washington eScience Institute",
@@ -128,6 +128,9 @@
       "orcid": "0000-0001-8950-0375"
     },
     {
+      "name": "S\u00f3lon, Anibal"
+    },
+    {
       "name": "Burns, Christopher"
     },
     {
@@ -139,9 +142,6 @@
       "affiliation": "CNRS LTCI, Telecom ParisTech, Universit\u00e9 Paris-Saclay",
       "name": "Gramfort, Alexandre",
       "orcid": "0000-0001-9791-4404"
-    },
-    {
-      "name": "S\u00f3lon, Anibal"
     },
     {
       "name": "Lepp\u00e4kangas, Jaakko"
@@ -159,6 +159,14 @@
     },
     {
       "name": "Subramaniam, Krish"
+    },
+    {
+      "affiliation": "CEA",
+      "name": "Papadopoulos Orfanos, Dimitri",
+      "orcid": "0000-0002-1242-8990"
+    },
+    {
+      "name": "Van, Andrew"
     },
     {
       "affiliation": "Google",
@@ -209,6 +217,9 @@
       "orcid": "0000-0001-9090-3024"
     },
     {
+      "name": "Dock\u00e8s, J\u00e9r\u00f4me"
+    },
+    {
       "name": "Oosterhof, Nikolaas N."
     },
     {
@@ -227,11 +238,6 @@
     },
     {
       "name": "St-Jean, Samuel"
-    },
-    {
-      "affiliation": "CEA",
-      "name": "Papadopoulos Orfanos, Dimitri",
-      "orcid": "0000-0002-1242-8990"
     },
     {
       "name": "Panfilov, Egor",
@@ -254,10 +260,18 @@
       "name": "Hahn, Kevin S."
     },
     {
+      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
+      "name": "Waller, Lea",
+      "orcid": "0000-0002-3239-6957"
+    },
+    {
       "name": "Hinds, Oliver P."
     },
     {
       "name": "Fauber, Bennet"
+    },
+    {
+      "name": "Roberts, Jacob"
     },
     {
       "affiliation": "McGill University",
@@ -283,6 +297,9 @@
       "name": "Moreno, Miguel Estevan"
     },
     {
+      "name": "Hrn\u010diar, Tom\u00e1\u0161"
+    },
+    {
       "name": "Haenel, Valentin"
     },
     {
@@ -290,9 +307,6 @@
     },
     {
       "name": "Baratz, Zvi"
-    },
-    {
-      "name": "Van, Andrew"
     },
     {
       "affiliation": "Hospital for Sick Children",
@@ -330,11 +344,6 @@
       "name": "Raktivan, Konstantinos"
     },
     {
-      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
-      "name": "Waller, Lea",
-      "orcid": "0000-0002-3239-6957"
-    },
-    {
       "name": "Cal\u00e1bkov\u00e1, Mark\u00e9ta"
     },
     {
@@ -353,9 +362,6 @@
     },
     {
       "name": "Roos, Thomas"
-    },
-    {
-      "name": "Hrn\u010diar, Tom\u00e1\u0161"
     },
     {
       "affiliation": "National Institute of Mental Health and Neuro-Sciences, India",

--- a/Changelog
+++ b/Changelog
@@ -25,8 +25,90 @@ Eric Larson (EL), Demian Wassermann, Stephan Gerhard and Ross Markello (RM).
 
 References like "pr/298" refer to github pull request numbers.
 
+4.0.0 (To be determined)
+========================
+
+New feature release in the 4.0.x series.
+
+New features
+------------
+* Add ``'mask'``, ``'compat'`` and ``'smallest'`` dtype aliases to NIfTI images
+  to allow for dtype specifications that can depend on the contents of the data.
+  ``'mask'`` is a synonym for ``uint8``. ``'compat'`` will find the nearest
+  Analyze-compatible (therefore widely supported) dtype that will not truncate
+  the data. ``'smallest'`` attempts to find the smallest integer dtype that will
+  contain the data. (pr/1096) (CM, reviewed by Chris Rorden and Josh Teves)
+* Add ``dtype`` arguments to ``Cifti2Image`` (pr/1111) (CM)
+* Allow dtypes to be passed to Analyze-like images at ``__init__()`` and
+  ``to_filename()`` to provide better control over output images. (pr/1082)
+   (CM, following discussions with Chris Rorden, Josh Teves, Jerome Dockes, and MB)
+* Allow compressed GIFTI images (MB, reviewed by CM)
+* Add zstd compression support (pr/1005) (Andrew Van, reviewed by CM)
+* Support ``ExternalFileBinary`` GIFTI data arrays (PM, reviewed by CM)
+
+Enhancements
+------------
+* Document ``InTemporaryDirectory`` as non-thread-safe (pr/1103) (Jacob Roberts,
+  reviewed by MB)
+* Unify Caret-XML-style metadata structure (GiftiMetaData, Cifti2MetaData)
+  as dict-like (pr/1091) (CM, reviewed by Josh Teves and Hao-Ting Wang)
+* Add ``__repr__`` methods to GIFTI objects (pr/1092) (CM,
+  reviewed by Josh Teves and Hao-Ting Wang)
+* Create gzip header deterministically by default (pr/1024) (CM, reviewed by YOH)
+* Provide clear error message when files with zip extensions don't match
+  file contents (pr/1013) (Jérôme Dockès, reviewed by CM)
+
+Bug fixes
+---------
+* Re-import externals/netcdf.py from scipy to resolve numpy API change (pr/1110)
+  (CM)
+* Resize ArraySequence.data without helper function to avoid reference increment
+  (pr/1093) (MC, reviewed by CM)
+
+Maintenance
+-----------
+* Update submodule URLs to use https over git protocol (pr/1097) (CM)
+* Published BIAP 9: CoordinateImage API (pr/1084) (CM)
+* Drop uses of deprecated ``distutils`` (pr/1073) (CM, reviewed by MB)
+* Suppress LGTM false alarm "Clear-text logging of sensitive information"
+  (pr/1052) (Dimitri Papadopoulos, reviewed by CM)
+* Test on Python 3.10 (pr/1047) (CM)
+* Fix typos found by codespell (pr/1040, pr/1044)
+  (Dimitri Papadopoulos, reviewed by CM)
+* Run stable tests weekly, pre-release tests nightly (pr/1025) (CM)
+* Documentation updates to establish/clarify governance and decision
+  making (pr/1019, pr/1020, pr/1022, pr/1018, pr/1017, pr/1016) (MB and CM)
+
+API changes and deprecations
+----------------------------
+* Writing NIfTIs with 64-bit integer dtypes is getting harder.
+  Passing ``(u)int64`` arrays to ``Nifti1Image`` and subclasses will warn unless
+  a ``header`` or ``dtype`` option is passed; in the future this will become an
+  error.
+  Additionally, passing ``int`` or ``'int'`` to ``set_data_dtype()`` now raises
+  an error, requiring an explicit numpy dtype to make 64-bit integer images.
+  (pr/1082) (CM, following discussions with Chris Rorden, Josh Teves, Jerome Dockes,
+  and MB)
+* Drop support for Python 3.6, Numpy < 1.17 (pr/1079) (CM)
+* Fully removed the following APIs, which have raised errors on use
+  since 3.0 (pr/980) (CM, reviewed by Jonathan Daniel)
+   * ``nibabel.trackvis``
+   * ``nibabel.volumeutils.calculate_scale``
+   * ``nibabel.volumeutils.can_cast``
+   * ``nibabel.volumeutils.scale_min_max``
+   * ``nibabel.dataobj_images.DataobjImage.get_shape``
+   * ``nibabel.minc1.MincImage`` (use ``Minc1Image``)
+   * ``nibabel.minc1.MincFile`` (use ``Minc1File``)
+   * ``nibabel.filebasedimages.FileBasedImage.from_files``
+   * ``nibabel.filebasedimages.FileBasedImage.filespec_to_files``
+   * ``nibabel.filebasedimages.FileBasedImage.to_filespec``
+   * ``nibabel.filebasedimages.FileBasedImage.to_files``
+   * ``nibabel.arrayproxy.ArrayProxy.header``
+   * ``keep_file_open=="auto"`` parameter to load method (now must be boolean)
+
+
 3.2.2 (Monday 7 February 2022)
-=================================
+==============================
 
 Bug fix release in the 3.2.x series.
 
@@ -557,7 +639,7 @@ Maintenance
 * Use SSH address to use key-based auth (pr/587) (CM, reviewed by MB)
 * Fix doctests for numpy 1.14 array printing (pr/591) (MB, reviewed by CM)
 * Refactor for pydicom 1.0 API changes (pr/599) (MB, reviewed by CM)
-* Increase test coverage, remove unreachable code (pr/602) (CM, reviewed by 
+* Increase test coverage, remove unreachable code (pr/602) (CM, reviewed by
   Yaroslav Halchenko, MB)
 * Move ``nib-ls`` and other programs to a new cmdline module (pr/601, pr/615)
   (Chris Cheng, reviewed by MB, Yaroslav Halchenko)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -117,6 +117,8 @@ contributed code and discussion (in rough order of appearance):
 * Lea Waller
 * Tomáš Hrnčiar
 * Andrew Van
+* Jérôme Dockès
+* Jacob Roberts
 
 License reprise
 ===============


### PR DESCRIPTION
Preparation for 4.0.0rc0. As noted in #1078, the prospect of many deprecations needing to be double-checked has slowed down my ability to make this release happen. It still needs to happen, and it should start with a release candidate.

We've jumped a few numpy versions and dropped Python 3.6, and we have some improvements that will make things easier for downstream projects.

I think let's aim for next Monday to give everyone time to polish off enhancement/new feature PRs. Additional bug fixes can come post-release.

Pre-release checklist
--------
* [x] Review the open list of [nibabel issues](https://github.com/nipy/nibabel/issues). Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release. Label them!
* [x] Review and update the release notes. Review and update the [Changelog file](https://github.com/nipy/nibabel/blob/master/Changelog).
* [x] Look at [`doc/source/index.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/index.rst) and add any authors not yet acknowledged.
* [x] Use the opportunity to update the [`.mailmap file`](https://github.com/nipy/nibabel/blob/master/.mailmap) if there are any duplicate authors listed from `git shortlog -nse`.
* [x] Check the copyright year in [doc/source/conf.py](https://github.com/nipy/nibabel/blob/master/doc/source/conf.py)
* [x] Refresh the [README.rst](https://github.com/nipy/nibabel/blob/master/README.rst) text from the `LONG_DESCRIPTION` in [`info.py`](https://github.com/nipy/nibabel/blob/master/nibabel/info.py) by running `make refresh-readme`.
* [x] Check the dependencies listed in [`setup.cfg`](https://github.com/nipy/nibabel/blob/master/setup.cfg) (e.g., `install_requires`, `options.extras_require`) and in [`doc/source/installation.rst`](https://github.com/nipy/nibabel/blob/master/doc/source/installation.rst) and in [`requirements.txt`](https://github.com/nipy/nibabel/blob/master/requirements.txt) and [`.travis.yml`](https://github.com/nipy/nibabel/blob/master/.travis.yml). They should at least match. Do they still hold? Make sure nibabel on travis is testing the minimum dependencies specifically.
* [x] Make sure all tests pass (from the nibabel root directory): `pytest --doctest-modules nibabel`

Adapted from http://nipy.org/nibabel/devel/make_release.html#release-checklist