### PR TITLE
MNT: No need to inherit `object` in Python 3

### DIFF
--- a/doc/source/devel/biaps/biap_0002.rst
+++ b/doc/source/devel/biaps/biap_0002.rst
@@ -104,8 +104,8 @@ sliced array, as in:
 
 .. code:: python
 
-    class SomeImage(object):
-        class Slicer(object):
+    class SomeImage:
+        class Slicer:
             def __init__(self, parent):
                 self.parent = parent
             def __getitem__(self, slicedef):

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -28,7 +28,7 @@ from types import BuiltinFunctionType, FunctionType
 DEBUG = True
 
 
-class ApiDocWriter(object):
+class ApiDocWriter:
     """ Class for automatic detection and parsing of API docs
     to Sphinx-parsable reST format"""
 
@@ -118,7 +118,7 @@ class ApiDocWriter(object):
         >>> docwriter = ApiDocWriter('sphinx')
         >>> docwriter._get_object_name("  def func():  ")
         'func'
-        >>> docwriter._get_object_name("  class Klass(object):  ")
+        >>> docwriter._get_object_name("  class Klass:  ")
         'Klass'
         >>> docwriter._get_object_name("  class Klass:  ")
         'Klass'

--- a/nibabel/arraywriters.py
+++ b/nibabel/arraywriters.py
@@ -45,7 +45,7 @@ class ScalingError(WriterError):
     pass
 
 
-class ArrayWriter(object):
+class ArrayWriter:
 
     def __init__(self, array, out_dtype=None, **kwargs):
         r""" Initialize array writer

--- a/nibabel/batteryrunners.py
+++ b/nibabel/batteryrunners.py
@@ -108,7 +108,7 @@ or the pixdims::
 """
 
 
-class BatteryRunner(object):
+class BatteryRunner:
     """ Class to run set of checks """
 
     def __init__(self, checks):
@@ -174,7 +174,7 @@ class BatteryRunner(object):
         return len(self._checks)
 
 
-class Report(object):
+class Report:
 
     def __init__(self,
                  error=Exception,

--- a/nibabel/cmdline/dicomfs.py
+++ b/nibabel/cmdline/dicomfs.py
@@ -18,7 +18,7 @@ import locale
 import logging
 
 
-class dummy_fuse(object):
+class dummy_fuse:
     """Dummy fuse "module" so that nose does not blow during doctests"""
     Fuse = object
 

--- a/nibabel/data.py
+++ b/nibabel/data.py
@@ -31,7 +31,7 @@ class BomberError(DataError, AttributeError):
     pass
 
 
-class Datasource(object):
+class Datasource:
     """ Simple class to add base path to relative path """
 
     def __init__(self, base_path):
@@ -302,7 +302,7 @@ def make_datasource(pkg_def, **kwargs):
     return VersionedDatasource(pth)
 
 
-class Bomber(object):
+class Bomber:
     """ Class to raise an informative error when used """
 
     def __init__(self, name, msg):

--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -7,7 +7,7 @@ from .deprecator import Deprecator
 from .pkg_info import cmp_pkg_version
 
 
-class ModuleProxy(object):
+class ModuleProxy:
     """ Proxy for module that may not yet have been imported
 
     Parameters
@@ -39,12 +39,12 @@ class ModuleProxy(object):
         return f"<module proxy for {self._module_name}>"
 
 
-class FutureWarningMixin(object):
+class FutureWarningMixin:
     """ Insert FutureWarning for object creation
 
     Examples
     --------
-    >>> class C(object): pass
+    >>> class C: pass
     >>> class D(FutureWarningMixin, C):
     ...     warn_message = "Please, don't use this class"
 

--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -83,7 +83,7 @@ def _add_dep_doc(old_doc, dep_doc, setup='', cleanup=''):
                      old_lines[next_line:] + cleanup_lines + [''])
 
 
