### PR TITLE
RF: Unify Caret-XML-style metadata structure as dict-like

### DIFF
--- a/nibabel/caret.py
+++ b/nibabel/caret.py
@@ -1,0 +1,117 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the NiBabel package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+from collections.abc import MutableMapping
+
+from . import xmlutils as xml
+
+
+class CaretMetaData(xml.XmlSerializable, MutableMapping):
+    """ A list of name-value pairs used in various Caret-based XML formats
+
+    * Description - Provides a simple method for user-supplied metadata that
+      associates names with values.
+    * Attributes: [NA]
+    * Child Elements
+
+        * MD (0...N)
+
+    * Text Content: [NA]
+
+    MD elements are a single metadata entry consisting of a name and a value.
+
+    Attributes
+    ----------
+    data : mapping of {name: value} pairs
+
+    >>> md = CaretMetaData()
+    >>> md['key'] = 'val'
+    >>> md
+    <CaretMetaData {'key': 'val'}>
+    >>> dict(md)
+    {'key': 'val'}
+    >>> md.to_xml()
+    b'<MetaData><MD><Name>key</Name><Value>val</Value></MD></MetaData>'
+
+    Objects may be constructed like any ``dict``:
+
+    >>> md = CaretMetaData(key='val')
+    >>> md.to_xml()
+    b'<MetaData><MD><Name>key</Name><Value>val</Value></MD></MetaData>'
+    """
+    def __init__(self, *args, **kwargs):
+        self._data = dict(*args, **kwargs)
+
+    def __getitem__(self, key):
+        """ Get metadata entry by name
+
+        >>> md = CaretMetaData({'key': 'val'})
+        >>> md['key']
+        'val'
+        """
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        """ Set metadata entry by name
+
+        >>> md = CaretMetaData({'key': 'val'})
+        >>> dict(md)
+        {'key': 'val'}
+        >>> md['newkey'] = 'newval'
+        >>> dict(md)
+        {'key': 'val', 'newkey': 'newval'}
+        >>> md['key'] = 'otherval'
+        >>> dict(md)
+        {'key': 'otherval', 'newkey': 'newval'}
+        """
+        self._data[key] = value
+
+    def __delitem__(self, key):
+        """ Delete metadata entry by name
+
+        >>> md = CaretMetaData({'key': 'val'})
+        >>> dict(md)
+        {'key': 'val'}
+        >>> del md['key']
+        >>> dict(md)
+        {}
+        """
+        del self._data[key]
+
+    def __len__(self):
+        """ Get length of metadata list
+
+        >>> md = CaretMetaData({'key': 'val'})
+        >>> len(md)
+        1
+        """
+        return len(self._data)
+
+    def __iter__(self):
+        """ Iterate over metadata entries
+
+        >>> md = CaretMetaData({'key': 'val'})
+        >>> for key in md:
+        ...     print(key)
+        key
+        """
+        return iter(self._data)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self._data!r}>"
+
+    def _to_xml_element(self):
+        metadata = xml.Element('MetaData')
+
+        for name_text, value_text in self._data.items():
+            md = xml.SubElement(metadata, 'MD')
+            name = xml.SubElement(md, 'Name')
+            name.text = str(name_text)
+            value = xml.SubElement(md, 'Value')
+            value.text = str(value_text)
+        return metadata

--- a/nibabel/caret.py
+++ b/nibabel/caret.py
@@ -45,7 +45,14 @@ class CaretMetaData(xml.XmlSerializable, MutableMapping):
     b'<MetaData><MD><Name>key</Name><Value>val</Value></MD></MetaData>'
     """
     def __init__(self, *args, **kwargs):
+        args, kwargs = self._sanitize(args, kwargs)
         self._data = dict(*args, **kwargs)
+
+    @staticmethod
+    def _sanitize(args, kwargs):
+        """ Override in subclasses to accept and warn on previous invocations
+        """
+        return args, kwargs
 
     def __getitem__(self, key):
         """ Get metadata entry by name

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -122,23 +122,51 @@ class Cifti2MetaData(CaretMetaData):
     ----------
     data : list of (name, value) tuples
     """
-    def __init__(self, *args, **kwargs):
+    @staticmethod
+    def _sanitize(args, kwargs):
+        """ Sanitize and warn on deprecated arguments
+
+        Accept metadata positional/keyword argument that can take
+        ``None`` to indicate no initialization.
+
+        >>> import pytest
+        >>> Cifti2MetaData()
+        <Cifti2MetaData {}>
+        >>> Cifti2MetaData([("key", "val")])
+        <Cifti2MetaData {'key': 'val'}>
+        >>> Cifti2MetaData(key="val")
+        <Cifti2MetaData {'key': 'val'}>
+        >>> with pytest.warns(FutureWarning):
+        ...     Cifti2MetaData(None)
+        <Cifti2MetaData {}>
+        >>> with pytest.warns(FutureWarning):
+        ...     Cifti2MetaData(metadata=None)
+        <Cifti2MetaData {}>
+        >>> with pytest.warns(FutureWarning):
+        ...     Cifti2MetaData(metadata={'key': 'val'})
+        <Cifti2MetaData {'key': 'val'}>
+
+        Note that "metadata" could be a valid key:
+
+        >>> Cifti2MetaData(metadata='val')
+        <Cifti2MetaData {'metadata': 'val'}>
+        """
         if not args and list(kwargs) == ["metadata"]:
-            md = kwargs.pop("metadata")
-            if not isinstance(md, str):
-                warn("CaretMetaData now has a dict-like interface and will "
+            if not isinstance(kwargs["metadata"], str):
+                warn("Cifti2MetaData now has a dict-like interface and will "
                      "no longer accept the ``metadata`` keyword argument in "
                      "NiBabel 6.0. See ``pydoc dict`` for initialization options.",
-                     FutureWarning, stacklevel=2)
+                     FutureWarning, stacklevel=3)
+                md = kwargs.pop("metadata")
                 if md is not None:
                     args = (md,)
         if args == (None,):
-            warn("CaretMetaData now has a dict-like interface and will no longer "
+            warn("Cifti2MetaData now has a dict-like interface and will no longer "
                  "accept the positional argument ``None`` in NiBabel 6.0. "
                  "See ``pydoc dict`` for initialization options.",
-                 FutureWarning, stacklevel=2)
+                 FutureWarning, stacklevel=3)
             args = ()
-        super().__init__(*args, **kwargs)
+        return args, kwargs
 
     @property
     def data(self):

--- a/nibabel/cifti2/cifti2_axes.py
+++ b/nibabel/cifti2/cifti2_axes.py
@@ -1075,7 +1075,6 @@ class ScalarAxis(Axis):
         """
         mim = cifti2.Cifti2MatrixIndicesMap([dim], 'CIFTI_INDEX_TYPE_SCALARS')
         for name, meta in zip(self.name, self.meta):
