### PR TITLE
CI: Run tests with available parallelism

### DIFF
--- a/nibabel/tests/test_api_validators.py
+++ b/nibabel/tests/test_api_validators.py
@@ -1,6 +1,7 @@
 """ Metaclass and class for validating instance APIs
 """
-
+import os
+import pytest
 
 
 class validator2test(type):
@@ -82,6 +83,10 @@ class TestValidateSomething(ValidateAPI):
         assert obj.get_var() == params['var']
 
 
+@pytest.mark.xfail(
+    os.getenv("PYTEST_XDIST_WORKER") is not None,
+    reason="Execution in the same scope cannot be guaranteed"
+)
 class TestRunAllTests(ValidateAPI):
     """ Class to test that each validator test gets run
 
@@ -98,7 +103,7 @@ class TestRunAllTests(ValidateAPI):
     def validate_second(self, obj, param):
         self.run_tests.append('second')
 
-
-def teardown():
-    # Check that both validate_xxx tests got run
-    assert TestRunAllTests.run_tests == ['first', 'second']
+    @classmethod
+    def teardown_class(cls):
+        # Check that both validate_xxx tests got run
+        assert cls.run_tests == ['first', 'second']

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ test =
     pytest-cov
     pytest-doctestplus
     pytest-httpserver
+    pytest-xdist
 zstd =
     pyzstd >= 0.14.3
 all =

--- a/tools/ci/check.sh
+++ b/tools/ci/check.sh
@@ -25,7 +25,7 @@ elif [ "${CHECK_TYPE}" == "test" ]; then
     cd for_testing
     cp ../.coveragerc .
     pytest --doctest-modules --doctest-plus --cov nibabel --cov-report xml \
-        --junitxml=test-results.xml -v --pyargs nibabel
+        --junitxml=test-results.xml -v --pyargs nibabel -n auto
 else
     false
 fi


### PR DESCRIPTION
Uses pytest-xdist to hopefully reduce the amount of time we're spending on tests.

One check needs to be made more tolerant of this case, as it assumed that two tests could edit variables in a shared scope.