### PR TITLE
MNT: Fix spacing and expected error types

### DIFF
--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -853,7 +853,7 @@ class EcatImage(SpatialImage):
     def shape(self):
         x, y, z = self._subheader.get_shape()
         nframes = self._subheader.get_nframes()
-        return(x, y, z, nframes)
+        return (x, y, z, nframes)
 
     def get_mlist(self):
         """ get access to the mlist

--- a/nibabel/tests/test_viewers.py
+++ b/nibabel/tests/test_viewers.py
@@ -55,7 +55,12 @@ def test_viewer():
     v.clim = (0, 3)
     with pytest.raises(ValueError):
         OrthoSlicer3D.clim.fset(v, (0.,))  # bad limits
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        (
+            ValueError,  # MPL3.5 and lower
+            KeyError,    # MPL3.6 and higher
+        )
+    ):
         OrthoSlicer3D.cmap.fset(v, 'foo')  # wrong cmap
 
     # decrement/increment volume numbers via keypress


### PR DESCRIPTION
Style and pre-release tests are failing. This should fix them up.