-class Deprecator(object):
+class Deprecator:
     """ Class to make decorator marking function or method as deprecated
 
     The decorated function / method will:

--- a/nibabel/dft.py
+++ b/nibabel/dft.py
@@ -58,7 +58,7 @@ class InstanceStackError(DFTError):
         return fmt % (self.i + 1, self.si.instance_number)
 
 
-class _Study(object):
+class _Study:
 
     def __init__(self, d):
         self.uid = d['uid']
@@ -91,7 +91,7 @@ class _Study(object):
         return self.patient_name
 
 
-class _Series(object):
+class _Series:
 
     def __init__(self, d):
         self.uid = d['uid']
@@ -219,7 +219,7 @@ class _Series(object):
         return 352 + 2 * len(self.storage_instances) * self.columns * self.rows
 
 
-class _StorageInstance(object):
+class _StorageInstance:
 
     def __init__(self, d):
         self.uid = d['uid']

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -511,7 +511,7 @@ def read_subheaders(fileobj, mlist, endianness):
     return subheaders
 
 
-class EcatSubHeader(object):
+class EcatSubHeader:
 
     _subhdrdtype = subhdr_dtype
     _data_type_codes = data_type_codes
@@ -660,7 +660,7 @@ class EcatSubHeader(object):
         return data
 
 
-class EcatImageArrayProxy(object):
+class EcatImageArrayProxy:
     """ Ecat implementation of array proxy protocol
 
     The array proxy allows us to freeze the passed fileobj and

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -22,7 +22,7 @@ class ImageFileError(Exception):
     pass
 
 
-class FileBasedHeader(object):
+class FileBasedHeader:
     """ Template class to implement header protocol """
 
     @classmethod
@@ -60,7 +60,7 @@ class FileBasedHeader(object):
         return deepcopy(self)
 
 
-class FileBasedImage(object):
+class FileBasedImage:
     """
     Abstract image class with interface for loading/saving images from disk.
 

--- a/nibabel/fileholders.py
+++ b/nibabel/fileholders.py
@@ -17,7 +17,7 @@ class FileHolderError(Exception):
     pass
 
 
-class FileHolder(object):
+class FileHolder:
     """ class to contain filename, fileobj and file position
     """
 

--- a/nibabel/fileslice.py
+++ b/nibabel/fileslice.py
@@ -16,7 +16,7 @@ import numpy as np
 SKIP_THRESH = 2 ** 8
 
 
-class _NullLock(object):
+class _NullLock:
     """Can be used as no-function dummy object in place of ``threading.lock``.
 
     The ``_NullLock`` is an object which can be used in place of a

--- a/nibabel/imageglobals.py
+++ b/nibabel/imageglobals.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('nibabel.global')
 logger.addHandler(logging.StreamHandler())
 
 
-class ErrorLevel(object):
+class ErrorLevel:
     """ Context manager to set log error level
     """
 
@@ -49,7 +49,7 @@ class ErrorLevel(object):
         return False
 
 
-class LoggingOutputSuppressor(object):
+class LoggingOutputSuppressor:
     """Context manager to prevent global logger from printing"""
 
     def __enter__(self):

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -39,7 +39,7 @@ class MincError(Exception):
     """ Error when reading MINC files """
 
 
-class Minc1File(object):
+class Minc1File:
     """ Class to wrap MINC1 format opened netcdf object
 
     Although it has some of the same methods as a ``Header``, we use
@@ -235,7 +235,7 @@ class Minc1File(object):
         return self._normalize(data, sliceobj)
 
 
-class MincImageArrayProxy(object):
+class MincImageArrayProxy:
     """ MINC implementation of array proxy protocol
 
     The array proxy allows us to freeze the passed fileobj and

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -30,7 +30,7 @@ import numpy as np
 from .minc1 import Minc1File, MincHeader, Minc1Image, MincError
 
 
-class Hdf5Bunch(object):
+class Hdf5Bunch:
     """ Make object for accessing attributes of variable
     """
 

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -96,7 +96,7 @@ def wrapper_from_data(dcm_data):
     return SiemensWrapper(dcm_data, csa)
 
 
