### PR TITLE
ENH: Annotate SpatialImage API, improve  superclass annotations

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -1064,5 +1064,5 @@ class AnalyzeImage(SpatialImage):
             hdr['scl_inter'] = inter
 
 
-load = AnalyzeImage.load
+load = AnalyzeImage.from_filename
 save = AnalyzeImage.instance_to_filename

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -59,6 +59,9 @@ KEEP_FILE_OPEN_DEFAULT = False
 if ty.TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 
+    # Taken from numpy/__init__.pyi
+    _DType = ty.TypeVar('_DType', bound=np.dtype[ty.Any])
+
 
 class ArrayLike(ty.Protocol):
     """Protocol for numpy ndarray-like objects
@@ -68,9 +71,19 @@ class ArrayLike(ty.Protocol):
     """
 
     shape: tuple[int, ...]
-    ndim: int
 
-    def __array__(self, dtype: npt.DTypeLike | None = None, /) -> npt.NDArray:
+    @property
+    def ndim(self) -> int:
+        ...  # pragma: no cover
+
+    # If no dtype is passed, any dtype might be returned, depending on the array-like
+    @ty.overload
+    def __array__(self, dtype: None = ..., /) -> np.ndarray[ty.Any, np.dtype[ty.Any]]:
+        ...  # pragma: no cover
+
+    # Any dtype might be passed, and *that* dtype must be returned
+    @ty.overload
+    def __array__(self, dtype: _DType, /) -> np.ndarray[ty.Any, _DType]:
         ...  # pragma: no cover
 
     def __getitem__(self, key, /) -> npt.NDArray:

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -564,4 +564,4 @@ class AFNIImage(SpatialImage):
         return file_map
 
 
-load = AFNIImage.load
+load = AFNIImage.from_filename

--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -20,12 +20,14 @@ from .filebasedimages import FileBasedHeader, FileBasedImage, FileMap, FileSpec
 if ty.TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
 
+ArrayImgT = ty.TypeVar('ArrayImgT', bound='DataobjImage')
+
 
 class DataobjImage(FileBasedImage):
     """Template class for images that have dataobj data stores"""
 
     _data_cache: np.ndarray | None
-    _fdata_cache: np.ndarray | None
+    _fdata_cache: np.ndarray[ty.Any, np.dtype[np.floating]] | None
 
     def __init__(
         self,
@@ -222,7 +224,7 @@ class DataobjImage(FileBasedImage):
         self,
         caching: ty.Literal['fill', 'unchanged'] = 'fill',
         dtype: npt.DTypeLike = np.float64,
-    ) -> np.ndarray:
+    ) -> np.ndarray[ty.Any, np.dtype[np.floating]]:
         """Return floating point image data with necessary scaling applied
 
         The image ``dataobj`` property can be an array proxy or an array.  An
@@ -421,12 +423,12 @@ class DataobjImage(FileBasedImage):
 
     @classmethod
     def from_file_map(
-        klass,
+        klass: type[ArrayImgT],
         file_map: FileMap,
         *,
         mmap: bool | ty.Literal['c', 'r'] = True,
         keep_file_open: bool | None = None,
-    ):
+    ) -> ArrayImgT:
         """Class method to create image from mapping in ``file_map``
 
         Parameters
