### PR TITLE
ENH: Add minimal support for TRKv3

### DIFF
--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -593,7 +593,10 @@ class TrkFile(TractogramFile):
             if header_rec['version'] == 1:
                 # There is no 4x4 matrix for voxel to RAS transformation.
                 header_rec[Field.VOXEL_TO_RASMM] = np.zeros((4, 4))
-            elif header_rec['version'] == 2:
+            elif header_rec['version'] == 3:
+                warnings.warn('Parsing a TRK v3 file as v2. Some features may not '
+                              'be handled correctly.', HeaderWarning)
+            elif header_rec['version'] in (2, 3):
                 pass  # Nothing more to do.
             else:
                 raise HeaderError('NiBabel only supports versions 1 and 2 of '


### PR DESCRIPTION
Closes #1123.

This is not ideal, but if TrackVis is producing v3 files without documenting what's in them, I can't see many better options.

The example data file I was given does successfully parse, but at 240MB (and possibly not available for public distribution), I will skip including it as a test file.

@MarcCote @jchoude I don't know if you've got any insights here...