### PR TITLE
FIX: Return to cwd on exception in InTemporaryDirectory

### DIFF
--- a/nibabel/tmpdirs.py
+++ b/nibabel/tmpdirs.py
@@ -20,8 +20,10 @@ except ImportError:  # PY310
     def _chdir(path):
         cwd = os.getcwd()
         os.chdir(path)
-        yield
-        os.chdir(cwd)
+        try:
+            yield
+        finally:
+            os.chdir(cwd)
 
 
 from .deprecated import deprecate_with_version


### PR DESCRIPTION
Bug introduced in #1172 that is breaking tests now that we raise an `ExpiredDeprecationError` inside an `InTemporaryDirectory`. If a context manager doesn't catch exceptions raised in `yield` and do cleanup in a `finally:` block, the cleanup may not get done. Here, it caused our CWD to be a deleted directory, breaking the next use of `InTemporaryDirectory`.