### PR TITLE
TYP: Annotate volumeutils

### DIFF
--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import gzip
 import sys
+import typing as ty
 import warnings
 from collections import OrderedDict
 from functools import reduce
@@ -120,6 +121,13 @@ class Recoder:
             self.__dict__[name] = map_maker()
         self.field1 = self.__dict__[fields[0]]
         self.add_codes(codes)
+
+    def __getattr__(self, key: str) -> ty.Mapping:
+        # By setting this, we let static analyzers know that dynamic attributes will
+        # be dict-like (Mapping).
+        # However, __getattr__ is called if looking up the field in __dict__ fails,
+        # so we only get here if the attribute is really missing.
+        raise AttributeError(f'{self.__class__.__name__!r} object has no attribute {key!r}')
 
     def add_codes(self, code_syn_seqs):
         """Add codes to object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,12 @@ test = [
 ]
 typing = [
   "mypy",
+  "importlib_resources",
+  "pydicom",
   "pytest",
+  "pyzstd",
   "types-setuptools",
   "types-Pillow",
-  "pydicom",
-  "importlib_resources",
 ]
 zstd = ["pyzstd >= 0.14.3"]
 


### PR DESCRIPTION
This PR has two significant issues that required changes:

1) `Recoder`s set instance variables based on their input parameters. These variables are always dict-like, but we can't know their names. Adding and annotating `__getattr__` resolves this.
2) The `DtypeMapper` used to allow for `Recoder`s with numpy dtypes was dict-ish, but not quite enough to make annotating it straightforward. Subclassing from `dict` was sufficient.

Otherwise, it's a fiddly file, so it needs a careful check that I haven't changed the logic or missed renaming a variable.