### PR TITLE
ENH: Make layout order an initialization parameter of ArrayProxy

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -119,7 +119,8 @@ class ArrayProxy:
         order : {None, 'F', 'C'}, optional, keyword only
             `order` controls the order of the data array layout. Fortran-style,
             column-major order may be indicated with 'F', and C-style, row-major
-            order may be indicated with 'C'. The default order is 'F'.
+            order may be indicated with 'C'. None gives the default order, that
+            comes from the `_default_order` class variable.
         keep_file_open : { None, True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
@@ -133,7 +134,7 @@ class ArrayProxy:
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
         if order not in (None, 'C', 'F'):
-            raise ValueError("order should be one of {'C', 'F'}")
+            raise ValueError("order should be one of {None, 'C', 'F'}")
         self.file_like = file_like
         if hasattr(spec, 'get_data_shape'):
             slope, inter = spec.get_slope_inter()

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -115,7 +115,7 @@ class ArrayProxy:
             True gives the same behavior as ``mmap='c'``.  If `file_like`
             cannot be memory-mapped, ignore `mmap` value and read array from
             file.
-        order : {'F', 'C'}, optional, keyword only
+        order : {None, 'F', 'C'}, optional, keyword only
             `order` controls the order of the data array layout. Fortran-style,
             column-major order may be indicated with 'F', and C-style, row-major
             order may be indicated with 'C'. The default order is 'F'.

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -53,7 +53,7 @@ raised.
 KEEP_FILE_OPEN_DEFAULT = False
 
 
-class ArrayProxy(object):
+class ArrayProxy:
     """ Class to act as proxy for the array that can be read from a file
 
     The array proxy allows us to freeze the passed fileobj and header such that
@@ -83,10 +83,9 @@ class ArrayProxy(object):
     See :mod:`nibabel.minc1`, :mod:`nibabel.ecat` and :mod:`nibabel.parrec` for
     examples.
     """
-    # Assume Fortran array memory layout
     order = 'F'
 
-    def __init__(self, file_like, spec, *, mmap=True, keep_file_open=None):
+    def __init__(self, file_like, spec, *, mmap=True, order=None, keep_file_open=None):
         """Initialize array proxy instance
 
         Parameters
@@ -116,6 +115,10 @@ class ArrayProxy(object):
             True gives the same behavior as ``mmap='c'``.  If `file_like`
             cannot be memory-mapped, ignore `mmap` value and read array from
             file.
+        order : {'F', 'C'}, optional, keyword only
+            `order` controls the order of the data array layout. Fortran-style,
+            column-major order may be indicated with 'F', and C-style, row-major
+            order may be indicated with 'C'. The default order is 'F'.
         keep_file_open : { None, True, False }, optional, keyword only
             `keep_file_open` controls whether a new file handle is created
             every time the image is accessed, or a single file handle is
@@ -128,6 +131,8 @@ class ArrayProxy(object):
         """
         if mmap not in (True, False, 'c', 'r'):
             raise ValueError("mmap should be one of {True, False, 'c', 'r'}")
+        if order not in (None, 'C', 'F'):
+            raise ValueError("order should be one of {'C', 'F'}")
         self.file_like = file_like
         if hasattr(spec, 'get_data_shape'):
             slope, inter = spec.get_slope_inter()
@@ -147,6 +152,8 @@ class ArrayProxy(object):
         # Permit any specifier that can be interpreted as a numpy dtype
         self._dtype = np.dtype(self._dtype)
         self._mmap = mmap
+        if order is not None:
+            self.order = order
         # Flags to keep track of whether a single ImageOpener is created, and
         # whether a single underlying file handle is created.
         self._keep_file_open, self._persist_opener = \

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -190,6 +190,19 @@ def test_proxy_slicing_with_scaling():
     assert_array_equal(arr[sliceobj] * 2.0 + 1.0, prox[sliceobj])
 
 
+@pytest.mark.parametrize("order", ("C", "F"))
+def test_order_override(order):
+    shape = (15, 16, 17)
+    arr = np.arange(np.prod(shape)).reshape(shape)
+    fobj = BytesIO()
+    fobj.write(arr.tobytes(order=order))
+    for klass in (ArrayProxy, CArrayProxy):
+        prox = klass(fobj, (shape, arr.dtype), order=order)
+        assert prox.order == order
+        sliceobj = (None, slice(None), 1, -1)
+        assert_array_equal(arr[sliceobj], prox[sliceobj])
+
+
 def test_is_proxy():
     # Test is_proxy function
     hdr = FunkyHeader((2, 3, 4))

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -88,6 +88,9 @@ def test_init():
     assert ap.shape != shape
     # Data stays the same, also
     assert_array_equal(np.asarray(ap), arr)
+    # You wouldn't do this, but order=None explicitly requests the default order
+    ap2 = ArrayProxy(bio, FunkyHeader(arr.shape), order=None)
+    assert_array_equal(np.asarray(ap2), arr)
     # C order also possible
     bio = BytesIO()
     bio.seek(16)
@@ -97,6 +100,8 @@ def test_init():
     # Illegal init
     with pytest.raises(TypeError):
         ArrayProxy(bio, object())
+    with pytest.raises(ValueError):
+        ArrayProxy(bio, hdr, order='badval')
 
 
 def test_tuplespec():

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -64,6 +64,7 @@ class CArrayProxy(ArrayProxy):
 
 
 class DeprecatedCArrayProxy(ArrayProxy):
+    # Used in test_deprecated_order_classvar. Remove when that test is removed (8.0)
     order = 'C'
 
 


### PR DESCRIPTION
For #1090, it's been useful to set the proxy order dynamically, rather than subclassing `ArrayProxy`. This makes it an initialization argument. I've left it as a class variable on the off-chance that somebody actually uses something like:

```Python
class CArrayProxy(ArrayProxy):
    order = 'C'
```

Minor in-passing cleanups, such as removing the explicit `(object)` superclass and moving the test loops to parametrizations.