### PR TITLE
Fixed documentation build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ Thumbs.db
 # Things specific to this project #
 ###################################
 doc/source/reference
+doc/source/generated
 venv/
 .buildbot.patch
 .vscode

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,8 +20,10 @@
 # serve to show the default.
 
 import os
-from configparser import ConfigParser
+from pathlib import Path
 from runpy import run_path
+
+import toml
 
 # Check for external Sphinx extensions we depend on
 try:
@@ -50,9 +52,8 @@ with open('_long_description.inc', 'wt') as fobj:
     fobj.write(rel['long_description'])
 
 # Load metadata from setup.cfg
-config = ConfigParser()
-config.read(os.path.join('..', '..', 'setup.cfg'))
-metadata = config['metadata']
+pyproject_dict = toml.load(Path("../../pyproject.toml"))
+metadata = pyproject_dict["project"]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -86,7 +87,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'NiBabel'
-copyright = f"2006-2022, {metadata['maintainer']} <{metadata['author_email']}>"
+author_name = metadata["authors"][0]["name"]
+author_email = metadata["authors"][0]["email"]
+copyright = f"2006-2022, {author_name} <{author_email}>"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,10 +19,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-from runpy import run_path
 from configparser import ConfigParser
+from runpy import run_path
 
 # Check for external Sphinx extensions we depend on
 try:
@@ -40,11 +39,6 @@ try:
 except ImportError:
     raise RuntimeError('Need nibabel on Python PATH; consider "make htmldoc" '
                        'from nibabel root directory')
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.append(os.path.abspath('../sphinxext'))
 
 # -- General configuration ----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,10 @@ build-backend = "setuptools.build_meta:__legacy__"
 [project]
 name = "nibabel"
 description = "Access a multitude of neuroimaging data formats"
-authors = [
-  { name = "nibabel developers", email = "neuroimaging@python.org" },
-]
-maintainers = [
-  { name = "Christopher Markiewicz" },
-]
+authors = [{ name = "NiBabel developers", email = "neuroimaging@python.org" }]
+maintainers = [{ name = "Christopher Markiewicz" }]
 readme = "README.rst"
-license = { text="MIT License" }
+license = { text = "MIT License" }
 requires-python = ">=3.7"
 dependencies = ["numpy >=1.17", "packaging >=17", "setuptools"]
 classifiers = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,9 @@ dev =
 doc =
     matplotlib >= 1.5.3
     numpydoc
-    sphinx >=0.3,<3
+    sphinx ~= 5.3
     texext
+    toml
 minc2 =
     h5py
 spm =


### PR DESCRIPTION
The *conf.py* file included an extraction of a `[metadata]` attribute from *setup.cfg* using `ConfigParser`. Since the metadata was moved to *pyproject.toml*, this raised an exception. To solve this, I added the `toml` library to the doc requirements and replaced `ConfigParser.read()` with `toml.load()`. Sphinx also required a version update to build successfully. This PR resolved #1160.