### PR TITLE
ENH: Add to/from_stream methods and from_url classmethod to SerializableImage

### DIFF
--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -540,27 +540,27 @@ class SerializableImage(FileBasedImage):
     """
 
     @classmethod
-    def _filemap_from_iobase(klass, ioobject: io.IOBase):
+    def _filemap_from_iobase(klass, io_obj: io.IOBase):
         """For single-file image types, make a file map with the correct key"""
         if len(klass.files_types) > 1:
             raise NotImplementedError(
                 "(de)serialization is undefined for multi-file images"
             )
-        return klass.make_file_map({klass.files_types[0][0]: ioobject})
+        return klass.make_file_map({klass.files_types[0][0]: io_obj})
 
     @classmethod
-    def _from_iobase(klass, ioobject: io.IOBase):
+    def _from_iobase(klass, io_obj: io.IOBase):
         """Load image from readable IO stream
 
         Convert to BytesIO to enable seeking, if input stream is not seekable
         """
-        if not ioobject.seekable():
-            ioobject = io.BytesIO(ioobject.read())
-        return klass.from_file_map(klass._filemap_from_iobase(ioobject))
+        if not io_obj.seekable():
+            io_obj = io.BytesIO(io_obj.read())
+        return klass.from_file_map(klass._filemap_from_iobase(io_obj))
 
-    def _to_iobase(self, ioobject: io.IOBase, **kwargs):
+    def _to_iobase(self, io_obj: io.IOBase, **kwargs):
         """Save image from writable IO stream"""
-        self.to_file_map(self._filemap_from_iobase(ioobject), **kwargs)
+        self.to_file_map(self._filemap_from_iobase(io_obj), **kwargs)
 
     @classmethod
     def from_bytes(klass, bytestring: bytes):

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -549,17 +549,30 @@ class SerializableImage(FileBasedImage):
         return klass.make_file_map({klass.files_types[0][0]: io_obj})
 
     @classmethod
-    def _from_iobase(klass, io_obj: io.IOBase):
+    def from_stream(klass, io_obj: io.IOBase):
         """Load image from readable IO stream
 
         Convert to BytesIO to enable seeking, if input stream is not seekable
+
+        Parameters
+        ----------
+        io_obj : IOBase object
+            Readable stream
         """
         if not io_obj.seekable():
             io_obj = io.BytesIO(io_obj.read())
         return klass.from_file_map(klass._filemap_from_iobase(io_obj))
 
-    def _to_iobase(self, io_obj: io.IOBase, **kwargs):
-        """Save image from writable IO stream"""
+    def to_stream(self, io_obj: io.IOBase, **kwargs):
+        """Save image to writable IO stream
+
+        Parameters
+        ----------
+        io_obj : IOBase object
+            Writable stream
+        \*\*kwargs : keyword arguments
+            Keyword arguments that may be passed to ``img.to_file_map()``
+        """
         self.to_file_map(self._filemap_from_iobase(io_obj), **kwargs)
 
     @classmethod
@@ -573,7 +586,7 @@ class SerializableImage(FileBasedImage):
         bstring : bytes
             Byte string containing the on-disk representation of an image
         """
-        return klass._from_iobase(io.BytesIO(bytestring))
+        return klass.from_stream(io.BytesIO(bytestring))
 
     def to_bytes(self, **kwargs) -> bytes:
         r""" Return a ``bytes`` object with the contents of the file that would
@@ -590,7 +603,7 @@ class SerializableImage(FileBasedImage):
             Serialized image
         """
         bio = io.BytesIO()
-        self._to_iobase(bio, **kwargs)
+        self.to_stream(bio, **kwargs)
         return bio.getvalue()
 
     @classmethod
@@ -603,6 +616,8 @@ class SerializableImage(FileBasedImage):
         ----------
         url : str or urllib.request.Request object
             URL of file to retrieve
