### PR TITLE
NF: Pass dtype to Analyze-like images at initialization/serialization, warn on creation of NIfTI images with 64-bit ints (API change)

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -914,12 +914,15 @@ class AnalyzeImage(SpatialImage):
     ImageArrayProxy = ArrayProxy
 
     def __init__(self, dataobj, affine, header=None,
-                 extra=None, file_map=None):
+                 extra=None, file_map=None, dtype=None):
         super(AnalyzeImage, self).__init__(
             dataobj, affine, header, extra, file_map)
         # Reset consumable values
         self._header.set_data_offset(0)
         self._header.set_slope_inter(None, None)
+
+        if dtype is not None:
+            self.set_data_dtype(dtype)
     __init__.__doc__ = SpatialImage.__init__.__doc__
 
     def get_data_dtype(self):

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -412,3 +412,17 @@ def reshape_dataobj(obj, shape):
     """
     return (obj.reshape(shape) if hasattr(obj, 'reshape')
             else np.reshape(obj, shape))
+
+
+def get_obj_dtype(obj):
+    """ Get the effective dtype of an array-like object """
+    if is_proxy(obj):
+        # Read and potentially apply scaling to one value
+        idx = (0,) * len(obj.shape)
+        return obj[idx].dtype
+    elif hasattr(obj, "dtype"):
+        # Trust the dtype (probably an ndarray)
+        return obj.dtype
+    else:
+        # Coerce; this could be expensive but we don't know what we can do with it
+        return np.asanyarray(obj).dtype

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -1460,7 +1460,7 @@ class Cifti2Image(DataobjImage, SerializableImage):
             return img
         raise NotImplementedError
 
-    def to_file_map(self, file_map=None):
+    def to_file_map(self, file_map=None, dtype=None):
         """ Write image to `file_map` or contained ``self.file_map``
 
         Parameters
@@ -1493,7 +1493,7 @@ class Cifti2Image(DataobjImage, SerializableImage):
         # If qform not set, reset pixdim values so Nifti2 does not complain
         if header['qform_code'] == 0:
             header['pixdim'][:4] = 1
-        img = Nifti2Image(data, None, header)
+        img = Nifti2Image(data, None, header, dtype=dtype)
         img.to_file_map(file_map or self.file_map)
 
     def update_headers(self):

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -299,8 +299,8 @@ class FileBasedImage(object):
             file_map[key] = FileHolder(filename=fname)
         return file_map
 
-    def to_filename(self, filename):
-        """ Write image to files implied by filename string
+    def to_filename(self, filename, **kwargs):
+        r""" Write image to files implied by filename string
 
         Parameters
         ----------
@@ -308,15 +308,17 @@ class FileBasedImage(object):
            filename to which to save image.  We will parse `filename`
            with ``filespec_to_file_map`` to work out names for image,
            header etc.