@@ -460,12 +462,12 @@ class DataobjImage(FileBasedImage):
 
     @classmethod
     def from_filename(
-        klass,
+        klass: type[ArrayImgT],
         filename: FileSpec,
         *,
         mmap: bool | ty.Literal['c', 'r'] = True,
         keep_file_open: bool | None = None,
-    ):
+    ) -> ArrayImgT:
         """Class method to create image from filename `filename`
 
         Parameters

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -747,11 +747,13 @@ class EcatImageArrayProxy:
 class EcatImage(SpatialImage):
     """Class returns a list of Ecat images, with one image(hdr/data) per frame"""
 
-    _header = EcatHeader
-    header_class = _header
+    header_class = EcatHeader
+    subheader_class = EcatSubHeader
     valid_exts = ('.v',)
-    _subheader = EcatSubHeader
     files_types = (('image', '.v'), ('header', '.v'))
+
+    _header: EcatHeader
+    _subheader: EcatSubHeader
 
     ImageArrayProxy = EcatImageArrayProxy
 
@@ -879,14 +881,14 @@ class EcatImage(SpatialImage):
         hdr_file, img_file = klass._get_fileholders(file_map)
         # note header and image are in same file
         hdr_fid = hdr_file.get_prepare_fileobj(mode='rb')
-        header = klass._header.from_fileobj(hdr_fid)
+        header = klass.header_class.from_fileobj(hdr_fid)
         hdr_copy = header.copy()
         # LOAD MLIST
         mlist = np.zeros((header['num_frames'], 4), dtype=np.int32)
         mlist_data = read_mlist(hdr_fid, hdr_copy.endianness)
         mlist[: len(mlist_data)] = mlist_data
         # LOAD SUBHEADERS
-        subheaders = klass._subheader(hdr_copy, mlist, hdr_fid)
+        subheaders = klass.subheader_class(hdr_copy, mlist, hdr_fid)
         # LOAD DATA
         # Class level ImageArrayProxy
         data = klass.ImageArrayProxy(subheaders)

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -589,5 +589,5 @@ class MGHImage(SpatialImage, SerializableImage):
         hdr['Pxyz_c'] = c_ras
 
 
-load = MGHImage.load
+load = MGHImage.from_filename
 save = MGHImage.instance_to_filename

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -334,4 +334,4 @@ class Minc1Image(SpatialImage):
         return klass(data, affine, header, extra=None, file_map=file_map)
 
 
-load = Minc1Image.load
+load = Minc1Image.from_filename

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -172,4 +172,4 @@ class Minc2Image(Minc1Image):
         return klass(data, affine, header, extra=None, file_map=file_map)
 
 
-load = Minc2Image.load
+load = Minc2Image.from_filename

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -25,10 +25,10 @@ from .arrayproxy import get_obj_dtype
 from .batteryrunners import Report
 from .casting import have_binary128
 from .deprecated import alert_future_error
-from .filebasedimages import SerializableImage
+from .filebasedimages import ImageFileError, SerializableImage
 from .optpkg import optional_package
 from .quaternions import fillpositive, mat2quat, quat2mat
-from .spatialimages import HeaderDataError, ImageFileError
+from .spatialimages import HeaderDataError
 from .spm99analyze import SpmAnalyzeHeader
 from .volumeutils import Recoder, endian_codes, make_dt_codes
 

--- a/nibabel/nifti2.py
+++ b/nibabel/nifti2.py
@@ -17,8 +17,9 @@ import numpy as np
 
 from .analyze import AnalyzeHeader
 from .batteryrunners import Report
+from .filebasedimages import ImageFileError
 from .nifti1 import Nifti1Header, Nifti1Image, Nifti1Pair
-from .spatialimages import HeaderDataError, ImageFileError
+from .spatialimages import HeaderDataError
 
 r"""
 Header struct from : https://www.nitrc.org/forum/message.php?msg_id=3738

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -284,19 +284,17 @@ def supported_np_types(obj):
         set of numpy types that `obj` supports
     """
     dt = obj.get_data_dtype()
-    supported = []
-    for name, np_types in np.sctypes.items():
-        for np_type in np_types:
-            try:
-                obj.set_data_dtype(np_type)
-            except HeaderDataError:
-                continue
-            # Did set work?
-            if np.dtype(obj.get_data_dtype()) == np.dtype(np_type):
-                supported.append(np_type)
-    # Reset original header dtype
+    supported = set()
+    for np_type in set(np.sctypeDict.values()):
+        try:
+            obj.set_data_dtype(np_type)
+        except HeaderDataError:
+            continue
+        # Did set work?
+        if np.dtype(obj.get_data_dtype()) == np.dtype(np_type):
+            supported.add(np_type)
     obj.set_data_dtype(dt)
-    return set(supported)
+    return supported
 
 
 class ImageDataError(Exception):

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -133,7 +133,8 @@ from __future__ import annotations
 
 import io
 import typing as ty
-from typing import Literal, Sequence
+from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -395,7 +395,11 @@ class SpatialFirstSlicer(ty.Generic[SpatialImgT]):
         affine = self.slice_affine(slicer)
         return self.img.__class__(dataobj.copy(), affine, self.img.header)
 
-    def check_slicing(self, slicer: object, return_spatial: bool = False) -> tuple[slice, ...]:
+    def check_slicing(
+        self,
+        slicer: object,
+        return_spatial: bool = False,
+    ) -> tuple[slice | int | None, ...]:
         """Canonicalize slicers and check for scalar indices in spatial dims
 
         Parameters
@@ -426,7 +430,7 @@ class SpatialFirstSlicer(ty.Generic[SpatialImgT]):
                 )
         return spatial_slices if return_spatial else canonical
 
