### PR TITLE
CI: Debug actions

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4.4.0
         with:
           python-version: 3
       - run: pip install --upgrade build twine


### PR DESCRIPTION
Trying to figure out why `os.getcwd()` is suddenly failing. One change between the last passing master and the failing cases is an update of `actions/setup-python` from v4.4.0 to v4.5.0.