+        \*\*kwargs : keyword arguments
+           Keyword arguments to format-specific save
 
         Returns
         -------
         None
         """
         self.file_map = self.filespec_to_file_map(filename)
-        self.to_file_map()
+        self.to_file_map(**kwargs)
 
-    def to_file_map(self, file_map=None):
+    def to_file_map(self, file_map=None, **kwargs):
         raise NotImplementedError
 
     @classmethod
@@ -552,13 +554,14 @@ class SerializableImage(FileBasedImage):
         file_map = klass.make_file_map({'image': bio, 'header': bio})
         return klass.from_file_map(file_map)
 
-    def to_bytes(self):
-        """ Return a ``bytes`` object with the contents of the file that would
+    def to_bytes(self, **kwargs):
+        r""" Return a ``bytes`` object with the contents of the file that would
         be written if the image were saved.
 
         Parameters
         ----------
-        None
+        \*\*kwargs : keyword arguments
+            Keyword arguments that may be passed to ``img.to_file_map()``
 
         Returns
         -------
@@ -569,5 +572,5 @@ class SerializableImage(FileBasedImage):
             raise NotImplementedError("to_bytes() is undefined for multi-file images")
         bio = io.BytesIO()
         file_map = self.make_file_map({'image': bio, 'header': bio})
-        self.to_file_map(file_map)
+        self.to_file_map(file_map, **kwargs)
         return bio.getvalue()

--- a/nibabel/funcs.py
+++ b/nibabel/funcs.py
@@ -35,7 +35,7 @@ def squeeze_image(img):
     --------
     >>> import nibabel as nf
     >>> shape = (10,20,30,1,1)
-    >>> data = np.arange(np.prod(shape)).reshape(shape)
+    >>> data = np.arange(np.prod(shape), dtype='int32').reshape(shape)
     >>> affine = np.eye(4)
     >>> img = nf.Nifti1Image(data, affine)
     >>> img.shape == (10, 20, 30, 1, 1)
@@ -47,7 +47,7 @@ def squeeze_image(img):
     If the data are 3D then last dimensions of 1 are ignored
 
     >>> shape = (10,1,1)
-    >>> data = np.arange(np.prod(shape)).reshape(shape)
+    >>> data = np.arange(np.prod(shape), dtype='int32').reshape(shape)
     >>> img = nf.ni1.Nifti1Image(data, affine)
     >>> img.shape == (10, 1, 1)
     True

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -130,8 +130,8 @@ def guessed_image_type(filename):
     raise ImageFileError(f'Cannot work out file type of "{filename}"')
 
 
-def save(img, filename):
-    """ Save an image to file adapting format to `filename`
+def save(img, filename, **kwargs):
+    r""" Save an image to file adapting format to `filename`
 
     Parameters
     ----------
@@ -139,6 +139,8 @@ def save(img, filename):
        image to save
     filename : str or os.PathLike
        filename (often implying filenames) to which to save `img`.
+    \*\*kwargs : keyword arguments
+        Keyword arguments to format-specific save
 
     Returns
     -------
@@ -148,7 +150,7 @@ def save(img, filename):
 
     # Save the type as expected
     try:
-        img.to_filename(filename)
+        img.to_filename(filename, **kwargs)
     except ImageFileError:
         pass
     else:
@@ -196,7 +198,7 @@ def save(img, filename):
     # Here, we either have a klass or a converted image.
     if converted is None:
         converted = klass.from_image(img)
-    converted.to_filename(filename)
+    converted.to_filename(filename, **kwargs)
 
 
 @deprecate_with_version('read_img_data deprecated. '

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -910,17 +910,17 @@ class Nifti1Header(SpmAnalyzeHeader):
         Traceback (most recent call last):
            ...
         HeaderDataError: data dtype "<type 'numpy.void'>" known but not supported
-        >>> hdr.set_data_dtype('int')
+        >>> hdr.set_data_dtype('int') #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
            ...
         ValueError: Invalid data type 'int'. Specify a sized integer, e.g., 'uint8' or numpy.int16.
-        >>> hdr.set_data_dtype(int)
+        >>> hdr.set_data_dtype(int) #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
            ...
         ValueError: Invalid data type 'int'. Specify a sized integer, e.g., 'uint8' or numpy.int16.
         >>> hdr.set_data_dtype('int64')
-        >>> hdr.get_data_dtype()
-        dtype('int64')
+        >>> hdr.get_data_dtype() == np.dtype('int64')
+        True
         """
         if not isinstance(datatype, np.dtype) and datatype in (int, "int"):
             raise ValueError(f"Invalid data type {datatype!r}. Specify a sized integer, "
@@ -1926,7 +1926,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
 
         Examples
         --------
-        >>> data = np.arange(24).reshape((2,3,4))
+        >>> data = np.arange(24, dtype='f4').reshape((2,3,4))
         >>> aff = np.diag([2, 3, 4, 1])
         >>> img = Nifti1Pair(data, aff)
         >>> img.get_qform()
@@ -2009,7 +2009,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
 
         Examples
         --------
-        >>> data = np.arange(24).reshape((2,3,4))
+        >>> data = np.arange(24, dtype='f4').reshape((2,3,4))
         >>> aff = np.diag([2, 3, 4, 1])
         >>> img = Nifti1Pair(data, aff)
         >>> img.get_sform()

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -17,6 +17,7 @@ import numpy as np
 import numpy.linalg as npl
 from numpy.compat.py3k import asstr
 
+from .arrayproxy import get_obj_dtype
 from .optpkg import optional_package
 from .filebasedimages import SerializableImage
 from .volumeutils import Recoder, make_dt_codes, endian_codes
@@ -1808,7 +1809,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
         # not support 64-bit integer data, so `set_data_dtype(int64)` would
         # already fail.
         danger_dts = (np.dtype("int64"), np.dtype("uint64"))
-        if header is None and dtype is None and dataobj.dtype in danger_dts:
+        if header is None and dtype is None and get_obj_dtype(dataobj) in danger_dts:
             msg = (f"Image data has type {dataobj.dtype}, which may cause "
                    "incompatibilities with other tools. This will error in "
                    "NiBabel 5.0. This warning can be silenced "

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1754,12 +1754,20 @@ class Nifti1Pair(analyze.AnalyzeImage):
     rw = True
 
     def __init__(self, dataobj, affine, header=None,
-                 extra=None, file_map=None):
+                 extra=None, file_map=None, dtype=None):
+        danger_dts = (np.dtype("int64"), np.dtype("uint64"))
+        if header is None and dtype is None and dataobj.dtype in danger_dts:
+            msg = (f"Image data has type {dataobj.dtype}, which may cause "
+                   "incompatibilities with other tools. This will error in "
+                   "NiBabel 5.0. This warning can be silenced "
+                   f"by passing the dtype argument to {self.__class__.__name__}().")
+            warnings.warn(msg, FutureWarning, stacklevel=2)
         super(Nifti1Pair, self).__init__(dataobj,
                                          affine,
                                          header,
                                          extra,
-                                         file_map)
+                                         file_map,
+                                         dtype)
         # Force set of s/q form when header is None unless affine is also None
         if header is None and affine is not None:
             self._affine2header()

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -308,7 +308,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
         ret._affine = np.dot(ret._affine, to_111)
         return ret
 