-    def slice_affine(self, slicer: tuple[slice, ...]) -> np.ndarray:
+    def slice_affine(self, slicer: object) -> np.ndarray:
         """Retrieve affine for current image, if sliced by a given index
 
         Applies scaling if down-sampling is applied, and adjusts the intercept

--- a/nibabel/spm2analyze.py
+++ b/nibabel/spm2analyze.py
@@ -130,5 +130,5 @@ class Spm2AnalyzeImage(spm99.Spm99AnalyzeImage):
     header_class = Spm2AnalyzeHeader
 
 
-load = Spm2AnalyzeImage.load
+load = Spm2AnalyzeImage.from_filename
 save = Spm2AnalyzeImage.instance_to_filename

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -331,5 +331,5 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             sio.savemat(mfobj, {'M': M, 'mat': mat}, format='4')
 
 
-load = Spm99AnalyzeImage.load
+load = Spm99AnalyzeImage.from_filename
 save = Spm99AnalyzeImage.instance_to_filename

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -210,19 +210,6 @@ def assert_arr_dict_equal(dict1, dict2):
         assert_array_equal(value1, value2)
 
 
-class BaseTestCase(unittest.TestCase):
-    """TestCase that does not attempt to run if prefixed with a ``_``
-
-    This restores the nose-like behavior of skipping so-named test cases
-    in test runners like pytest.
-    """
-
-    def setUp(self):
-        if self.__class__.__name__.startswith('_'):
-            raise unittest.SkipTest('Base test case - subclass to run')
-        super().setUp()
-
-
 def expires(version):
     """Decorator to mark a test as xfail with ExpiredDeprecationError after version"""
     from packaging.version import Version

--- a/nibabel/tests/conftest.py
+++ b/nibabel/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from ..spatialimages import supported_np_types
+
+
+# Generate dynamic fixtures
+def pytest_generate_tests(metafunc):
+    if 'supported_dtype' in metafunc.fixturenames:
+        if metafunc.cls is None or not getattr(metafunc.cls, 'image_class'):
+            raise pytest.UsageError(
+                'Attempting to use supported_dtype fixture outside an image test case'
+            )
+        # xdist needs a consistent ordering, so sort by class name
+        supported_dtypes = sorted(
+            supported_np_types(metafunc.cls.image_class.header_class()),
+            key=lambda x: x.__name__,
+        )
+        metafunc.parametrize('supported_dtype', supported_dtypes)

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -49,12 +49,12 @@ header_file = os.path.join(data_path, 'analyze.hdr')
 PIXDIM0_MSG = 'pixdim[1,2,3] should be non-zero; setting 0 dims to 1'
 
 
-def add_intp(supported_np_types):
-    # Add intp, uintp to supported types as necessary
-    supported_dtypes = [np.dtype(t) for t in supported_np_types]
-    for np_type in (np.intp, np.uintp):
-        if np.dtype(np_type) in supported_dtypes:
-            supported_np_types.add(np_type)
+def add_duplicate_types(supported_np_types):
+    # Update supported numpy types with named scalar types that map to the same set of dtypes
+    dtypes = {np.dtype(t) for t in supported_np_types}
+    supported_np_types.update(
+        scalar for scalar in set(np.sctypeDict.values()) if np.dtype(scalar) in dtypes
+    )
 
 
 class TestAnalyzeHeader(tws._TestLabeledWrapStruct):
@@ -62,7 +62,7 @@ class TestAnalyzeHeader(tws._TestLabeledWrapStruct):
     example_file = header_file
     sizeof_hdr = AnalyzeHeader.sizeof_hdr
     supported_np_types = {np.uint8, np.int16, np.int32, np.float32, np.float64, np.complex64}
-    add_intp(supported_np_types)
+    add_duplicate_types(supported_np_types)
 
     def test_supported_types(self):
         hdr = self.header_class()

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -80,7 +80,7 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
     )
     if have_binary128():
         supported_np_types = supported_np_types.union((np.longdouble, np.longcomplex))
-    tana.add_intp(supported_np_types)
+    tana.add_duplicate_types(supported_np_types)
 
     def test_empty(self):
         tana.TestAnalyzeHeader.test_empty(self)

--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -11,7 +11,6 @@
 
 import warnings
 from io import BytesIO
-from unittest import TestCase
 
 import numpy as np
 import pytest
@@ -205,7 +204,7 @@ class DataLike:
         return np.arange(3, dtype=dtype)
 
 
-class TestSpatialImage(TestCase):
+class TestSpatialImage:
     # class for testing images
     image_class = SpatialImage
     can_save = False

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -35,10 +35,18 @@ from ..testing import (
 from ..volumeutils import _dt_min_max, apply_read_scaling
 from . import test_analyze
 
-FLOAT_TYPES = np.sctypes['float']
-COMPLEX_TYPES = np.sctypes['complex']
-INT_TYPES = np.sctypes['int']
-UINT_TYPES = np.sctypes['uint']
+# np.sctypes values are lists of types with unique sizes
+# For testing, we want all concrete classes of a type
+# Key on kind, rather than abstract base classes, since timedelta64 is a signedinteger
+sctypes = {}
+for sctype in set(np.sctypeDict.values()):
+    sctypes.setdefault(np.dtype(sctype).kind, []).append(sctype)
+
+# Sort types to ensure that xdist doesn't complain about test order when we parametrize
+FLOAT_TYPES = sorted(sctypes['f'], key=lambda x: x.__name__)
+COMPLEX_TYPES = sorted(sctypes['c'], key=lambda x: x.__name__)
+INT_TYPES = sorted(sctypes['i'], key=lambda x: x.__name__)
+UINT_TYPES = sorted(sctypes['u'], key=lambda x: x.__name__)
 CFLOAT_TYPES = FLOAT_TYPES + COMPLEX_TYPES
 IUINT_TYPES = INT_TYPES + UINT_TYPES
 NUMERIC_TYPES = CFLOAT_TYPES + IUINT_TYPES

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -306,57 +306,57 @@ class ImageScalingMixin:
         img_rt = bytesio_round_trip(img)
         assert_array_equal(img_rt.get_fdata(), np.clip(arr, 0, 255))
 
-    def test_no_scaling(self):
+    # NOTE: Need to check complex scaling
+    @pytest.mark.parametrize('in_dtype', FLOAT_TYPES + IUINT_TYPES)
+    def test_no_scaling(self, in_dtype, supported_dtype):
         # Test writing image converting types when not calculating scaling
         img_class = self.image_class
         hdr_class = img_class.header_class
         hdr = hdr_class()
-        supported_types = supported_np_types(hdr)
         # Any old non-default slope and intercept
         slope = 2
         inter = 10 if hdr.has_data_intercept else 0
-        for in_dtype, out_dtype in itertools.product(FLOAT_TYPES + IUINT_TYPES, supported_types):
-            # Need to check complex scaling
-            mn_in, mx_in = _dt_min_max(in_dtype)
-            arr = np.array([mn_in, -1, 0, 1, 10, mx_in], dtype=in_dtype)
-            img = img_class(arr, np.eye(4), hdr)
-            img.set_data_dtype(out_dtype)
-            # Setting the scaling means we don't calculate it later
-            img.header.set_slope_inter(slope, inter)
-            with np.errstate(invalid='ignore'):
-                rt_img = bytesio_round_trip(img)
-            with suppress_warnings():  # invalid mult
-                back_arr = np.asanyarray(rt_img.dataobj)
-            exp_back = arr.copy()
-            # If converting to floating point type, casting is direct.
-            # Otherwise we will need to do float-(u)int casting at some point
-            if out_dtype in IUINT_TYPES:
-                if in_dtype in FLOAT_TYPES:
-                    # Working precision is (at least) float
-                    exp_back = exp_back.astype(float)
-                    # Float to iu conversion will always round, clip
-                    with np.errstate(invalid='ignore'):
-                        exp_back = np.round(exp_back)
-                    if in_dtype in FLOAT_TYPES:
-                        # Clip to shared range of working precision
-                        exp_back = np.clip(exp_back, *shared_range(float, out_dtype))
-                else:  # iu input and output type
-                    # No scaling, never gets converted to float.
-                    # Does get clipped to range of output type
-                    mn_out, mx_out = _dt_min_max(out_dtype)
-                    if (mn_in, mx_in) != (mn_out, mx_out):
-                        # Use smaller of input, output range to avoid np.clip
-                        # upcasting the array because of large clip limits.
-                        exp_back = np.clip(exp_back, max(mn_in, mn_out), min(mx_in, mx_out))
-            if out_dtype in COMPLEX_TYPES:
-                # always cast to real from complex
-                exp_back = exp_back.astype(out_dtype)
-            else:
-                # Cast to working precision
+
+        mn_in, mx_in = _dt_min_max(in_dtype)
+        arr = np.array([mn_in, -1, 0, 1, 10, mx_in], dtype=in_dtype)
+        img = img_class(arr, np.eye(4), hdr)
+        img.set_data_dtype(supported_dtype)
+        # Setting the scaling means we don't calculate it later
+        img.header.set_slope_inter(slope, inter)
+        with np.errstate(invalid='ignore'):
+            rt_img = bytesio_round_trip(img)
+        with suppress_warnings():  # invalid mult
+            back_arr = np.asanyarray(rt_img.dataobj)
+        exp_back = arr.copy()
+        # If converting to floating point type, casting is direct.
+        # Otherwise we will need to do float-(u)int casting at some point
+        if supported_dtype in IUINT_TYPES:
+            if in_dtype in FLOAT_TYPES:
+                # Working precision is (at least) float
                 exp_back = exp_back.astype(float)
-            # Allow for small differences in large numbers
-            with suppress_warnings():  # invalid value
-                assert_allclose_safely(back_arr, exp_back * slope + inter)
+                # Float to iu conversion will always round, clip
+                with np.errstate(invalid='ignore'):
+                    exp_back = np.round(exp_back)
+                if in_dtype in FLOAT_TYPES:
+                    # Clip to shared range of working precision
+                    exp_back = np.clip(exp_back, *shared_range(float, supported_dtype))
+            else:  # iu input and output type
+                # No scaling, never gets converted to float.
+                # Does get clipped to range of output type
+                mn_out, mx_out = _dt_min_max(supported_dtype)
+                if (mn_in, mx_in) != (mn_out, mx_out):
+                    # Use smaller of input, output range to avoid np.clip
+                    # upcasting the array because of large clip limits.
+                    exp_back = np.clip(exp_back, max(mn_in, mn_out), min(mx_in, mx_out))
+        if supported_dtype in COMPLEX_TYPES:
+            # always cast to real from complex
+            exp_back = exp_back.astype(supported_dtype)
+        else:
+            # Cast to working precision
+            exp_back = exp_back.astype(float)
+        # Allow for small differences in large numbers
+        with suppress_warnings():  # invalid value
+            assert_allclose_safely(back_arr, exp_back * slope + inter)
 
     def test_write_scaling(self):
         # Check writes with scaling set

--- a/nibabel/tests/test_spm99analyze.py
+++ b/nibabel/tests/test_spm99analyze.py
@@ -47,6 +47,8 @@ FLOAT_TYPES = sorted(sctypes['f'], key=lambda x: x.__name__)
 COMPLEX_TYPES = sorted(sctypes['c'], key=lambda x: x.__name__)
 INT_TYPES = sorted(sctypes['i'], key=lambda x: x.__name__)
 UINT_TYPES = sorted(sctypes['u'], key=lambda x: x.__name__)
+
+# Create combined type lists
 CFLOAT_TYPES = FLOAT_TYPES + COMPLEX_TYPES
 IUINT_TYPES = INT_TYPES + UINT_TYPES
 NUMERIC_TYPES = CFLOAT_TYPES + IUINT_TYPES

--- a/nibabel/tests/test_wrapstruct.py
+++ b/nibabel/tests/test_wrapstruct.py
@@ -33,7 +33,6 @@ from numpy.testing import assert_array_equal
 from .. import imageglobals
 from ..batteryrunners import Report
 from ..spatialimages import HeaderDataError
-from ..testing import BaseTestCase
 from ..volumeutils import Recoder, native_code, swapped_code
 from ..wrapstruct import LabeledWrapStruct, WrapStruct, WrapStructError
 
@@ -101,7 +100,7 @@ def log_chk(hdr, level):
     return hdrc, message, raiser
 
 
-class _TestWrapStructBase(BaseTestCase):
+class _TestWrapStructBase:
     """Class implements base tests for binary headers
 
     It serves as a base class for other binary header tests


