### PR TITLE
TYP: Annotate deprecation, one-time property, and optional package tooling

### DIFF
--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -2,11 +2,14 @@
 """
 from __future__ import annotations
 
+import typing as ty
 import warnings
-from typing import Type
 
 from .deprecator import Deprecator
 from .pkg_info import cmp_pkg_version
+
+if ty.TYPE_CHECKING:  # pragma: no cover
+    P = ty.ParamSpec('P')
 
 
 class ModuleProxy:
@@ -30,14 +33,14 @@ class ModuleProxy:
     module.
     """
 
-    def __init__(self, module_name):
+    def __init__(self, module_name: str):
         self._module_name = module_name
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> ty.Any:
         mod = __import__(self._module_name, fromlist=[''])
         return getattr(mod, key)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<module proxy for {self._module_name}>'
 
 
@@ -60,7 +63,7 @@ class FutureWarningMixin:
 
     warn_message = 'This class will be removed in future versions'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: P.args, **kwargs: P.kwargs) -> None:
         warnings.warn(self.warn_message, FutureWarning, stacklevel=2)
         super().__init__(*args, **kwargs)
 
@@ -85,12 +88,12 @@ def alert_future_error(
     msg: str,
     version: str,
     *,
-    warning_class: Type[Warning] = FutureWarning,
-    error_class: Type[Exception] = RuntimeError,
+    warning_class: type[Warning] = FutureWarning,
+    error_class: type[Exception] = RuntimeError,
     warning_rec: str = '',
     error_rec: str = '',
     stacklevel: int = 2,
-):
+) -> None:
     """Warn or error with appropriate messages for changing functionality.
 
     Parameters

--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -33,7 +33,7 @@ class ModuleProxy:
     module.
     """
 
-    def __init__(self, module_name: str):
+    def __init__(self, module_name: str) -> None:
         self._module_name = module_name
 
     def __getattr__(self, key: str) -> ty.Any:

--- a/nibabel/onetime.py
+++ b/nibabel/onetime.py
@@ -19,6 +19,12 @@ Hettinger. https://docs.python.org/howto/descriptor.html
 
 [2] Python data model, https://docs.python.org/reference/datamodel.html
 """
+from __future__ import annotations
+
+import typing as ty
+
+InstanceT = ty.TypeVar('InstanceT')
+T = ty.TypeVar('T')
 
 from nibabel.deprecated import deprecate_with_version
 
@@ -96,26 +102,24 @@ class ResetMixin:
     10.0
     """
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset all OneTimeProperty attributes that may have fired already."""
-        instdict = self.__dict__
-        classdict = self.__class__.__dict__
         # To reset them, we simply remove them from the instance dict.  At that
         # point, it's as if they had never been computed.  On the next access,
         # the accessor function from the parent class will be called, simply
         # because that's how the python descriptor protocol works.
-        for mname, mval in classdict.items():
-            if mname in instdict and isinstance(mval, OneTimeProperty):
+        for mname, mval in self.__class__.__dict__.items():
+            if mname in self.__dict__ and isinstance(mval, OneTimeProperty):
                 delattr(self, mname)
 
 
-class OneTimeProperty:
+class OneTimeProperty(ty.Generic[T]):
     """A descriptor to make special properties that become normal attributes.
 
     This is meant to be used mostly by the auto_attr decorator in this module.
     """
 
-    def __init__(self, func):
+    def __init__(self, func: ty.Callable[[InstanceT], T]):
         """Create a OneTimeProperty instance.
 
         Parameters
@@ -128,24 +132,35 @@ class OneTimeProperty:
         """
         self.getter = func
         self.name = func.__name__
+        self.__doc__ = func.__doc__
 
-    def __get__(self, obj, type=None):
+    @ty.overload
+    def __get__(
+        self, obj: None, objtype: type[InstanceT] | None = None
+    ) -> ty.Callable[[InstanceT], T]:
+        ...  # pragma: no cover
+
+    @ty.overload
+    def __get__(self, obj: InstanceT, objtype: type[InstanceT] | None = None) -> T:
+        ...  # pragma: no cover
+
+    def __get__(
+        self, obj: InstanceT | None, objtype: type[InstanceT] | None = None
+    ) -> T | ty.Callable[[InstanceT], T]:
         """This will be called on attribute access on the class or instance."""
         if obj is None:
             # Being called on the class, return the original function. This
             # way, introspection works on the class.
-            # return func
             return self.getter
 
-        # Errors in the following line are errors in setting a
-        # OneTimeProperty
+        # Errors in the following line are errors in setting a OneTimeProperty
         val = self.getter(obj)
 
-        setattr(obj, self.name, val)
+        obj.__dict__[self.name] = val
         return val
 
 
-def auto_attr(func):
+def auto_attr(func: ty.Callable[[InstanceT], T]) -> OneTimeProperty[T]:
     """Decorator to create OneTimeProperty attributes.
 
     Parameters

--- a/nibabel/onetime.py
+++ b/nibabel/onetime.py
@@ -119,7 +119,7 @@ class OneTimeProperty(ty.Generic[T]):
     This is meant to be used mostly by the auto_attr decorator in this module.
     """
 
-    def __init__(self, func: ty.Callable[[InstanceT], T]):
+    def __init__(self, func: ty.Callable[[InstanceT], T]) -> None:
         """Create a OneTimeProperty instance.
 
         Parameters

