### PR TITLE
ENH: Add dtype argument to Cifti2Image

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -19,6 +19,10 @@ Definition of the CIFTI-2 header format and file extensions can be found at:
 import re
 from collections.abc import MutableSequence, MutableMapping, Iterable
 from collections import OrderedDict
+from warnings import warn
+
+import numpy as np
+
 from .. import xmlutils as xml
 from ..filebasedimages import FileBasedHeader, SerializableImage
 from ..dataobj_images import DataobjImage
@@ -26,7 +30,7 @@ from ..nifti1 import Nifti1Extensions
 from ..nifti2 import Nifti2Image, Nifti2Header
 from ..arrayproxy import reshape_dataobj
 from ..caret import CaretMetaData
-from warnings import warn
+from ..volumeutils import make_dt_codes
 
 
 def _float_01(val):
@@ -1383,7 +1387,8 @@ class Cifti2Image(DataobjImage, SerializableImage):
                  header=None,
                  nifti_header=None,
                  extra=None,
-                 file_map=None):
+                 file_map=None,
+                 dtype=None):
         """ Initialize image
 
         The image is a combination of (dataobj, header), with optional metadata
@@ -1415,9 +1420,10 @@ class Cifti2Image(DataobjImage, SerializableImage):
         self._nifti_header = LimitedNifti2Header.from_header(nifti_header)
 
         # if NIfTI header not specified, get data type from input array
-        if nifti_header is None:
-            if hasattr(dataobj, 'dtype'):
-                self._nifti_header.set_data_dtype(dataobj.dtype)
+        if dtype is not None:
+            self.set_data_dtype(dtype)
+        elif nifti_header is None and hasattr(dataobj, 'dtype'):
+            self.set_data_dtype(dataobj.dtype)
         self.update_headers()
 
         if self._dataobj.shape != self.header.matrix.get_data_shape():

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -41,6 +41,22 @@ class Cifti2HeaderError(Exception):
     """
 
 
+_dtdefs = (  # code, label, dtype definition, niistring
+    (2, 'uint8', np.uint8, "NIFTI_TYPE_UINT8"),
+    (4, 'int16', np.int16, "NIFTI_TYPE_INT16"),
+    (8, 'int32', np.int32, "NIFTI_TYPE_INT32"),
+    (16, 'float32', np.float32, "NIFTI_TYPE_FLOAT32"),
+    (64, 'float64', np.float64, "NIFTI_TYPE_FLOAT64"),
+    (256, 'int8', np.int8, "NIFTI_TYPE_INT8"),
+    (512, 'uint16', np.uint16, "NIFTI_TYPE_UINT16"),
+    (768, 'uint32', np.uint32, "NIFTI_TYPE_UINT32"),
+    (1024, 'int64', np.int64, "NIFTI_TYPE_INT64"),
+    (1280, 'uint64', np.uint64, "NIFTI_TYPE_UINT64"),
+)
+
+# Make full code alias bank, including dtype column
+data_type_codes = make_dt_codes(_dtdefs)
+
 CIFTI_MAP_TYPES = ('CIFTI_INDEX_TYPE_BRAIN_MODELS',
                    'CIFTI_INDEX_TYPE_PARCELS',
                    'CIFTI_INDEX_TYPE_SERIES',
@@ -101,6 +117,10 @@ def _underscore(string):
     """ Convert a string from CamelCase to underscored """
     string = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1_\2', string)
     return re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', string).lower()
+
+
+class LimitedNifti2Header(Nifti2Header):
+    _data_type_codes = data_type_codes
 
 
 class Cifti2MetaData(CaretMetaData):
@@ -1392,7 +1412,7 @@ class Cifti2Image(DataobjImage, SerializableImage):
             header = Cifti2Header.from_axes(header)
         super(Cifti2Image, self).__init__(dataobj, header=header,
                                           extra=extra, file_map=file_map)
-        self._nifti_header = Nifti2Header.from_header(nifti_header)
+        self._nifti_header = LimitedNifti2Header.from_header(nifti_header)
 
         # if NIfTI header not specified, get data type from input array
         if nifti_header is None:

--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -12,7 +12,7 @@ from nibabel.cifti2.cifti2 import _float_01, _value_if_klass, Cifti2HeaderError
 import pytest
 
 from nibabel.tests.test_dataobj_images import TestDataobjAPI as _TDA
-from nibabel.tests.test_image_api import SerializeMixin
+from nibabel.tests.test_image_api import SerializeMixin, DtypeOverrideMixin
 
 
 def compare_xml_leaf(str1, str2):
@@ -415,7 +415,7 @@ def test_underscoring():
         assert ci.cifti2._underscore(camel) == underscored
 
 
-class TestCifti2ImageAPI(_TDA, SerializeMixin):
+class TestCifti2ImageAPI(_TDA, SerializeMixin, DtypeOverrideMixin):
     """ Basic validation for Cifti2Image instances
     """
     # A callable returning an image from ``image_maker(data, header)``
@@ -426,6 +426,8 @@ class TestCifti2ImageAPI(_TDA, SerializeMixin):
     ni_header_maker = Nifti2Header
     example_shapes = ((2,), (2, 3), (2, 3, 4))
     standard_extension = '.nii'
+    storable_dtypes = (np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32,
+                       np.int64, np.uint64, np.float32, np.float64)
 
     def make_imaker(self, arr, header=None, ni_header=None):
         for idx, sz in enumerate(arr.shape):


### PR DESCRIPTION
To bring into line with other Analyze-like formats.

Given that the subject that brought us here was inappropriate use of image dtypes, I am also constraining the dtypes to those listed in the standard:

> The datatype field in the NIfTI header can be any of float, double, and signed or unsigned int8,
int16, int32, or int64, with bitpix set correspondingly, per the NIfTI standard. Composite
datatypes, such as complex or RGB, and bitwise storage are not supported in CIFTI. Multiple
scalar maps, or separate files, can be used instead of composite datatypes.

I also dropped float128, which is not specifically restricted, but nor is it specifically permitted. Seems unlikely to be a good idea.