-    def to_file_map(self, file_map=None):
+    def to_file_map(self, file_map=None, dtype=None):
         """ Write image to `file_map` or contained ``self.file_map``
 
         Extends Analyze ``to_file_map`` method by writing ``mat`` file
@@ -321,7 +321,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
         """
         if file_map is None:
             file_map = self.file_map
-        super(Spm99AnalyzeImage, self).to_file_map(file_map)
+        super(Spm99AnalyzeImage, self).to_file_map(file_map, dtype=dtype)
         mat = self._affine
         if mat is None:
             return

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -290,7 +290,12 @@ class TestAnalyzeHeader(_TestLabeledWrapStruct):
         # Test aliases to Python types
         assert_set_dtype(float, np.float64)  # float64 always supported
         np_sys_int = np.dtype(int).type  # int could be 32 or 64 bit
-        if np_sys_int in self.supported_np_types:  # no int64 for Analyze
+        if issubclass(self.header_class, Nifti1Header):
+            # We don't allow int aliases in Nifti
+            with pytest.raises(ValueError):
+                hdr = self.header_class()
+                hdr.set_data_dtype(int)
+        elif np_sys_int in self.supported_np_types:  # no int64 for Analyze
             assert_set_dtype(int, np_sys_int)
         hdr = self.header_class()
         for inp in all_unsupported_types:

--- a/nibabel/tests/test_filehandles.py
+++ b/nibabel/tests/test_filehandles.py
@@ -26,7 +26,7 @@ def test_multiload():
     # Make a tiny image, save, load many times.  If we are leaking filehandles,
     # this will cause us to run out and generate an error
     N = SOFT_LIMIT + 100
-    arr = np.arange(24).reshape((2, 3, 4))
+    arr = np.arange(24, dtype='int32').reshape((2, 3, 4))
     img = Nifti1Image(arr, np.eye(4))
     imgs = []
     try:

--- a/nibabel/tests/test_funcs.py
+++ b/nibabel/tests/test_funcs.py
@@ -51,12 +51,12 @@ def test_concat():
         #   second position.
         for data0_shape in all_shapes:
             data0_numel = np.asarray(data0_shape).prod()
-            data0 = np.arange(data0_numel).reshape(data0_shape)
+            data0 = np.arange(data0_numel, dtype='int32').reshape(data0_shape)
             img0_mem = Nifti1Image(data0, affine)
 
             for data1_shape in all_shapes:
                 data1_numel = np.asarray(data1_shape).prod()
-                data1 = np.arange(data1_numel).reshape(data1_shape)
+                data1 = np.arange(data1_numel, dtype='int32').reshape(data1_shape)
                 img1_mem = Nifti1Image(data1, affine)
                 img2_mem = Nifti1Image(data1, affine + 1)  # bad affine
 

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -765,6 +765,23 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
     image_class = Nifti1Pair
     supported_np_types = TestNifti1PairHeader.supported_np_types
 