-            meta = None if len(meta) == 0 else meta
             named_map = cifti2.Cifti2NamedMap(name, cifti2.Cifti2MetaData(meta))
             mim.append(named_map)
         return mim
@@ -1213,8 +1212,6 @@ class LabelAxis(Axis):
             label_table = cifti2.Cifti2LabelTable()
             for key, value in label.items():
                 label_table[key] = (value[0],) + tuple(value[1])
-            if len(meta) == 0:
-                meta = None
             named_map = cifti2.Cifti2NamedMap(name, cifti2.Cifti2MetaData(meta),
                                               label_table)
             mim.append(named_map)

--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -35,11 +35,19 @@ def test_value_if_klass():
 
 
 def test_cifti2_metadata():
-    md = ci.Cifti2MetaData(metadata={'a': 'aval'})
+    md = ci.Cifti2MetaData({'a': 'aval'})
     assert len(md) == 1
     assert list(iter(md)) == ['a']
     assert md['a'] == 'aval'
     assert md.data == dict([('a', 'aval')])
+
+    with pytest.warns(FutureWarning):
+        md = ci.Cifti2MetaData(metadata={'a': 'aval'})
+    assert md == {'a': 'aval'}
+
+    with pytest.warns(FutureWarning):
+        md = ci.Cifti2MetaData(None)
+    assert md == {}
 
     md = ci.Cifti2MetaData()
     assert len(md) == 0

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -18,7 +18,7 @@ from xml.parsers.expat import ExpatError
 import numpy as np
 
 from .gifti import (GiftiMetaData, GiftiImage, GiftiLabel,
-                    GiftiLabelTable, GiftiNVPairs, GiftiDataArray,
+                    GiftiLabelTable, GiftiDataArray,
                     GiftiCoordSystem)
 from .util import (array_index_order_codes, gifti_encoding_codes,
                    gifti_endian_codes)
@@ -202,7 +202,7 @@ class GiftiImageParser(XmlParser):
                 self.meta_da = GiftiMetaData()
 
         elif name == 'MD':
-            self.nvpair = GiftiNVPairs()
+            self.nvpair = ['', '']
             self.fsm_state.append('MD')
 
         elif name == 'Name':
@@ -313,10 +313,11 @@ class GiftiImageParser(XmlParser):
 
         elif name == 'MD':
             self.fsm_state.pop()
+            key, val = self.nvpair
             if self.meta_global is not None and self.meta_da is None:
-                self.meta_global.data.append(self.nvpair)
+                self.meta_global[key] = val
             elif self.meta_da is not None and self.meta_global is None:
-                self.meta_da.data.append(self.nvpair)
+                self.meta_da[key] = val
             # remove reference
             self.nvpair = None
 
@@ -374,11 +375,11 @@ class GiftiImageParser(XmlParser):
         # Process data
         if self.write_to == 'Name':
             data = data.strip()
-            self.nvpair.name = data
+            self.nvpair[0] = data
 
         elif self.write_to == 'Value':
             data = data.strip()
-            self.nvpair.value = data
+            self.nvpair[1] = data
 
         elif self.write_to == 'DataSpace':
             data = data.strip()


### PR DESCRIPTION
We have two implementations of the same structure in GIFTI and CIFTI-2. The Cifti one is much nicer to deal with, but also a little short of a straight drop-in replacement for `dict()`.

Spurred by writing a parser for `CaretSpecFile`s in #1090. Mostly used the Cifti implementation, but dropped the `difference_update()` (not sure why this exists, so don't want to copy it without a use case). Used a private `_data` object to allow the `GiftiMetaData.data` to be a deprecated list view.

Scheduled dropping most of the custom bits of each subclass for 6.0 to give a good long warning period.