-class Wrapper(object):
+class Wrapper:
     """ Class to wrap general DICOM files
 
     Methods:

--- a/nibabel/nicom/structreader.py
+++ b/nibabel/nicom/structreader.py
@@ -5,7 +5,7 @@ from struct import Struct
 _ENDIAN_CODES = '@=<>!'
 
 
-class Unpacker(object):
+class Unpacker:
     """ Class to unpack values from buffer object
 
     The buffer object is usually a string. Caches compiled :mod:`struct`

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -124,7 +124,7 @@ def test_get_from_wrapper():
     assert dw.get('some_key') is None
     # Check get defers to dcm_data get
 
-    class FakeData2(object):
+    class FakeData2:
 
         def get(self, key, default):
             return 1
@@ -268,7 +268,7 @@ def test_vol_matching():
     # Just to check the interface, make a pretend signature-providing
     # object.
 
-    class C(object):
+    class C:
         series_signature = {}
     assert dw_empty.is_same_series(C())
 
@@ -386,7 +386,7 @@ def fake_frames(seq_name, field_name, value_seq):
         each element in list is obj.<seq_name>[0].<field_name> =
         value_seq[n] for n in range(N)
     """
-    class Fake(object):
+    class Fake:
         pass
     frames = []
     for value in value_seq:
@@ -410,16 +410,16 @@ def fake_shape_dependents(div_seq, sid_seq=None, sid_dim=None):
     sid_dim : int
         the index of the column in 'div_seq' to use as 'sid_seq'
     """
-    class DimIdxSeqElem(object):
+    class DimIdxSeqElem:
         def __init__(self, dip=(0, 0), fgp=None):
             self.DimensionIndexPointer = dip
             if fgp is not None:
                 self.FunctionalGroupPointer = fgp
-    class FrmContSeqElem(object):
+    class FrmContSeqElem:
         def __init__(self, div, sid):
             self.DimensionIndexValues = div
             self.StackID = sid
-    class PerFrmFuncGrpSeqElem(object):
+    class PerFrmFuncGrpSeqElem:
         def __init__(self, div, sid):
             self.FrameContentSequence = [FrmContSeqElem(div, sid)]
     # if no StackID values passed in then use the values at index 'sid_dim' in

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -253,7 +253,7 @@ intent_codes = Recoder((
 ), fields=('code', 'label', 'parameters', 'niistring'))
 
 
-class Nifti1Extension(object):
+class Nifti1Extension:
     """Baseclass for NIfTI1 header extensions.
 
     This class is sufficient to handle very simple text-based extensions, such

--- a/nibabel/onetime.py
+++ b/nibabel/onetime.py
@@ -27,7 +27,7 @@ from nibabel.deprecated import deprecate_with_version
 # -----------------------------------------------------------------------------
 
 
-class ResetMixin(object):
+class ResetMixin:
     """A Mixin class to add a .reset() method to users of OneTimeProperty.
 
     By default, auto attributes once computed, become static.  If they happen
@@ -109,7 +109,7 @@ class ResetMixin(object):
                 delattr(self, mname)
 
 
-class OneTimeProperty(object):
+class OneTimeProperty:
     """A descriptor to make special properties that become normal attributes.
 
     This is meant to be used mostly by the auto_attr decorator in this module.
@@ -157,7 +157,7 @@ def auto_attr(func):
 
     Examples
     --------
-    >>> class MagicProp(object):
+    >>> class MagicProp:
     ...     @auto_attr
     ...     def a(self):
     ...         return 99

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -80,7 +80,7 @@ def _zstd_open(filename, mode="r", *, level_or_option=None, zstd_dict=None):
                            level_or_option=level_or_option, zstd_dict=zstd_dict)
 
 
-class Opener(object):
+class Opener:
     r""" Class to accept, maybe open, and context-manage file-likes / filenames
 
     Provides context manager to close files that the constructor opened for

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -579,7 +579,7 @@ def exts2pars(exts_source):
     return headers
 
 