+    def test_int64_warning(self):
+        # Verify that initializing with (u)int64 data and no
+        # header/dtype info produces a warning
+        img_klass = self.image_class
+        hdr_klass = img_klass.header_class
+        for dtype in (np.int64, np.uint64):
+            data = np.arange(24, dtype=dtype).reshape((2, 3, 4))
+            with pytest.warns(FutureWarning):
+                img_klass(data, np.eye(4))
+            # No warnings if we're explicit, though
+            with clear_and_catch_warnings():
+                warnings.simplefilter("error")
+                img_klass(data, np.eye(4), dtype=dtype)
+                hdr = hdr_klass()
+                hdr.set_data_dtype(dtype)
+                img_klass(data, np.eye(4), hdr)
+
     def test_none_qsform(self):
         # Check that affine gets set to q/sform if header is None
         img_klass = self.image_class

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -770,7 +770,7 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
         img_klass = self.image_class
         hdr_klass = img_klass.header_class
         shape = (2, 3, 4)
-        data = np.arange(24).reshape(shape)
+        data = np.arange(24, dtype='f4').reshape((2, 3, 4))
         # With specified affine
         aff = from_matvec(euler2mat(0.1, 0.2, 0.3), [11, 12, 13])
         for hdr in (None, hdr_klass()):
@@ -1040,7 +1040,7 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
         # is some thoughts by Mark Jenkinson:
         # http://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/qsform_brief_usage
         IC = self.image_class
-        arr = np.arange(24).reshape((2, 3, 4))
+        arr = np.arange(24, dtype='f4').reshape((2, 3, 4))
         aff = np.diag([2, 3, 4, 1])
         # Default is sform set, qform not set
         img = IC(arr, aff)
@@ -1073,7 +1073,7 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
 
     def test_read_no_extensions(self):
         IC = self.image_class
-        arr = np.arange(24).reshape((2, 3, 4))
+        arr = np.arange(24, dtype='f4').reshape((2, 3, 4))
         img = IC(arr, np.eye(4))
         assert len(img.header.extensions) == 0
         img_rt = bytesio_round_trip(img)
@@ -1110,7 +1110,7 @@ class TestNifti1Image(TestNifti1Pair):
     def test_offset_errors(self):
         # Test that explicit offset too low raises error
         IC = self.image_class
-        arr = np.arange(24).reshape((2, 3, 4))
+        arr = np.arange(24, dtype='f4').reshape((2, 3, 4))
         img = IC(arr, np.eye(4))
         assert img.header.get_data_offset() == 0
         # Saving with zero offset is OK
@@ -1365,7 +1365,7 @@ class TestNifti1General(object):
     def test_load(self):
         # test module level load.  We try to load a nii and an .img and a .hdr
         # and expect to get a nifti back of single or pair type
-        arr = np.arange(24).reshape((2, 3, 4))
+        arr = np.arange(24, dtype='f4').reshape((2, 3, 4))
         aff = np.diag([2, 3, 4, 1])
         simg = self.single_class(arr, aff)
         pimg = self.pair_class(arr, aff)
@@ -1439,7 +1439,7 @@ class TestNifti1General(object):
 
     def test_reoriented_dim_info(self):
         # Check that dim_info is reoriented correctly
-        arr = np.arange(24).reshape((2, 3, 4))
+        arr = np.arange(24, dtype='f4').reshape((2, 3, 4))
         # Start as RAS
         aff = np.diag([2, 3, 4, 1])
         simg = self.single_class(arr, aff)

--- a/nibabel/tests/test_processing.py
+++ b/nibabel/tests/test_processing.py
@@ -97,7 +97,7 @@ def test_adapt_affine():
 @needs_scipy
 def test_resample_from_to(caplog):
     # Test resampling from image to image / image space
-    data = np.arange(24).reshape((2, 3, 4))
+    data = np.arange(24, dtype='int32').reshape((2, 3, 4))
     affine = np.diag([-4, 5, 6, 1])
     img = Nifti1Image(data, affine)
     img.header['descrip'] = 'red shirt image'
