### PR TITLE
MNT: Expire ArrayWriter.to_fileobj(nan2zero=...) argument

### DIFF
--- a/nibabel/arraywriters.py
+++ b/nibabel/arraywriters.py
@@ -29,13 +29,12 @@ something else to make sense of conversions between float and int, or between
 larger ints and smaller.
 """
 
-import warnings
-
 import numpy as np
 
 from .casting import (int_to_float, as_int, int_abs, type_info, floor_exact,
                       best_float, shared_range)
 from .volumeutils import finite_range, array_to_file
+from .deprecator import ExpiredDeprecationError
 
 
 class WriterError(Exception):
@@ -192,11 +191,12 @@ class ArrayWriter(object):
         if nan2zero != self._nan2zero:
             raise WriterError('Deprecated `nan2zero` argument to `to_fileobj` '
                               'must be same as class value set in __init__')
-        warnings.warn('Please remove `nan2zero` from call to ' '`to_fileobj` '
-                      'and use in instance __init__ instead.\n'
-                      '* deprecated in version: 2.0\n'
-                      '* will raise error in version: 4.0\n',
-                      DeprecationWarning, stacklevel=3)
+        raise ExpiredDeprecationError(
+            'Please remove `nan2zero` from call to `to_fileobj` '
+            'and use in instance __init__ instead.\n'
+            '* deprecated in version: 2.0\n'
+            '* Raises ExpiredDeprecationError as of version: 4.0\n'
+        )
 
     def _needs_nan2zero(self):
         """ True if nan2zero check needed for writing array """

--- a/nibabel/tests/test_arraywriters.py
+++ b/nibabel/tests/test_arraywriters.py
@@ -13,11 +13,11 @@ from ..arraywriters import (SlopeInterArrayWriter, SlopeArrayWriter,
                             make_array_writer, get_slope_inter)
 from ..casting import int_abs, type_info, shared_range, on_powerpc
 from ..volumeutils import array_from_file, apply_read_scaling, _dt_min_max
+from ..deprecator import ExpiredDeprecationError
 
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 import pytest
-from ..testing import (assert_allclose_safely, suppress_warnings,
-                       error_warnings)
+from ..testing import assert_allclose_safely, suppress_warnings
 
 
 FLOAT_TYPES = np.sctypes['float']
@@ -506,12 +506,11 @@ def test_nan2zero():
         aw = awt(arr, np.float32, **kwargs)
         data_back = round_trip(aw)
         assert_array_equal(np.isnan(data_back), [True, False])
-        # Deprecation warning for nan2zero as argument to `to_fileobj`
-        with error_warnings():
-            with pytest.deprecated_call():
-                aw.to_fileobj(BytesIO(), 'F', True)
-            with pytest.deprecated_call():
-                aw.to_fileobj(BytesIO(), 'F', nan2zero=True)
+        # Expired deprecation error for nan2zero as argument to `to_fileobj`
+        with pytest.raises(ExpiredDeprecationError):
+            aw.to_fileobj(BytesIO(), 'F', True)
+        with pytest.raises(ExpiredDeprecationError):
+            aw.to_fileobj(BytesIO(), 'F', nan2zero=True)
         # Error if nan2zero is not the value set at initialization
         with pytest.raises(WriterError):
             aw.to_fileobj(BytesIO(), 'F', False)
@@ -528,12 +527,11 @@ def test_nan2zero():
         data_back = round_trip(aw)
         astype_res = np.array(np.nan).astype(np.int32)
         assert_array_equal(data_back, [astype_res, 99])
-        # Deprecation warning for nan2zero as argument to `to_fileobj`
-        with error_warnings():
-            with pytest.deprecated_call():
-                aw.to_fileobj(BytesIO(), 'F', False)
-            with pytest.deprecated_call():
-                aw.to_fileobj(BytesIO(), 'F', nan2zero=False)
+        # Expired deprecation error for nan2zero as argument to `to_fileobj`
+        with pytest.raises(ExpiredDeprecationError):
+            aw.to_fileobj(BytesIO(), 'F', False)
+        with pytest.raises(ExpiredDeprecationError):
+            aw.to_fileobj(BytesIO(), 'F', nan2zero=False)
         # Error if nan2zero is not the value set at initialization
         with pytest.raises(WriterError):
             aw.to_fileobj(BytesIO(), 'F', True)

--- a/nibabel/tests/test_removalschedule.py
+++ b/nibabel/tests/test_removalschedule.py
@@ -62,6 +62,7 @@ ATTRIBUTE_SCHEDULE = [
                ("nibabel.ecat", "EcatImage", "from_filespec"),
                ("nibabel.filebasedimages", "FileBasedImage", "get_header"),
                ("nibabel.spatialimages", "SpatialImage", "get_affine"),
+               ("nibabel.arraywriters", "ArrayWriter", "_check_nan2zero"),
     ]),
     ("4.0.0", [("nibabel.dataobj_images", "DataobjImage", "get_shape"),
                ("nibabel.filebasedimages", "FileBasedImage", "filespec_to_files"),


### PR DESCRIPTION
Noticed this. Since it doesn't use the usual deprecation machinery, I missed it.