-class PARRECArrayProxy(object):
+class PARRECArrayProxy:
 
     def __init__(self, file_like, header, *, mmap=True, scaling='dv'):
         """ Initialize PARREC array proxy

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -322,7 +322,7 @@ class ImageDataError(Exception):
     pass
 
 
-class SpatialFirstSlicer(object):
+class SpatialFirstSlicer:
     """ Slicing interface that returns a new image with an updated affine
 
     Checks that an image's first three axes are spatial

--- a/nibabel/streamlines/array_sequence.py
+++ b/nibabel/streamlines/array_sequence.py
@@ -24,7 +24,7 @@ def is_ndarray_of_int_or_bool(obj):
             np.issubdtype(obj.dtype, np.bool_)))
 
 
-class _BuildCache(object):
+class _BuildCache:
     def __init__(self, arr_seq, common_shape, dtype):
         self.offsets = list(arr_seq._offsets)
         self.lengths = list(arr_seq._lengths)
@@ -88,7 +88,7 @@ def _define_operators(cls):
 
 
 @_define_operators
-class ArraySequence(object):
+class ArraySequence:
     """ Sequence of ndarrays having variable first dimension sizes.
 
     This is a container that can store multiple ndarrays where each ndarray

--- a/nibabel/streamlines/header.py
+++ b/nibabel/streamlines/header.py
@@ -2,7 +2,7 @@
 """
 
 
-class Field(object):
+class Field:
     """ Header fields common to multiple streamline file formats.
 
     In IPython, use `nibabel.streamlines.Field??` to list them.

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -220,7 +220,7 @@ class LazyDict(MutableMapping):
         return len(self.store)
 
 
-class TractogramItem(object):
+class TractogramItem:
     """ Class containing information about one streamline.
 
     :class:`TractogramItem` objects have three public attributes: `streamline`,
@@ -253,7 +253,7 @@ class TractogramItem(object):
         return len(self.streamline)
 
 
-class Tractogram(object):
+class Tractogram:
     """ Container for streamlines and their data information.
 
     Streamlines of a tractogram can be in any coordinate system of your

--- a/nibabel/tests/scriptrunner.py
+++ b/nibabel/tests/scriptrunner.py
@@ -46,7 +46,7 @@ def local_module_dir(module_name):
     return None
 
 
-class ScriptRunner(object):
+class ScriptRunner:
     """ Class to run scripts and return output
 
     Finds local scripts and local modules if running in the development

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -523,7 +523,7 @@ class TestAnalyzeHeader(tws._TestLabeledWrapStruct):
             assert hdr == copy
             assert hdr is not copy
 
-        class C(object):
+        class C:
 
             def get_data_dtype(self): return np.dtype('i2')
 
@@ -619,12 +619,12 @@ class TestAnalyzeHeader(tws._TestLabeledWrapStruct):
         klass = self.header_class
         # Header needs to implement data_dtype, data_shape, zooms
 
-        class H1(object):
+        class H1:
             pass
         with pytest.raises(AttributeError):
             klass.from_header(H1())
 
-        class H2(object):
+        class H2:
 
             def get_data_dtype(self):
                 return np.dtype('u1')

