### PR TITLE
MNT: Remove direct calls to setup.py, clean up install docs, update warnings

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -22,8 +22,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: [3.8]
-        install: ['setup']
+        python-version: ["3.10"]
+        install: ['pip']
         check: ['style', 'doc']
         pip-flags: ['']
         depends: ['REQUIREMENTS']

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -28,7 +28,7 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         python-version: ["3.9", "3.10"]
         architecture: ['x64', 'x86']
-        install: ['setup']
+        install: ['pip']
         check: ['test']
         pip-flags: ['PRE_PIP_FLAGS']
         depends: ['REQUIREMENTS']
@@ -37,7 +37,7 @@ jobs:
           # Pydicom master
           - os: ubuntu-latest
             python-version: "3.10"
-            install: setup
+            install: pip
             check: test
             pip-flags: ''
             depends: REQUIREMENTS

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -40,7 +40,7 @@ jobs:
           # Basic dependencies only
           - os: ubuntu-latest
             python-version: 3.7
-            install: setup
+            install: pip
             check: test
             pip-flags: ''
             depends: REQUIREMENTS
@@ -48,7 +48,7 @@ jobs:
           # Absolute minimum dependencies
           - os: ubuntu-latest
             python-version: 3.7
-            install: setup
+            install: pip
             check: test
             pip-flags: ''
             depends: MIN_REQUIREMENTS
@@ -56,7 +56,7 @@ jobs:
           # Absolute minimum dependencies plus old MPL, Pydicom, Pillow
           - os: ubuntu-latest
             python-version: 3.7
-            install: setup
+            install: pip
             check: test
             pip-flags: ''
             depends: MIN_REQUIREMENTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
         - DEPENDS="REQUIREMENTS"
         - OPTIONAL_DEPENDS="DEFAULT_OPT_DEPENDS"
         - EXTRA_PIP_FLAGS=""
-        - INSTALL_TYPE="setup"
+        - INSTALL_TYPE="pip"
         - CHECK_TYPE="test"
 
 python:
@@ -35,7 +35,6 @@ before_install:
 # command to install dependencies
 install:
     - tools/ci/install.sh
-    - if [ "$CHECK_TYPE" == "skiptests" ]; then exit 0; fi
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -13,12 +13,12 @@
 Installation
 ************
 
-NiBabel is a pure Python package at the moment, and it should be easy to get
-NiBabel running on any system. For the most popular platforms and operating
-systems there should be packages in the respective native packaging format
-(DEB, RPM or installers). On other systems you can install NiBabel using
-pip_ or by downloading the source package and running the usual ``python
-setup.py install``.
+NiBabel is a pure Python package,
+and it should be easy to get NiBabel running on any system.
+For the most popular platforms and operating systems
+there should be packages in the respective native packaging format
+(DEB, RPM or installers).
+On other systems you can install NiBabel using pip_.
 
 .. This remark below is not yet true; comment to avoid confusion
    To run all of the tests, you may need some extra data packages - see
@@ -121,14 +121,15 @@ Validating your install
 For a basic test of your installation, fire up Python and try importing the
 module to see if everything is fine.  It should look something like this::
 
