### PR TITLE
MNT: Switch to hatchling build backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# See also nibabel/.gitignore for test data rules that
+# are meant to make you think before you `git add --force`
+
 # Editor temporary/working/backup files #
 #########################################
 .#*
@@ -35,23 +38,6 @@
 *.o
 *.py[oc]
 *.so
-
-# Packages #
-############
-# it's better to unpack these files and commit the raw source
-# git has its own built in compression methods
-*.7z
-*.bz2
-*.bzip2
-*.dmg
-*.gz
-*.iso
-*.jar
-*.rar
-*.tar
-*.tbz2
-*.tgz
-*.zip
 
 # Python files #
 ################

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,14 @@ dist/
 .coverage
 .ropeproject/
 htmlcov/
+.*_cache/
 
 # Logs and databases #
 ######################
 *.log
 *.sql
 *.sqlite
+*.sqlite3
 
 # OS generated files #
 ######################

--- a/nibabel/.gitignore
+++ b/nibabel/.gitignore
@@ -1,0 +1,16 @@
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.bz2
+*.bzip2
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.tbz2
+*.tgz
+*.zip

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -622,12 +622,14 @@ class TestMultiFrameWrapper(TestCase):
         assert MFW(fake_mf).image_position.dtype == float
 
     @dicom_test
+    @pytest.mark.xfail(reason='Not packaged in install', raises=FileNotFoundError)
     def test_affine(self):
         # Make sure we find orientation/position/spacing info
         dw = didw.wrapper_from_file(DATA_FILE_4D)
         aff = dw.affine
 
     @dicom_test
+    @pytest.mark.xfail(reason='Not packaged in install', raises=FileNotFoundError)
     def test_data_real(self):
         # The data in this file is (initially) a 1D gradient so it compresses
         # well.  This just tests that the data ordering produces a consistent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "nibabel"
@@ -70,13 +70,22 @@ test = [
 ]
 zstd = ["pyzstd >= 0.14.3"]
 
-[tool.setuptools]
-platforms = ["OS Independent"]
-provides = ["nibabel", "nisext"]
-zip-safe = false
+[tool.hatch.build.targets.sdist]
+exclude = [".git_archival.txt"]
 
-[tool.setuptools.packages.find]
-include = ["nibabel*", "nisext*"]
+[tool.hatch.build.targets.wheel]
+packages = ["nibabel", "nisext"]
+exclude = [
+  # 56MB test file does not need to be installed everywhere
+  "nibabel/nicom/tests/data/4d_multiframe_test.dcm",
+]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { version_scheme = "release-branch-semver" }
+
+[tool.hatch.build.hooks.vcs]
+version-file = "nibabel/_version.py"
 
 [tool.blue]
 line_length = 99
@@ -93,6 +102,3 @@ force-exclude = """
 profile = "black"
 line_length = 99
 extend_skip = ["_version.py", "externals"]
-
-[tool.setuptools_scm]
-write_to = "nibabel/_version.py"


### PR DESCRIPTION
I've become increasingly frustrated with setuptools across various projects, in large part due to the weird blend of backward compatibility and churn related to trying to support modern standards.

#1133 converted most of our build metadata to backend-agnostic `pyproject.toml` metadata.
#1171 converted the rest and replaced the setuptools-specific versioneer with the (surprisingly) backend-agnostic setuptools_scm.

This PR finishes the job by selecting a new backend, and one that actually works better with `setuptools_scm` by separating version calculation from version file writing and both of these from determining which files belong in the sdist or wheel. Even better, you can separately decide what goes in an sdist and what goes in a wheel.

See [Hatch](https://hatch.pypa.io/) and [hatch-vcs](https://github.com/ofek/hatch-vcs) for further details.

This will also let us resolve #1087 in the short term by excluding it from the wheel/installation, while keeping it in the sdist for testing purposes.

Fixes #1087.