--- a/nibabel/tests/test_api_validators.py
+++ b/nibabel/tests/test_api_validators.py
@@ -61,7 +61,7 @@ class TestValidateSomething(ValidateAPI):
         against ``obj``.  See the :meth:`validate_something` method for an
         example.
         """
-        class C(object):
+        class C:
 
             def __init__(self, var):
                 self.var = var

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -36,7 +36,7 @@ from .test_fileslice import slicer_samples
 from .test_openers import patch_indexed_gzip
 
 
-class FunkyHeader(object):
+class FunkyHeader:
 
     def __init__(self, shape):
         self.shape = shape
@@ -258,7 +258,7 @@ def test_is_proxy():
     assert not is_proxy(hdr)
     assert not is_proxy(np.zeros((2, 3, 4)))
 
-    class NP(object):
+    class NP:
         is_proxy = False
     assert not is_proxy(NP())
 
@@ -280,7 +280,7 @@ def test_reshape_dataobj():
                        np.reshape(arr, (2, 3, 4)))
     assert arr.shape == shape
 
-    class ArrGiver(object):
+    class ArrGiver:
 
         def __array__(self):
             return arr

--- a/nibabel/tests/test_brikhead.py
+++ b/nibabel/tests/test_brikhead.py
@@ -71,7 +71,7 @@ EXAMPLE_BAD_IMAGES = [
     )
 ]
 
-class TestAFNIHeader(object):
+class TestAFNIHeader:
     module = brikhead
     test_files = EXAMPLE_IMAGES
 
@@ -86,7 +86,7 @@ class TestAFNIHeader(object):
                 self.module.AFNIHeader.from_header(tp['fname'])
 
 
-class TestAFNIImage(object):
+class TestAFNIImage:
     module = brikhead
     test_files = EXAMPLE_IMAGES
 
@@ -127,7 +127,7 @@ class TestAFNIImage(object):
                 assert_array_equal(arr[sliceobj], prox[sliceobj])
 
 
-class TestBadFiles(object):
+class TestBadFiles:
     module = brikhead
     test_files = EXAMPLE_BAD_IMAGES
 
@@ -137,7 +137,7 @@ class TestBadFiles(object):
                 self.module.load(tp['head'])
 
 
-class TestBadVars(object):
+class TestBadVars:
     module = brikhead
     vars = ['type = badtype-attribute\nname = BRICK_TYPES\ncount = 1\n1\n',
             'type = integer-attribute\ncount = 1\n1\n']

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -32,7 +32,7 @@ def test_module_proxy():
 
 def test_futurewarning_mixin():
     # Test mixin for FutureWarning
-    class C(object):
+    class C:
 
         def __init__(self, val):
             self.val = val

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -62,7 +62,7 @@ def func_doc_long(i, j):
     "A docstring\n\n   Some text"
 
 
-class TestDeprecatorFunc(object):
+class TestDeprecatorFunc:
     """ Test deprecator function specified in ``dep_func`` """
 
     dep_func = Deprecator(cmp_func)
@@ -136,7 +136,7 @@ class TestDeprecatorFunc(object):
             func()
 
 
-class TestDeprecatorMaker(object):
+class TestDeprecatorMaker:
     """ Test deprecator class creation with custom warnings and errors """
 
     dep_maker = partial(Deprecator, cmp_func)

--- a/nibabel/tests/test_ecat_data.py
+++ b/nibabel/tests/test_ecat_data.py
@@ -22,7 +22,7 @@ from numpy.testing import (assert_array_equal, assert_almost_equal)
 ECAT_TEST_PATH = pjoin(get_nibabel_data(), 'nipy-ecattest')
 
 
-class TestNegatives(object):
+class TestNegatives:
     opener = staticmethod(load)
     example_params = dict(
         fname=os.path.join(ECAT_TEST_PATH, 'ECAT7_testcaste_neg_values.v'),

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -481,7 +481,7 @@ class DataInterfaceMixin(GetSetDtypeMixin):
             del rt_img  # to allow windows to delete the directory
 
 
-class HeaderShapeMixin(object):
+class HeaderShapeMixin:
     """ Tests that header shape can be set and got
 
     Add this one of your header supports ``get_data_shape`` and
@@ -499,7 +499,7 @@ class HeaderShapeMixin(object):
         assert img.header.get_data_shape() == new_shape
 
 