--- a/nibabel/optpkg.py
+++ b/nibabel/optpkg.py
@@ -1,20 +1,31 @@
 """Routines to support optional packages"""
+from __future__ import annotations
+
+import typing as ty
+from types import ModuleType
+
 from packaging.version import Version
 
 from .tripwire import TripWire
 
 
-def _check_pkg_version(pkg, min_version):
-    # Default version checking function
-    if isinstance(min_version, str):
-        min_version = Version(min_version)
-    try:
-        return min_version <= Version(pkg.__version__)
-    except AttributeError:
+def _check_pkg_version(min_version: str | Version) -> ty.Callable[[ModuleType], bool]:
+    min_ver = Version(min_version) if isinstance(min_version, str) else min_version
+
+    def check(pkg: ModuleType) -> bool:
+        pkg_ver = getattr(pkg, '__version__', None)
+        if isinstance(pkg_ver, str):
+            return min_ver <= Version(pkg_ver)
         return False
 
+    return check
 
-def optional_package(name, trip_msg=None, min_version=None):
+
+def optional_package(
+    name: str,
+    trip_msg: str | None = None,
+    min_version: str | Version | ty.Callable[[ModuleType], bool] | None = None,
+) -> tuple[ModuleType | TripWire, bool, ty.Callable[[], None]]:
     """Return package-like thing and module setup for package `name`
 
     Parameters
@@ -81,7 +92,7 @@ def optional_package(name, trip_msg=None, min_version=None):
     elif min_version is None:
         check_version = lambda pkg: True
     else:
-        check_version = lambda pkg: _check_pkg_version(pkg, min_version)
+        check_version = _check_pkg_version(min_version)
     # fromlist=[''] results in submodule being returned, rather than the top
     # level module.  See help(__import__)
     fromlist = [''] if '.' in name else []
@@ -107,11 +118,11 @@ def optional_package(name, trip_msg=None, min_version=None):
         trip_msg = (
             f'We need package {name} for these functions, but ``import {name}`` raised {exc}'
         )
-    pkg = TripWire(trip_msg)
+    trip = TripWire(trip_msg)
 
-    def setup_module():
+    def setup_module() -> None:
         import unittest
 
         raise unittest.SkipTest(f'No {name} for these tests')
 
-    return pkg, False, setup_module
+    return trip, False, setup_module

--- a/nibabel/pkg_info.py
+++ b/nibabel/pkg_info.py
@@ -14,7 +14,7 @@ except ImportError:
 COMMIT_HASH = '$Format:%h$'
 
 
-def _cmp(a, b) -> int:
+def _cmp(a: Version, b: Version) -> int:
     """Implementation of ``cmp`` for Python 3"""
     return (a > b) - (a < b)
 
@@ -113,7 +113,7 @@ def pkg_commit_hash(pkg_path: str | None = None) -> tuple[str, str]:
     return '(none found)', '<not found>'
 
 
-def get_pkg_info(pkg_path: str) -> dict:
+def get_pkg_info(pkg_path: str) -> dict[str, str]:
     """Return dict describing the context of this package
 
     Parameters

--- a/nibabel/processing.py
+++ b/nibabel/processing.py
@@ -20,7 +20,7 @@ import numpy.linalg as npl
 
 from .optpkg import optional_package
 
-spnd, _, _ = optional_package('scipy.ndimage')
+spnd = optional_package('scipy.ndimage')[0]
 
 from .affines import AffineError, append_diag, from_matvec, rescale_affine, to_matvec
 from .imageclasses import spatial_axes_first

--- a/nibabel/testing/helpers.py
+++ b/nibabel/testing/helpers.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..optpkg import optional_package
 
-_, have_scipy, _ = optional_package('scipy.io')
+have_scipy = optional_package('scipy.io')[1]
 
 from numpy.testing import assert_array_equal
 

--- a/nibabel/tripwire.py
+++ b/nibabel/tripwire.py
@@ -1,5 +1,6 @@
 """Class to raise error for missing modules or other misfortunes
 """
+from typing import Any
 
 
 class TripWireError(AttributeError):
@@ -11,7 +12,7 @@ class TripWireError(AttributeError):
     # is not present.
 
 
-def is_tripwire(obj):
+def is_tripwire(obj: Any) -> bool:
     """Returns True if `obj` appears to be a TripWire object
 
     Examples
@@ -44,9 +45,9 @@ class TripWire:
     TripWireError: We do not have a_module
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg: str):
         self._msg = msg
 
-    def __getattr__(self, attr_name):
+    def __getattr__(self, attr_name: str) -> Any:
         """Raise informative error accessing attributes"""
         raise TripWireError(self._msg)

--- a/nibabel/tripwire.py
+++ b/nibabel/tripwire.py
@@ -45,7 +45,7 @@ class TripWire:
     TripWireError: We do not have a_module
     """
 
-    def __init__(self, msg: str):
+    def __init__(self, msg: str) -> None:
         self._msg = msg
 
     def __getattr__(self, attr_name: str) -> Any:


### PR DESCRIPTION
These are mostly self-contained pieces that allow us to transparently handle edge cases. So annotating them is relatively free of rabbit holes and should help avoid unnoticed `Any`s as we annotate portions of the code that they do wrap.