### PR TITLE
ENH: Set symmetric threshold for identifying unit quaternions in qform calculation

### DIFF
--- a/doc/source/nifti_images.rst
+++ b/doc/source/nifti_images.rst
@@ -273,8 +273,8 @@ You can get and set the qform affine using the equivalent methods to those for
 the sform: ``get_qform()``, ``set_qform()``.
 
 >>> n1_header.get_qform(coded=True)
-(array([[ -2.  ,   0.  ,   0.  , 117.86],
-       [ -0.  ,   1.97,  -0.36, -35.72],
+(array([[ -2.  ,   0.  ,  -0.  , 117.86],
+       [  0.  ,   1.97,  -0.36, -35.72],
        [  0.  ,   0.32,   2.17,  -7.25],
        [  0.  ,   0.  ,   0.  ,   1.  ]]), 1)
 

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -688,7 +688,7 @@ class Nifti1Header(SpmAnalyzeHeader):
     single_magic = b'n+1'
 
     # Quaternion threshold near 0, based on float32 precision
-    quaternion_threshold = -np.finfo(np.float32).eps * 3
+    quaternion_threshold = np.finfo(np.float32).eps * 3
 
     def __init__(self, binaryblock=None, endianness=None, check=True, extensions=()):
         """Initialize header from binary data block and extensions"""

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -42,7 +42,7 @@ def fillpositive(xyz, w2_thresh=None):
     xyz : iterable
        iterable containing 3 values, corresponding to quaternion x, y, z
     w2_thresh : None or float, optional
-       threshold to determine if w squared is really negative.
+       threshold to determine if w squared is non-zero.
        If None (default) then w2_thresh set equal to
        ``-np.finfo(xyz.dtype).eps``, if possible, otherwise
        ``-np.finfo(np.float64).eps``
@@ -95,11 +95,11 @@ def fillpositive(xyz, w2_thresh=None):
     # Use maximum precision
     xyz = np.asarray(xyz, dtype=MAX_FLOAT)
     # Calculate w
-    w2 = 1.0 - np.dot(xyz, xyz)
-    if w2 < 0:
-        if w2 < w2_thresh:
-            raise ValueError(f'w2 should be positive, but is {w2:e}')
+    w2 = 1.0 - xyz @ xyz
+    if np.abs(w2) < np.abs(w2_thresh):
         w = 0
+    elif w2 < 0:
+        raise ValueError(f'w2 should be positive, but is {w2:e}')
     else:
         w = np.sqrt(w2)
     return np.r_[w, xyz]

--- a/nibabel/quaternions.py
+++ b/nibabel/quaternions.py
@@ -44,8 +44,8 @@ def fillpositive(xyz, w2_thresh=None):
     w2_thresh : None or float, optional
        threshold to determine if w squared is non-zero.
        If None (default) then w2_thresh set equal to
-       ``-np.finfo(xyz.dtype).eps``, if possible, otherwise
-       ``-np.finfo(np.float64).eps``
+       3 * ``np.finfo(xyz.dtype).eps``, if possible, otherwise
+       3 * ``np.finfo(np.float64).eps``
 
     Returns
     -------
@@ -89,9 +89,9 @@ def fillpositive(xyz, w2_thresh=None):
     # If necessary, guess precision of input
     if w2_thresh is None:
         try:  # trap errors for non-array, integer array
-            w2_thresh = -np.finfo(xyz.dtype).eps * 3
+            w2_thresh = np.finfo(xyz.dtype).eps * 3
         except (AttributeError, ValueError):
-            w2_thresh = -FLOAT_EPS * 3
+            w2_thresh = FLOAT_EPS * 3
     # Use maximum precision
     xyz = np.asarray(xyz, dtype=MAX_FLOAT)
     # Calculate w

--- a/nibabel/tests/test_quaternions.py
+++ b/nibabel/tests/test_quaternions.py
@@ -108,7 +108,7 @@ def test_fillpositive_simulated_error(dtype):
     # as xyz with small error, and we want to recover the w of 0
 
     # Permit 1 epsilon per value (default, but make explicit here)
-    w2_thresh = 3 * -np.finfo(dtype).eps
+    w2_thresh = 3 * np.finfo(dtype).eps
 
     pos_error = neg_error = False
     for _ in range(50):

--- a/nibabel/tests/test_quaternions.py
+++ b/nibabel/tests/test_quaternions.py
@@ -91,6 +91,15 @@ def test_fillpositive_plus_minus_epsilon(dtype):
     assert nq.fillpositive(plus)[0] == 0.0
     assert nq.fillpositive(minus)[0] == 0.0
 
+    # |(x, y, z)| > 1, no real solutions
+    plus = baseline * nptype(1 + 2 * np.finfo(dtype).eps)
+    with pytest.raises(ValueError):
+        nq.fillpositive(plus)
+
+    # |(x, y, z)| < 1, two real solutions, we choose positive
+    minus = baseline * nptype(1 - 2 * np.finfo(dtype).eps)
+    assert nq.fillpositive(minus)[0] > 0.0
+
 
 @pytest.mark.parametrize('dtype', ('f4', 'f8'))
 def test_fillpositive_simulated_error(dtype):
@@ -107,18 +116,7 @@ def test_fillpositive_simulated_error(dtype):
     for _ in range(50):
         xyz = norm(gen_vec(dtype))
 
-        wxyz = nq.fillpositive(xyz, w2_thresh)
-        assert wxyz[0] == 0.0
-
-        # Verify that we exercise the threshold
-        magnitude = xyz @ xyz
-        if magnitude < 1:
-            pos_error = True
-        elif magnitude > 1:
-            neg_error = True
-
-    assert pos_error, 'Did not encounter a case where 1 - |xyz| > 0'
-    assert neg_error, 'Did not encounter a case where 1 - |xyz| < 0'
+        assert nq.fillpositive(xyz, w2_thresh)[0] == 0.0
 
 
 def test_conjugate():


### PR DESCRIPTION
The `quaternions.fillpositive` function is intended to augment a partial quaternion to make a unit 4-vector by finding `w`, given `(x, y, z)`, such that `|(w, x, y, z)| == 1`. Floating point precision error means that a `(w, x, y, z)` selected to be a unit vector can still sometimes result in `|(w, x, y, z)| != 1` by a small amount. Currently if `1 - |(x, y, z)| > -3*eps`, we call that close enough to zero that `w = 0` will still produce a unit quaternion.

This is asymmetric, as if `1 - 3*eps < |(x, y, z)| < 1`, we will get `w = sqrt(1 - |(x, y, z)|) > 0`, which can result in a surprising failure to preserve an affine that encodes a rotation in only one plane (see #1181 for an example). This is not exactly wrong, but the asymmetry is unsatisfying and inconsistent with `fslhd` at the least.

I'm starting this PR with a (failing) test to assert that a passing `fillpositive()` unit 3-vector, up to the precision allowed by its dtype, will result in a 0 `w`.

Following failing tests, I will use the change proposed in https://github.com/nipy/nibabel/issues/1181#issuecomment-1379211496 to satisfy the constraint imposed by the test.

Closes #1181.