### PR TITLE
FIX: Make GiftiMetaData.data a list proxy, deprecate

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -108,10 +108,11 @@ class GiftiMetaData(CaretMetaData):
         return (), {pair.name: pair.value}
 
     @property
+    @deprecate_with_version(
+        'The data attribute is deprecated. Use GiftiMetaData object '
+        'directly as a dict.',
+        '4.0', '6.0')
     def data(self):
-        warnings.warn(
-            "GiftiMetaData.data will be a dict in NiBabel 6.0.",
-            FutureWarning, stacklevel=2)
         return _GiftiMDList(self)
 
     @classmethod
@@ -130,7 +131,7 @@ class GiftiMetaData(CaretMetaData):
 
     @property
     @deprecate_with_version(
-        'metadata property deprecated. Use GiftiMetadata object '
+        'metadata property deprecated. Use GiftiMetaData object '
         'as dict or pass to dict() for a standard dictionary.',
         '4.0', '6.0')
     def metadata(self):
@@ -149,6 +150,10 @@ class GiftiNVPairs:
     name : str
     value : str
     """
+    @deprecate_with_version(
+        'GiftiNVPairs objects are deprecated. Use the GiftiMetaData object '
+        'as a dict, instead.',
+        '4.0', '6.0')
     def __init__(self, name=u'', value=u''):
         self._name = name
         self._value = value
@@ -156,7 +161,10 @@ class GiftiNVPairs:
 
     @classmethod
     def _private_init(cls, name, value, md):
-        self = cls(name, value)
+        """Private init method to provide warning-free experience"""
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            self = cls(name, value)
         self._container = md
         return self
 

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -228,7 +228,8 @@ def test_labeltable():
 def test_metadata():
     md = GiftiMetaData(key='value')
     # Old initialization methods
-    nvpair = GiftiNVPairs('key', 'value')
+    with pytest.warns(DeprecationWarning) as w:
+        nvpair = GiftiNVPairs('key', 'value')
     with pytest.warns(FutureWarning) as w:
         md2 = GiftiMetaData(nvpair=nvpair)
     assert len(w) == 1
@@ -236,7 +237,7 @@ def test_metadata():
         md3 = GiftiMetaData.from_dict({'key': 'value'})
     assert md == md2 == md3 == {'key': 'value'}
     # .data as a list of NVPairs is going away
-    with pytest.warns(FutureWarning) as w:
+    with pytest.warns(DeprecationWarning) as w:
         assert md.data[0].name == 'key'
         assert md.data[0].value == 'value'
     assert len(w) == 2
@@ -247,7 +248,7 @@ def test_metadata():
 
 def test_metadata_list_interface():
     md = GiftiMetaData(key='value')
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         mdlist = md.data
     assert len(mdlist) == 1
     assert mdlist[0].name == 'key'
@@ -264,7 +265,8 @@ def test_metadata_list_interface():
     assert md['foo'] == 'bar'
 
     # Append new NVPair
-    nvpair = GiftiNVPairs('key', 'value')
+    with pytest.warns(DeprecationWarning) as w:
+        nvpair = GiftiNVPairs('key', 'value')
     mdlist.append(nvpair)
     assert len(mdlist) == 2
     assert mdlist[1].name == 'key'
@@ -278,14 +280,16 @@ def test_metadata_list_interface():
     assert len(md) == 0
 
     # Extension adds multiple keys
-    foobar = GiftiNVPairs('foo', 'bar')
+    with pytest.warns(DeprecationWarning) as w:
+        foobar = GiftiNVPairs('foo', 'bar')
     mdlist.extend([nvpair, foobar])
     assert len(mdlist) == 2
     assert len(md) == 2
     assert md == {'key': 'value', 'foo': 'bar'}
 
     # Insertion updates list order, though we don't attempt to preserve it in the dict
-    lastone = GiftiNVPairs('last', 'one')
+    with pytest.warns(DeprecationWarning) as w:
+        lastone = GiftiNVPairs('last', 'one')
     mdlist.insert(1, lastone)
     assert len(mdlist) == 3
     assert len(md) == 3
@@ -314,7 +318,8 @@ def test_metadata_list_interface():
     assert md == {'last': 'one'}
 
     # And let's remove an old pair with a new object
-    lastoneagain = GiftiNVPairs('last', 'one')
+    with pytest.warns(DeprecationWarning) as w:
+        lastoneagain = GiftiNVPairs('last', 'one')
     mdlist.remove(lastoneagain)
     assert len(mdlist) == 0
     assert len(md) == 0

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -147,7 +147,7 @@ def test_default_types():
         # GiftiMetaData
         assert_default_types(img.meta)
         # GiftiNVPairs - Remove in NIB6
-        with pytest.warns(FutureWarning):
+        with pytest.warns(DeprecationWarning):
             for nvpair in img.meta.data:
                 assert_default_types(nvpair)
         # GiftiLabelTable
@@ -161,7 +161,7 @@ def test_default_types():
             # GiftiMetaData
             assert_default_types(darray.meta)
             # GiftiNVPairs - Remove in NIB6
-            with pytest.warns(FutureWarning):
+            with pytest.warns(DeprecationWarning):
                 for nvpair in darray.meta.data:
                     assert_default_types(nvpair)
 

--- a/nibabel/tests/test_removalschedule.py
+++ b/nibabel/tests/test_removalschedule.py
@@ -12,6 +12,8 @@ MODULE_SCHEDULE = [
 ]
 
 OBJECT_SCHEDULE = [
+    ("7.0.0", [("nibabel.gifti.gifti", "GiftiNVPairs"),
+    ]),
     ("6.0.0", [("nibabel.loadsave", "guessed_image_type"),
                ("nibabel.loadsave", "read_img_data"),
                ("nibabel.orientations", "flip_axis"),
@@ -41,6 +43,7 @@ OBJECT_SCHEDULE = [
 ATTRIBUTE_SCHEDULE = [
     ("7.0.0", [("nibabel.gifti.gifti", "GiftiMetaData", "from_dict"),
                ("nibabel.gifti.gifti", "GiftiMetaData", "metadata"),
+               ("nibabel.gifti.gifti", "GiftiMetaData", "data"),
     ]),
     ("5.0.0", [("nibabel.dataobj_images", "DataobjImage", "get_data"),
                ("nibabel.freesurfer.mghformat", "MGHHeader", "_header_data"),


### PR DESCRIPTION
This is a follow-up to #1091 with things that should have been done there, including proxying actions on the `GiftiMetaData.data` internal list and deprecating the property altogether.

I added a comprehensive test that checks that attempting to use `GiftiMetaData.data` as one might have pre-4.0 works once again.