+        timeout : float, optional
+            Time (in seconds) to wait for a response
         """
         response = request.urlopen(url, timeout=timeout)
-        return klass._from_iobase(response)
+        return klass.from_stream(response)

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -10,6 +10,7 @@
 
 import io
 from copy import deepcopy
+from urllib import request
 from .fileholders import FileHolder
 from .filename_parser import (types_filenames, TypesFilenamesError,
                               splitext_addext)
@@ -488,7 +489,7 @@ class FileBasedImage(object):
 
 class SerializableImage(FileBasedImage):
     """
-    Abstract image class for (de)serializing images to/from byte strings.
+    Abstract image class for (de)serializing images to/from byte streams/strings.
 
     The class doesn't define any image properties.
 
@@ -501,6 +502,7 @@ class SerializableImage(FileBasedImage):
     classmethods:
 
        * from_bytes(bytestring) - make instance by deserializing a byte string
+       * from_url(url) - make instance by fetching and deserializing a URL
 
     Loading from byte strings should provide round-trip equivalence:
 
@@ -538,7 +540,30 @@ class SerializableImage(FileBasedImage):
     """
 
     @classmethod
-    def from_bytes(klass, bytestring):
+    def _filemap_from_iobase(klass, ioobject: io.IOBase):
+        """For single-file image types, make a file map with the correct key"""
+        if len(klass.files_types) > 1:
+            raise NotImplementedError(
+                "(de)serialization is undefined for multi-file images"
+            )
+        return klass.make_file_map({klass.files_types[0][0]: ioobject})
+
+    @classmethod
+    def _from_iobase(klass, ioobject: io.IOBase):
+        """Load image from readable IO stream
+
+        Convert to BytesIO to enable seeking, if input stream is not seekable
+        """
+        if not ioobject.seekable():
+            ioobject = io.BytesIO(ioobject.read())
+        return klass.from_file_map(klass._filemap_from_iobase(ioobject))
+
+    def _to_iobase(self, ioobject: io.IOBase, **kwargs):
+        """Save image from writable IO stream"""
+        self.to_file_map(self._filemap_from_iobase(ioobject), **kwargs)
+
+    @classmethod
+    def from_bytes(klass, bytestring: bytes):
         """ Construct image from a byte string
 
         Class method
@@ -548,13 +573,9 @@ class SerializableImage(FileBasedImage):
         bstring : bytes
             Byte string containing the on-disk representation of an image
         """
-        if len(klass.files_types) > 1:
-            raise NotImplementedError("from_bytes is undefined for multi-file images")
-        bio = io.BytesIO(bytestring)
-        file_map = klass.make_file_map({'image': bio, 'header': bio})
-        return klass.from_file_map(file_map)
+        return klass._from_iobase(io.BytesIO(bytestring))
 
-    def to_bytes(self, **kwargs):
+    def to_bytes(self, **kwargs) -> bytes:
         r""" Return a ``bytes`` object with the contents of the file that would
         be written if the image were saved.
 
@@ -568,9 +589,20 @@ class SerializableImage(FileBasedImage):
         bytes
             Serialized image
         """
-        if len(self.__class__.files_types) > 1:
-            raise NotImplementedError("to_bytes() is undefined for multi-file images")
         bio = io.BytesIO()
-        file_map = self.make_file_map({'image': bio, 'header': bio})
-        self.to_file_map(file_map, **kwargs)
+        self._to_iobase(bio, **kwargs)
         return bio.getvalue()
+
+    @classmethod
+    def from_url(klass, url, timeout=5):
+        """Retrieve and load an image from a URL
+
+        Class method
+
+        Parameters
+        ----------
+        url : str or urllib.request.Request object
+            URL of file to retrieve
+        """
+        with request.urlopen(url, timeout=timeout) as response:
+            return klass._from_iobase(response)

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -604,5 +604,5 @@ class SerializableImage(FileBasedImage):
         url : str or urllib.request.Request object
             URL of file to retrieve
         """
-        with request.urlopen(url, timeout=timeout) as response:
-            return klass._from_iobase(response)
+        response = request.urlopen(url, timeout=timeout)
+        return klass._from_iobase(response)

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -573,9 +573,10 @@ class SerializeMixin(object):
                 del img_b
 
     @pytest.fixture(autouse=True)
-    def setup(self, httpserver):
+    def setup(self, httpserver, tmp_path):
         """Make pytest fixtures available to validate functions"""
         self.httpserver = httpserver