-class AffineMixin(object):
+class AffineMixin:
     """ Adds test of affine property, method
 
     Add this one if your image has an ``affine`` property.  If so, it should

--- a/nibabel/tests/test_keywordonly.py
+++ b/nibabel/tests/test_keywordonly.py
@@ -33,7 +33,7 @@ def test_kw_only_func():
         kw_func(1, akeyarg=3)
     assert kw_func.__doc__ == 'Another docstring'
 
-    class C(object):
+    class C:
 
         @kw_only_meth(1)
         def kw_meth(self, an_arg, a_kwarg='thing'):

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -103,7 +103,7 @@ EXAMPLE_IMAGES = [
 ]
 
 
-class _TestMincFile(object):
+class _TestMincFile:
     module = minc1
     file_class = Minc1File
     fname = EG_FNAME

--- a/nibabel/tests/test_minc2_data.py
+++ b/nibabel/tests/test_minc2_data.py
@@ -34,7 +34,7 @@ def _make_affine(coses, zooms, starts):
     return affine
 
 
-class TestEPIFrame(object):
+class TestEPIFrame:
     opener = staticmethod(top_load)
     x_cos = [1, 0, 0]
     y_cos = [0., 1, 0]

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1387,7 +1387,7 @@ def test_nifti_dicom_extension():
         Nifti1DicomExtension(2, 0)
 
 
-class TestNifti1General(object):
+class TestNifti1General:
     """ Test class to test nifti1 in general
 
     Tests here which mix the pair and the single type, and that should only be

--- a/nibabel/tests/test_nifti2.py
+++ b/nibabel/tests/test_nifti2.py
@@ -26,7 +26,7 @@ header_file = os.path.join(data_path, 'nifti2.hdr')
 image_file = os.path.join(data_path, 'example_nifti2.nii.gz')
 
 
-class _Nifti2Mixin(object):
+class _Nifti2Mixin:
     example_file = header_file
     sizeof_hdr = Nifti2Header.sizeof_hdr
     quat_dtype = np.float64

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -34,7 +34,7 @@ from ..deprecator import ExpiredDeprecationError
 pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 
-class Lunk(object):
+class Lunk:
     # bare file-like for testing
     closed = False
 

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -728,7 +728,7 @@ def test_image_creation():
         assert_array_equal(img.dataobj, arr_prox_fp)
 
 
-class FakeHeader(object):
+class FakeHeader:
     """ Minimal API of header for PARRECArrayProxy
     """
 

--- a/nibabel/tests/test_recoder.py
+++ b/nibabel/tests/test_recoder.py
@@ -85,7 +85,7 @@ def test_recoder_6():
 
 def test_custom_dicter():
     # Allow custom dict-like object in constructor
-    class MyDict(object):
+    class MyDict:
 
         def __init__(self):
             self._keys = []

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -69,7 +69,7 @@ def test_from_header():
     assert hdr == copy
     assert hdr is not copy
 
-    class C(object):
+    class C:
 
         def get_data_dtype(self): return np.dtype('u2')
 
@@ -188,7 +188,7 @@ def test_read_data():
         assert (data == data2).all()
 
 
-class DataLike(object):
+class DataLike:
     # Minimal class implementing 'data' API
     shape = (3,)
 
@@ -530,7 +530,7 @@ class TestSpatialImage(TestCase):
                         assert (sliced_data == img.get_fdata()[sliceobj]).all()
 
 
-class MmapImageMixin(object):
+class MmapImageMixin:
     """ Mixin for testing images that may return memory maps """
     #: whether to test mode of returned memory map
     check_mmap_mode = True

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -47,7 +47,7 @@ IUINT_TYPES = INT_TYPES + UINT_TYPES
 NUMERIC_TYPES = CFLOAT_TYPES + IUINT_TYPES
 
 
-class HeaderScalingMixin(object):
+class HeaderScalingMixin:
     """ Mixin to add scaling tests to header tests
 
     Needs to be a mixin so nifti tests can use this method without inheriting
@@ -155,7 +155,7 @@ class TestSpm99AnalyzeHeader(test_analyze.TestAnalyzeHeader,
         assert dxer(hdr.binaryblock) == 'very large origin values relative to dims'
 
 
-class ImageScalingMixin(object):
+class ImageScalingMixin:
     # Mixin to add scaling checks to image test class
     # Nifti tests inherits from Analyze tests not Spm Analyze tests.  We need
     # these tests for Nifti scaling, hence the mixin.

--- a/nibabel/tmpdirs.py
+++ b/nibabel/tmpdirs.py
@@ -13,7 +13,7 @@ import shutil
 from tempfile import template, mkdtemp
 
 
-class TemporaryDirectory(object):
+class TemporaryDirectory:
     """Create and return a temporary directory.  This has the same
     behavior as mkdtemp but can be used as a context manager.
 