-    Python 2.7.8 (v2.7.8:ee879c0ffa11, Jun 29 2014, 21:07:35)
-    [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
+    Python 3.8.5 (default, Sep  4 2020, 07:30:14)
+    [GCC 7.3.0] :: Anaconda, Inc. on linux
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import nibabel
     >>>
 
 
-To run the nibabel test suite, from the terminal run ``pytest nibabel`` or
+To run the nibabel test suite, from the terminal run
+``pytest --pyargs nibabel`` or
 ``python -c "import nibabel; nibabel.test()``.
 
 To run an extended test suite that validates ``nibabel`` for long-running and

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -361,10 +361,10 @@ def test_assert_parallel():
 
 @dicom_test
 def test_decimal_rescale():
-    # Test that we don't get back a data array with dtype np.object when our
+    # Test that we don't get back a data array with dtype object when our
     # rescale slope is a decimal
     dw = didw.wrapper_from_file(DATA_FILE_DEC_RSCL)
-    assert dw.get_data().dtype != np.object
+    assert dw.get_data().dtype != np.dtype(object)
 
 
 def fake_frames(seq_name, field_name, value_seq):

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import tempfile
 import numpy as np
+import warnings
 
 import pytest
 
@@ -12,7 +13,7 @@ from io import BytesIO
 from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.compat.py3k import asbytes
 
-from nibabel.testing import data_path
+from nibabel.testing import data_path, error_warnings, clear_and_catch_warnings
 
 from .test_tractogram import assert_tractogram_equal
 from ..tractogram import Tractogram, LazyTractogram
@@ -142,7 +143,7 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                with pytest.warns(Warning if lazy_load else None):
+                with pytest.warns(Warning) if lazy_load else error_warnings():
                     assert_tractogram_equal(tfile.tractogram,
                                             DATA['empty_tractogram'])
 
@@ -158,7 +159,7 @@ class TestLoadSave(unittest.TestCase):
                 else:
                     assert type(tfile.tractogram), LazyTractogram
 
-                with pytest.warns(Warning if lazy_load else None):
+                with pytest.warns(Warning) if lazy_load else error_warnings():
                     assert_tractogram_equal(tfile.tractogram,
                                             DATA['simple_tractogram'])
 
@@ -184,7 +185,7 @@ class TestLoadSave(unittest.TestCase):
                     data = DATA['data_per_streamline']
                     tractogram.data_per_streamline = data
 
-                with pytest.warns(Warning if lazy_load else None):
+                with pytest.warns(Warning) if lazy_load else error_warnings():
                     assert_tractogram_equal(tfile.tractogram,
                                             tractogram)
 
@@ -244,7 +245,8 @@ class TestLoadSave(unittest.TestCase):
                     ((not cls.SUPPORTS_DATA_PER_POINT) +
                      (not cls.SUPPORTS_DATA_PER_STREAMLINE))
 
-                with pytest.warns(Warning if nb_expected_warnings else None) as w:
+                with clear_and_catch_warnings() as w:
+                    warnings.simplefilter('always')
                     nib.streamlines.save(complex_tractogram, filename)
                 assert len(w) == nb_expected_warnings
 

--- a/nibabel/streamlines/tests/test_tck.py
+++ b/nibabel/streamlines/tests/test_tck.py
@@ -15,7 +15,7 @@ from ..tck import TckFile
 
 import pytest
 from numpy.testing import assert_array_equal
-from ...testing import data_path
+from ...testing import data_path, error_warnings
 from .test_tractogram import assert_tractogram_equal
 
 DATA = {}
@@ -47,13 +47,13 @@ class TestTCK(unittest.TestCase):
     def test_load_empty_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['empty_tck_fname'], lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(tck.tractogram, DATA['empty_tractogram'])
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_fname'], lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
 
         # Force TCK loading to use buffering.
@@ -88,7 +88,7 @@ class TestTCK(unittest.TestCase):
         for lazy_load in [False, True]:
             tck = TckFile.load(DATA['simple_tck_big_endian_fname'],
                                lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(tck.tractogram, DATA['simple_tractogram'])
             assert tck.header['datatype'] == 'Float32BE'
 

--- a/nibabel/streamlines/tests/test_trk.py
+++ b/nibabel/streamlines/tests/test_trk.py
@@ -8,7 +8,7 @@ from os.path import join as pjoin
 from io import BytesIO
 
 import pytest
-from ...testing import data_path, clear_and_catch_warnings, assert_arr_dict_equal
+from ...testing import data_path, clear_and_catch_warnings, assert_arr_dict_equal, error_warnings
 from numpy.testing import assert_array_equal
 
 from .test_tractogram import assert_tractogram_equal
@@ -87,19 +87,19 @@ class TestTRK(unittest.TestCase):
     def test_load_empty_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['empty_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(trk.tractogram, DATA['empty_tractogram'])
 
     def test_load_simple_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['simple_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(trk.tractogram, DATA['simple_tractogram'])
 
     def test_load_complex_file(self):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['complex_trk_fname'], lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(trk.tractogram, DATA['complex_tractogram'])
 
     def trk_with_bytes(self, trk_key='simple_trk_fname', endian='<'):
@@ -199,7 +199,7 @@ class TestTRK(unittest.TestCase):
         for lazy_load in [False, True]:
             trk = TrkFile.load(DATA['complex_trk_big_endian_fname'],
                                lazy_load=lazy_load)
-            with pytest.warns(Warning if lazy_load else None):
+            with pytest.warns(Warning) if lazy_load else error_warnings():
                 assert_tractogram_equal(trk.tractogram, DATA['complex_tractogram'])
 
     def test_tractogram_file_properties(self):

--- a/nibabel/tests/test_quaternions.py
+++ b/nibabel/tests/test_quaternions.py
@@ -13,7 +13,7 @@ from numpy import pi
 
 import pytest
 
-from numpy.testing import assert_array_almost_equal, assert_array_equal, dec
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from .. import quaternions as nq
 from .. import eulerangles as nea
@@ -122,7 +122,6 @@ def test_norm():
     assert not nq.isunit(qi)
 
 
-@dec.slow
 @pytest.mark.parametrize("M1, q1", eg_pairs[0::4])
 @pytest.mark.parametrize("M2, q2", eg_pairs[1::4])
 def test_mult(M1, q1, M2, q2):

--- a/tools/ci/build_archive.sh
+++ b/tools/ci/build_archive.sh
@@ -11,18 +11,21 @@ echo "INSTALL_TYPE = $INSTALL_TYPE"
 
 set -x
 
-if [ "$INSTALL_TYPE" == "sdist" ]; then
-    python setup.py egg_info  # check egg_info while we're here
-    python setup.py sdist
-    export ARCHIVE=$( ls dist/*.tar.gz )
-elif [ "$INSTALL_TYPE" == "wheel" ]; then
-    python setup.py bdist_wheel
-    export ARCHIVE=$( ls dist/*.whl )
-elif [ "$INSTALL_TYPE" == "archive" ]; then
-    export ARCHIVE="package.tar.gz"
+if [ "$INSTALL_TYPE" = "sdist" -o "$INSTALL_TYPE" = "wheel" ]; then
+    python -m build
+elif [ "$INSTALL_TYPE" = "archive" ]; then
+    ARCHIVE="package.tar.gz"
     git archive -o $ARCHIVE HEAD
-elif [ "$INSTALL_TYPE" == "pip" ]; then
-    export ARCHIVE="."
 fi
+
+if [ "$INSTALL_TYPE" = "sdist" ]; then
+    ARCHIVE=$( ls dist/*.tar.gz )
+elif [ "$INSTALL_TYPE" = "wheel" ]; then
+    ARCHIVE=$( ls dist/*.whl )
+elif [ "$INSTALL_TYPE" = "pip" ]; then
+    ARCHIVE="."
+fi
+
+export ARCHIVE
 
 set +eux

--- a/tools/ci/build_archive.sh
+++ b/tools/ci/build_archive.sh
@@ -14,16 +14,16 @@ set -x
 if [ "$INSTALL_TYPE" = "sdist" -o "$INSTALL_TYPE" = "wheel" ]; then
     python -m build
 elif [ "$INSTALL_TYPE" = "archive" ]; then
-    ARCHIVE="package.tar.gz"
+    ARCHIVE="/tmp/package.tar.gz"
     git archive -o $ARCHIVE HEAD
 fi
 
 if [ "$INSTALL_TYPE" = "sdist" ]; then
-    ARCHIVE=$( ls dist/*.tar.gz )
+    ARCHIVE=$( ls $PWD/dist/*.tar.gz )
 elif [ "$INSTALL_TYPE" = "wheel" ]; then
-    ARCHIVE=$( ls dist/*.whl )
+    ARCHIVE=$( ls $PWD/dist/*.whl )
 elif [ "$INSTALL_TYPE" = "pip" ]; then
-    ARCHIVE="."
+    ARCHIVE="$PWD"
 fi
 
 export ARCHIVE

--- a/tools/ci/env.sh
+++ b/tools/ci/env.sh
@@ -1,4 +1,4 @@
-SETUP_REQUIRES="pip setuptools>=30.3.0 wheel"
+SETUP_REQUIRES="pip build"
 
 # Minimum requirements
 REQUIREMENTS="-r requirements.txt"

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -18,10 +18,15 @@ if [ -n "$EXTRA_PIP_FLAGS" ]; then
     EXTRA_PIP_FLAGS=${!EXTRA_PIP_FLAGS}
 fi
 
-pip install $EXTRA_PIP_FLAGS $ARCHIVE
+(
+  # Ensure installation does not depend on being in source tree
+  mkdir ../unversioned_install_dir
+  cd ../unversioned_install_dir
+  pip install $EXTRA_PIP_FLAGS $ARCHIVE
 
-# Basic import check
-python -c 'import nibabel; print(nibabel.__version__)'
+  # Basic import check
+  python -c 'import nibabel; print(nibabel.__version__)'
+)
 
 if [ "$CHECK_TYPE" == "skiptests" ]; then
     exit 0

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -18,11 +18,7 @@ if [ -n "$EXTRA_PIP_FLAGS" ]; then
     EXTRA_PIP_FLAGS=${!EXTRA_PIP_FLAGS}
 fi
 
-if [ "$INSTALL_TYPE" == "setup" ]; then
-    python setup.py install
-else
-    pip install $EXTRA_PIP_FLAGS $ARCHIVE
-fi
+pip install $EXTRA_PIP_FLAGS $ARCHIVE
 
 # Basic import check
 python -c 'import nibabel; print(nibabel.__version__)'


### PR DESCRIPTION
This PR:

* Drops `python setup.py` calls from tests in favor of `python -m build` and `pip install`
* While working on CI, reduce warnings that have been starting to pop up.