+        self.tmp_path = tmp_path
 
     def validate_from_url(self, imaker, params):
         server = self.httpserver
@@ -593,6 +594,22 @@ class SerializeMixin(object):
         assert np.array_equal(img.get_fdata(), rt_img.get_fdata())
         del img
         del rt_img
+
+    def validate_from_file_url(self, imaker, params):
+        tmp_path = self.tmp_path
+
+        img = imaker()
+        import uuid
+        fname = tmp_path / f'img-{uuid.uuid4()}{self.standard_extension}'
+        img.to_filename(fname)
+
+        rt_img = img.__class__.from_url(f"file:///{fname}")
+
+        assert self._header_eq(img.header, rt_img.header)
+        assert np.array_equal(img.get_fdata(), rt_img.get_fdata())
+        del img
+        del rt_img
+
 
     @staticmethod
     def _header_eq(header_a, header_b):

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -26,6 +26,7 @@ What is the image API?
 import warnings
 from functools import partial
 from itertools import product
+import io
 import pathlib
 
 import numpy as np
@@ -523,34 +524,41 @@ class AffineMixin(object):
             img.get_affine()
 
 
-class SerializeMixin(object):
-    def validate_to_bytes(self, imaker, params):
+class SerializeMixin:
+    def validate_to_from_stream(self, imaker, params):
         img = imaker()
-        serialized = img.to_bytes()
-        with InTemporaryDirectory():
-            fname = 'img' + self.standard_extension
-            img.to_filename(fname)
-            with open(fname, 'rb') as fobj:
-                file_contents = fobj.read()
-        assert serialized == file_contents
+        klass = getattr(self, 'klass', img.__class__)
+        stream = io.BytesIO()
+        img.to_stream(stream)
 
-    def validate_from_bytes(self, imaker, params):
+        rt_img = klass.from_stream(stream)
+        assert self._header_eq(img.header, rt_img.header)
+        assert np.array_equal(img.get_fdata(), rt_img.get_fdata())
+
+    def validate_file_stream_equivalence(self, imaker, params):
         img = imaker()
         klass = getattr(self, 'klass', img.__class__)
         with InTemporaryDirectory():
             fname = 'img' + self.standard_extension
             img.to_filename(fname)
 
-            all_images = list(getattr(self, 'example_images', [])) + [{'fname': fname}]
-            for img_params in all_images:
-                img_a = klass.from_filename(img_params['fname'])
-                with open(img_params['fname'], 'rb') as fobj:
-                    img_b = klass.from_bytes(fobj.read())
+            with open("stream", "wb") as fobj:
+                img.to_stream(fobj)
 
-                assert self._header_eq(img_a.header, img_b.header)
+            # Check that writing gets us the same thing
+            contents1 = pathlib.Path(fname).read_bytes()
+            contents2 = pathlib.Path("stream").read_bytes()
+            assert contents1 == contents2
+
+            # Check that reading gets us the same thing
+            img_a = klass.from_filename(fname)
+            with open(fname, "rb") as fobj:
+                img_b = klass.from_stream(fobj)
+                # This needs to happen while the filehandle is open
                 assert np.array_equal(img_a.get_fdata(), img_b.get_fdata())
-                del img_a
-                del img_b
+            assert self._header_eq(img_a.header, img_b.header)
+            del img_a
+            del img_b
 
     def validate_to_from_bytes(self, imaker, params):
         img = imaker()

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
     pytest !=5.3.4
     pytest-cov
     pytest-doctestplus
+    pytest-httpserver
 zstd =
     pyzstd >= 0.14.3
 all =


### PR DESCRIPTION
Extends #639 to allow `from_url()` to load an image. Does not currently handle gzipped (see #1128 for some more discussion) streams, though this should be doable.

Abstracts to using `io.IOBase` to permit easy extension to other streams, but does not expose it generically at this point.

Tested to work on https://openneuro.org/crn/datasets/ds000117/snapshots/1.0.5/files/sub-01:ses-mri:fmap:sub-01_ses-mri_magnitude1.nii and a `file:///...` option.