@@ -81,7 +81,7 @@ class InTemporaryDirectory(TemporaryDirectory):
         return super(InTemporaryDirectory, self).__exit__(exc, value, tb)
 
 
-class InGivenDirectory(object):
+class InGivenDirectory:
     """ Change directory to given directory for duration of ``with`` block
 
     Useful when you want to use `InTemporaryDirectory` for the final test, but

--- a/nibabel/tripwire.py
+++ b/nibabel/tripwire.py
@@ -29,7 +29,7 @@ def is_tripwire(obj):
     return False
 
 
-class TripWire(object):
+class TripWire:
     """ Class raising error if used
 
     Standard use is to proxy modules that we could not import

--- a/nibabel/viewers.py
+++ b/nibabel/viewers.py
@@ -12,7 +12,7 @@ from .optpkg import optional_package
 from .orientations import aff2axcodes, axcodes2ornt
 
 
-class OrthoSlicer3D(object):
+class OrthoSlicer3D:
     """ Orthogonal-plane slice viewer.
 
     OrthoSlicer3d expects 3- or 4-dimensional array data.  It treats

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -48,7 +48,7 @@ if HAVE_ZSTD:
     COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, pyzstd.ZstdFile)
 
 
-class Recoder(object):
+class Recoder:
     """ class to return canonical code(s) from code or aliases
 
     The concept is a lot easier to read in the implementation and
@@ -224,7 +224,7 @@ class Recoder(object):
 endian_codes = Recoder(endian_codes)
 
 
-class DtypeMapper(object):
+class DtypeMapper:
     """ Specialized mapper for numpy dtypes
 
     We pass this mapper into the Recoder class to deal with numpy dtype
@@ -307,7 +307,7 @@ def pretty_mapping(mapping, getterfunc=None):
     >>> d = {'a key': 'a value'}
     >>> print(pretty_mapping(d))
     a key  : a value
-    >>> class C(object): # to control ordering, show get_ method
+    >>> class C: # to control ordering, show get_ method
     ...     def __iter__(self):
     ...         return iter(('short_field','longer_field'))
     ...     def __getitem__(self, key):

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -121,7 +121,7 @@ class WrapStructError(Exception):
     pass
 
 
-class WrapStruct(object):
+class WrapStruct:
     # placeholder datatype
     template_dtype = np.dtype([('integer', 'i2')])
 

--- a/nibabel/xmlutils.py
+++ b/nibabel/xmlutils.py
@@ -17,7 +17,7 @@ from xml.parsers.expat import ParserCreate
 from .filebasedimages import FileBasedHeader
 
 
-class XmlSerializable(object):
+class XmlSerializable:
     """ Basic interface for serializing an object to xml"""
 
     def _to_xml_element(self):
@@ -35,7 +35,7 @@ class XmlBasedHeader(FileBasedHeader, XmlSerializable):
     """ Basic wrapper around FileBasedHeader and XmlSerializable."""
 
 
-class XmlParser(object):
+class XmlParser:
     """ Base class for defining how to parse xml-based image snippets.
 
     Image-specific parsers should define:

--- a/nisext/sexts.py
+++ b/nisext/sexts.py
@@ -260,7 +260,7 @@ class install_scripts_bat(install_scripts):
                 fobj.write(bat_contents)
 
 
-class Bunch(object):
+class Bunch:
     def __init__(self, vars):
         for key, name in vars.items():
             if key.startswith('__'):


### PR DESCRIPTION
Classes inherit from `object` implicitly.