### PR TITLE
FIX: Testing for extension/signature mismatches shouldn't use sniff 

### DIFF
--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -430,7 +430,7 @@ class FileBasedImage(object):
         try:
             with ImageOpener(meta_fname, 'rb') as fobj:
                 binaryblock = fobj.read(sniff_nbytes)
-        except IOError:
+        except (IOError, EOFError):
             return None
         return (binaryblock, meta_fname)
 

--- a/nibabel/filename_parser.py
+++ b/nibabel/filename_parser.py
@@ -253,7 +253,7 @@ def _iendswith(whole, end):
 
 
 def splitext_addext(filename,
-                    addexts=('.gz', '.bz2'),
+                    addexts=('.gz', '.bz2', '.zst'),
                     match_case=False):
     """ Split ``/pth/fname.ext.gz`` into ``/pth/fname, .ext, .gz``
 

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -22,17 +22,13 @@ from .deprecated import deprecate_with_version
 _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
 
-def _signature_matches_extension(filename, sniff):
+def _signature_matches_extension(filename):
     """Check if signature aka magic number matches filename extension.
 
     Parameters
     ----------
     filename : str or os.PathLike
         Path to the file to check
-
-    sniff : bytes or None
-        First bytes of the file. If not `None` and long enough to contain the
-        signature, avoids having to read the start of the file.
 
     Returns
     -------
@@ -56,12 +52,11 @@ def _signature_matches_extension(filename, sniff):
     if ext not in signatures:
         return True, ""
     expected_signature = signatures[ext]["signature"]
-    if sniff is None or len(sniff) < len(expected_signature):
-        try:
-            with open(filename, "rb") as fh:
-                sniff = fh.read(len(expected_signature))
-        except OSError:
-            return False, f"Could not read file: {filename}"
+    try:
+        with open(filename, "rb") as fh:
+            sniff = fh.read(len(expected_signature))
+    except OSError:
+        return False, f"Could not read file: {filename}"
     if sniff.startswith(expected_signature):
         return True, ""
     format_name = signatures[ext]["format_name"]
@@ -100,7 +95,7 @@ def load(filename, **kwargs):
             img = image_klass.from_filename(filename, **kwargs)
             return img
 
-    matches, msg = _signature_matches_extension(filename, sniff)
+    matches, msg = _signature_matches_extension(filename)
     if not matches:
         raise ImageFileError(msg)
 

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -44,7 +44,8 @@ def _signature_matches_extension(filename):
     """
     signatures = {
         ".gz": {"signature": b"\x1f\x8b", "format_name": "gzip"},
-        ".bz2": {"signature": b"BZh", "format_name": "bzip2"}
+        ".bz2": {"signature": b"BZh", "format_name": "bzip2"},
+        ".zst": {"signature": b"\x28\xb5\x2f\xfd", "format_name": "ztsd"},
     }
     filename = _stringify_path(filename)
     *_, ext = splitext_addext(filename)

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -13,6 +13,7 @@ from .. import (Spm99AnalyzeImage, Spm2AnalyzeImage,
 from ..loadsave import load, read_img_data, _signature_matches_extension
 from ..filebasedimages import ImageFileError
 from ..tmpdirs import InTemporaryDirectory, TemporaryDirectory
+from ..openers import Opener
 
 from ..optpkg import optional_package
 _, have_scipy, _ = optional_package('scipy')
@@ -79,6 +80,15 @@ def test_load_bad_compressed_extension(tmp_path, extension):
     file_path = tmp_path / f"img.nii{extension}"
     file_path.write_bytes(b"bad")
     with pytest.raises(ImageFileError, match=".*is not a .* file"):
+        load(file_path)
+
+
+@pytest.mark.parametrize("extension", [".gz", ".bz2"])
+def test_load_good_extension_with_bad_data(tmp_path, extension):
+    file_path = tmp_path / f"img.nii{extension}"
+    with Opener(file_path, "wb") as fobj:
+        fobj.write(b"bad")
+    with pytest.raises(ImageFileError, match="Cannot work out file type of .*"):
         load(file_path)
 
 

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -17,6 +17,7 @@ from ..openers import Opener
 
 from ..optpkg import optional_package
 _, have_scipy, _ = optional_package('scipy')
+_, have_pyzstd, _ = optional_package('pyzstd')
 
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal)
@@ -75,16 +76,20 @@ def test_load_empty_image():
     assert str(err.value).startswith('Empty file: ')
 
 
-@pytest.mark.parametrize("extension", [".gz", ".bz2"])
+@pytest.mark.parametrize("extension", [".gz", ".bz2", ".zst"])
 def test_load_bad_compressed_extension(tmp_path, extension):
+    if extension == ".zst" and not have_pyzstd:
+        pytest.skip()
     file_path = tmp_path / f"img.nii{extension}"
     file_path.write_bytes(b"bad")
     with pytest.raises(ImageFileError, match=".*is not a .* file"):
         load(file_path)
 
 
-@pytest.mark.parametrize("extension", [".gz", ".bz2"])
+@pytest.mark.parametrize("extension", [".gz", ".bz2", ".zst"])
 def test_load_good_extension_with_bad_data(tmp_path, extension):
+    if extension == ".zst" and not have_pyzstd:
+        pytest.skip()
     file_path = tmp_path / f"img.nii{extension}"
     with Opener(file_path, "wb") as fobj:
         fobj.write(b"bad")

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -98,27 +98,19 @@ def test_signature_matches_extension(tmp_path):
     good_file.write_bytes(gz_signature)
     bad_file = tmp_path / "bad.gz"
     bad_file.write_bytes(b"bad")
-    matches, msg = _signature_matches_extension(
-        tmp_path / "uncompressed.nii", None)
+    matches, msg = _signature_matches_extension(tmp_path / "uncompressed.nii")
     assert matches
     assert msg == ""
-    matches, msg = _signature_matches_extension(tmp_path / "missing.gz", None)
+    matches, msg = _signature_matches_extension(tmp_path / "missing.gz")
     assert not matches
     assert msg.startswith("Could not read")
-    matches, msg = _signature_matches_extension(bad_file, None)
+    matches, msg = _signature_matches_extension(bad_file)
     assert not matches
     assert "is not a" in msg
-    matches, msg = _signature_matches_extension(bad_file, gz_signature + b"abc")
+    matches, msg = _signature_matches_extension(good_file)
     assert matches
     assert msg == ""
-    matches, msg = _signature_matches_extension(
-        good_file, gz_signature + b"abc")
-    assert matches
-    assert msg == ""
-    matches, msg = _signature_matches_extension(good_file, gz_signature[:1])
-    assert matches
-    assert msg == ""
-    matches, msg = _signature_matches_extension(good_file, None)
+    matches, msg = _signature_matches_extension(tmp_path / "missing.nii")
     assert matches
     assert msg == ""
 


### PR DESCRIPTION
Bug introduced in #1013 and reported in #1137. Added a test that fails with an unexpected error, and then updated `_signature_matches_extension` to not accept any `sniff`. (If the file was compressed, the sniff would be read from the uncompressed stream. If it wasn't compressed, the sniff would be empty.)

Some updates to make the same machinery work transparently for `.zst`.

Closes #1137.