### PR DESCRIPTION
The most interesting thing about annotating the `SpatialImage` was annotating the slicer, which needs to know what kind of thing it returns when sliced. This required learning about [generic types](https://docs.python.org/3/library/typing.html#typing.Generic) and [type variables](https://docs.python.org/3/library/typing.html#typing.TypeVar).

To get a sense of how they work, here's an excerpt:

```Python
SpatialImgT = ty.TypeVar('SpatialImgT', bound='SpatialImage')

class SpatialFirstSlicer(ty.Generic[SpatialImgT]):
    def __init__(self, img: SpatialImgT): ...
    def __getitem__(self, slicer: object) -> SpatialImgT: ...

class SpatialImage:
    @property
    def slicer(self: SpatialImgT) -> SpatialFirstSlicer[SpatialImgT]: ...
```

`SpatialImgT` will match any type that is a subclass of `SpatialImage`. So when we call `Nifti1Image().slicer` we get back a `SpatialFirstSlicer[Nifti1Image]`. So `Nifti1Image().slicer[:, :, :, 0]` will have type `Nifti1Image`.

The type variables also helped with figuring out the right types for the `@classmethod`s, which I then went back and added to filebasedimages and dataobj_images. This led to some mypy complaints deeper in the hierarchy. I don't think any were actually bugs, but we don't lose functionality by "fixing" them.