@@ -186,7 +186,7 @@ def test_resample_from_to(caplog):
     out = resample_from_to(img, (img_2d.shape, img_2d.affine))
     assert_array_equal(out.dataobj, data[:, :, 0])
     # 4D input and output also OK
-    data_4d = np.arange(24 * 5).reshape((2, 3, 4, 5))
+    data_4d = np.arange(24 * 5, dtype='int32').reshape((2, 3, 4, 5))
     img_4d = Nifti1Image(data_4d, affine)
     out = resample_from_to(img_4d, img_4d)
     assert_almost_equal(data_4d, out.dataobj)
@@ -202,7 +202,7 @@ def test_resample_from_to(caplog):
 def test_resample_to_output(caplog):
     # Test routine to sample iamges to output space
     # Image aligned to output axes - no-op
-    data = np.arange(24).reshape((2, 3, 4))
+    data = np.arange(24, dtype='int32').reshape((2, 3, 4))
     img = Nifti1Image(data, np.eye(4))
     # Check default resampling
     img2 = resample_to_output(img)
@@ -305,7 +305,7 @@ def test_resample_to_output(caplog):
 @needs_scipy
 def test_smooth_image(caplog):
     # Test image smoothing
-    data = np.arange(24).reshape((2, 3, 4))
+    data = np.arange(24, dtype='int32').reshape((2, 3, 4))
     aff = np.diag([-4, 5, 6, 1])
     img = Nifti1Image(data, aff)
     # Zero smoothing is no-op
@@ -332,7 +332,7 @@ def test_smooth_image(caplog):
     with pytest.raises(ValueError):
         smooth_image(img_2d, [8, 8, 8])
     # Isotropic in 4D has zero for last dimension in scalar case
-    data_4d = np.arange(24 * 5).reshape((2, 3, 4, 5))
+    data_4d = np.arange(24 * 5, dtype='int32').reshape((2, 3, 4, 5))
     img_4d = Nifti1Image(data_4d, aff)
     exp_out = spnd.gaussian_filter(data_4d, list(sd) + [0], mode='nearest')
     assert_array_equal(smooth_image(img_4d, 8).dataobj, exp_out)

--- a/nibabel/tests/test_round_trip.py
+++ b/nibabel/tests/test_round_trip.py
@@ -17,9 +17,8 @@ DEBUG = False
 
 
 def round_trip(arr, out_dtype):
-    img = Nifti1Image(arr, np.eye(4))
+    img = Nifti1Image(arr, np.eye(4), dtype=out_dtype)
     img.file_map['image'].fileobj = BytesIO()
-    img.set_data_dtype(out_dtype)
     img.to_file_map()
     back = Nifti1Image.from_file_map(img.file_map)
     # Recover array and calculated scaling from array proxy object

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -414,6 +414,7 @@ class TestSpm99AnalyzeImage(test_analyze.TestAnalyzeImage, ImageScalingMixin):
     test_header_updating = needs_scipy(test_analyze.TestAnalyzeImage.test_header_updating)
     test_offset_to_zero = needs_scipy(test_analyze.TestAnalyzeImage.test_offset_to_zero)
     test_big_offset_exts = needs_scipy(test_analyze.TestAnalyzeImage.test_big_offset_exts)
+    test_dtype_to_filename_arg = needs_scipy(test_analyze.TestAnalyzeImage.test_dtype_to_filename_arg)
     test_header_scaling = needs_scipy(ImageScalingMixin.test_header_scaling)
     test_int_int_scaling = needs_scipy(ImageScalingMixin.test_int_int_scaling)
     test_write_scaling = needs_scipy(ImageScalingMixin.test_write_scaling)


### PR DESCRIPTION
No test yet, but a quick prototype based on the discussion in #1046.

I'm not sure what people's intuition about the behavior of a `dtype` parameter should be. What I've done for now is just to `set_data_dtype()` so that the array is untouched but will be coerced at write time. However, I could see an argument that the expectation is that the array would be immediately cast so that the result of `np.asanyarray(img.dataobj)` will have the dtype passed to the image.

Additionally, this currently assumes that passing a header is as good as passing a dtype, but this is going to have the problem that passing the header of a 64-bit image will succeed silently.

I have not made any attempt to implement a `from nibabel.__future__ import int64_error` at this point. Figured I'd get some code out and argue out the semantics before refining.