### PR TITLE
ENH: Schedule int64 warning to convert to error at 5.0

### DIFF
--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -1,7 +1,9 @@
 """Module to help with deprecating objects and classes
 """
+from __future__ import annotations
 
 import warnings
+from typing import Type
 
 from .deprecator import Deprecator
 from .pkg_info import cmp_pkg_version
@@ -77,3 +79,40 @@ class VisibleDeprecationWarning(UserWarning):
 
 
 deprecate_with_version = Deprecator(cmp_pkg_version)
+
+
+def alert_future_error(
+    msg: str,
+    version: str,
+    *,
+    warning_class: Type[Warning] = FutureWarning,
+    error_class: Type[Exception] = RuntimeError,
+    warning_rec: str = '',
+    error_rec: str = '',
+    stacklevel: int = 2,
+):
+    """Warn or error with appropriate messages for changing functionality.
+
+    Parameters
+    ----------
+    msg : str
+        Description of the condition that led to the alert
+    version : str
+        NiBabel version at which the warning will become an error
+    warning_class : subclass of Warning, optional
+        Warning class to emit before version
+    error_class : subclass of Exception, optional
+        Error class to emit after version
+    warning_rec : str, optional
+        Guidance for suppressing the warning and avoiding the future error
+    error_rec: str, optional
+        Guidance for resolving the error
+    stacklevel: int, optional
+        Warnings stacklevel to provide; note that this will be incremented by
+        1, so provide the stacklevel you would provide directly to warnings.warn()
+    """
+    if cmp_pkg_version(version) >= 0:
+        msg = f'{msg} This will error in NiBabel {version}. {warning_rec}'
+        warnings.warn(msg.strip(), warning_class, stacklevel=stacklevel + 1)
+    else:
+        raise error_class(f'{msg} {error_rec}'.strip())

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -21,6 +21,7 @@ from . import analyze  # module import
 from .arrayproxy import get_obj_dtype
 from .batteryrunners import Report
 from .casting import have_binary128
+from .deprecated import alert_future_error
 from .filebasedimages import SerializableImage
 from .optpkg import optional_package
 from .quaternions import fillpositive, mat2quat, quat2mat
@@ -1831,13 +1832,16 @@ class Nifti1Pair(analyze.AnalyzeImage):
         # already fail.
         danger_dts = (np.dtype('int64'), np.dtype('uint64'))
         if header is None and dtype is None and get_obj_dtype(dataobj) in danger_dts:
-            msg = (
+            alert_future_error(
                 f'Image data has type {dataobj.dtype}, which may cause '
-                'incompatibilities with other tools. This will error in '
-                'NiBabel 5.0. This warning can be silenced '
-                f'by passing the dtype argument to {self.__class__.__name__}().'
+                'incompatibilities with other tools.',
+                '5.0',
+                warning_rec='This warning can be silenced by passing the dtype argument'
+                f' to {self.__class__.__name__}().',
+                error_rec='To use this type, pass an explicit header or dtype argument'
+                f' to {self.__class__.__name__}().',
+                error_class=ValueError,
             )
-            warnings.warn(msg, FutureWarning, stacklevel=2)
         super().__init__(dataobj, affine, header, extra, file_map, dtype)
         # Force set of s/q form when header is None unless affine is also None
         if header is None and affine is not None:

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -6,7 +6,12 @@ import warnings
 import pytest
 
 from nibabel import pkg_info
-from nibabel.deprecated import FutureWarningMixin, ModuleProxy, deprecate_with_version
+from nibabel.deprecated import (
+    FutureWarningMixin,
+    ModuleProxy,
+    alert_future_error,
+    deprecate_with_version,
+)
 from nibabel.tests.test_deprecator import TestDeprecatorFunc as _TestDF
 
 
@@ -79,3 +84,28 @@ def test_dev_version():
             assert func() == 99
     finally:
         pkg_info.cmp_pkg_version.__defaults__ = ('2.0',)
+
+
+def test_alert_future_error():
+    with pytest.warns(FutureWarning):
+        alert_future_error(
+            'Message',
+            '9999.9.9',
+            warning_rec='Silence this warning by doing XYZ.',
+            error_rec='Fix this issue by doing XYZ.',
+        )
+    with pytest.raises(RuntimeError):
+        alert_future_error(
+            'Message',
+            '1.0.0',
+            warning_rec='Silence this warning by doing XYZ.',
+            error_rec='Fix this issue by doing XYZ.',
+        )
+    with pytest.raises(ValueError):
+        alert_future_error(
+            'Message',
+            '1.0.0',
+            warning_rec='Silence this warning by doing XYZ.',
+            error_rec='Fix this issue by doing XYZ.',
+            error_class=ValueError,
+        )


### PR DESCRIPTION
Follow-up to #1082, which will need to transition from a warning to an error on the release of 5.0 (which I'm aiming for next week).

Created a new function in `nibabel.deprecated` to turn what we need to do here into a template that can be used elsewhere.