### PR TITLE
MNT: Finish removing distutils and setuptools dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,6 @@ repos:
           - pydicom
           - numpy
           - pyzstd
+          - importlib_resources
         args: ["nibabel"]
         pass_filenames: false

--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -171,11 +171,16 @@ def bench(label=None, verbose=1, extra_argv=None):
     code : ExitCode
         Returns the result of running the tests as a ``pytest.ExitCode`` enum
     """
-    from pkg_resources import resource_filename
+    try:
+        from importlib.resources import as_file, files
+    except ImportError:
+        from importlib_resources import as_file, files
 
-    config = resource_filename('nibabel', 'benchmarks/pytest.benchmark.ini')
     args = []
     if extra_argv is not None:
         args.extend(extra_argv)
-    args.extend(['-c', config])
-    return test(label, verbose, extra_argv=args)
+
+    config_path = files('nibabel') / 'benchmarks/pytest.benchmark.ini'
+    with as_file(config_path) as config:
+        args.extend(['-c', str(config)])
+        return test(label, verbose, extra_argv=args)

--- a/nibabel/cmdline/tests/test_conform.py
+++ b/nibabel/cmdline/tests/test_conform.py
@@ -15,7 +15,7 @@ import pytest
 import nibabel as nib
 from nibabel.cmdline.conform import main
 from nibabel.optpkg import optional_package
-from nibabel.testing import test_data
+from nibabel.testing import get_test_data
 
 _, have_scipy, _ = optional_package('scipy.ndimage')
 needs_scipy = unittest.skipUnless(have_scipy, 'These tests need scipy')
@@ -23,7 +23,7 @@ needs_scipy = unittest.skipUnless(have_scipy, 'These tests need scipy')
 
 @needs_scipy
 def test_default(tmpdir):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmpdir / 'output.nii.gz'
     main([str(infile), str(outfile)])
     assert outfile.isfile()
@@ -41,7 +41,7 @@ def test_default(tmpdir):
 
 @needs_scipy
 def test_nondefault(tmpdir):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmpdir / 'output.nii.gz'
     out_shape = (100, 100, 150)
     voxel_size = (1, 2, 4)

--- a/nibabel/cmdline/tests/test_convert.py
+++ b/nibabel/cmdline/tests/test_convert.py
@@ -13,11 +13,11 @@ import pytest
 
 import nibabel as nib
 from nibabel.cmdline import convert
-from nibabel.testing import test_data
+from nibabel.testing import get_test_data
 
 
 def test_convert_noop(tmp_path):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmp_path / 'output.nii.gz'
 
     orig = nib.load(infile)
@@ -31,7 +31,7 @@ def test_convert_noop(tmp_path):
     assert converted.shape == orig.shape
     assert converted.get_data_dtype() == orig.get_data_dtype()
 
-    infile = test_data(fname='resampled_anat_moved.nii')
+    infile = get_test_data(fname='resampled_anat_moved.nii')
 
     with pytest.raises(FileExistsError):
         convert.main([str(infile), str(outfile)])
@@ -50,7 +50,7 @@ def test_convert_noop(tmp_path):
 
 @pytest.mark.parametrize('data_dtype', ('u1', 'i2', 'float32', 'float', 'int64'))
 def test_convert_dtype(tmp_path, data_dtype):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmp_path / 'output.nii.gz'
 
     orig = nib.load(infile)
@@ -78,7 +78,7 @@ def test_convert_dtype(tmp_path, data_dtype):
     ],
 )
 def test_convert_by_extension(tmp_path, ext, img_class):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmp_path / f'output.{ext}'
 
     orig = nib.load(infile)
@@ -102,7 +102,7 @@ def test_convert_by_extension(tmp_path, ext, img_class):
     ],
 )
 def test_convert_imgtype(tmp_path, ext, img_class):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmp_path / f'output.{ext}'
 
     orig = nib.load(infile)
@@ -118,7 +118,7 @@ def test_convert_imgtype(tmp_path, ext, img_class):
 
 
 def test_convert_nifti_int_fail(tmp_path):
-    infile = test_data(fname='anatomical.nii')
+    infile = get_test_data(fname='anatomical.nii')
     outfile = tmp_path / f'output.nii'
 
     orig = nib.load(infile)

--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -701,8 +701,8 @@ class GiftiImage(xml.XmlSerializable, SerializableImage):
         Consider a surface GIFTI file:
 
         >>> import nibabel as nib
-        >>> from nibabel.testing import test_data
-        >>> surf_img = nib.load(test_data('gifti', 'ascii.gii'))
+        >>> from nibabel.testing import get_test_data
+        >>> surf_img = nib.load(get_test_data('gifti', 'ascii.gii'))
 
         The coordinate data, which is indicated by the ``NIFTI_INTENT_POINTSET``
         intent code, may be retrieved using any of the following equivalent
@@ -754,7 +754,7 @@ class GiftiImage(xml.XmlSerializable, SerializableImage):
         The following image is a GIFTI file with ten (10) data arrays of the same
         size, and with intent code 2001 (``NIFTI_INTENT_TIME_SERIES``):
 
-        >>> func_img = nib.load(test_data('gifti', 'task.func.gii'))
+        >>> func_img = nib.load(get_test_data('gifti', 'task.func.gii'))
 
         When aggregating time series data, these arrays are concatenated into
         a single, vertex-by-timestep array:

--- a/nibabel/gifti/tests/test_gifti.py
+++ b/nibabel/gifti/tests/test_gifti.py
@@ -14,7 +14,7 @@ from nibabel.tmpdirs import InTemporaryDirectory
 from ... import load
 from ...fileholders import FileHolder
 from ...nifti1 import data_type_codes
-from ...testing import test_data
+from ...testing import get_test_data
 from .. import (
     GiftiCoordSystem,
     GiftiDataArray,
@@ -35,9 +35,9 @@ from .test_parse_gifti_fast import (
 
 
 def test_agg_data():
-    surf_gii_img = load(test_data('gifti', 'ascii.gii'))
-    func_gii_img = load(test_data('gifti', 'task.func.gii'))
-    shape_gii_img = load(test_data('gifti', 'rh.shape.curv.gii'))
+    surf_gii_img = load(get_test_data('gifti', 'ascii.gii'))
+    func_gii_img = load(get_test_data('gifti', 'task.func.gii'))
+    shape_gii_img = load(get_test_data('gifti', 'rh.shape.curv.gii'))
     # add timeseries data with intent code ``none``
 
     point_data = surf_gii_img.get_arrays_from_intent('pointset')[0].data
@@ -478,7 +478,7 @@ def test_darray_dtype_coercion_failures():
 
 
 def test_gifti_file_close(recwarn):
-    gii = load(test_data('gifti', 'ascii.gii'))
+    gii = load(get_test_data('gifti', 'ascii.gii'))
     with InTemporaryDirectory():
         gii.to_filename('test.gii')
     assert not any(isinstance(r.message, ResourceWarning) for r in recwarn)

--- a/nibabel/pkg_info.py
+++ b/nibabel/pkg_info.py
@@ -101,7 +101,7 @@ def pkg_commit_hash(pkg_path: str | None = None) -> tuple[str, str]:
         return 'archive substitution', COMMIT_HASH
     ver = Version(__version__)
     if ver.local is not None and ver.local.startswith('g'):
-        return ver.local[1:8], 'installation'
+        return 'installation', ver.local[1:8]
     # maybe we are in a repository
     proc = run(
         ('git', 'rev-parse', '--short', 'HEAD'),

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -33,7 +33,7 @@ except ImportError:  # PY38
     from importlib_resources.abc import Traversable
 
 
-def test_data(
+def get_test_data(
     subdir: ty.Literal['gifti', 'nicom', 'externals'] | None = None,
     fname: str | None = None,
 ) -> Traversable:
@@ -52,7 +52,7 @@ def test_data(
 
 
 # set path to example data
-data_path = test_data()
+data_path = get_test_data()
 
 
 def assert_dt_equal(a, b):

--- a/nibabel/testing/__init__.py
+++ b/nibabel/testing/__init__.py
@@ -7,10 +7,12 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Utilities for testing"""
+from __future__ import annotations
 
 import os
 import re
 import sys
+import typing as ty
 import unittest
 import warnings
 from contextlib import nullcontext
@@ -19,24 +21,34 @@ from itertools import zip_longest
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from pkg_resources import resource_filename
 
 from .helpers import assert_data_similar, bytesio_filemap, bytesio_round_trip
 from .np_features import memmap_after_ufunc
 
+try:
+    from importlib.abc import Traversable
+    from importlib.resources import as_file, files
+except ImportError:  # PY38
+    from importlib_resources import as_file, files
+    from importlib_resources.abc import Traversable
 
-def test_data(subdir=None, fname=None):
+
+def test_data(
+    subdir: ty.Literal['gifti', 'nicom', 'externals'] | None = None,
+    fname: str | None = None,
+) -> Traversable:
+    parts: tuple[str, ...]
     if subdir is None:
-        resource = os.path.join('tests', 'data')
+        parts = ('tests', 'data')
     elif subdir in ('gifti', 'nicom', 'externals'):
-        resource = os.path.join(subdir, 'tests', 'data')
+        parts = (subdir, 'tests', 'data')
     else:
         raise ValueError(f'Unknown test data directory: {subdir}')
 
     if fname is not None:
-        resource = os.path.join(resource, fname)
+        parts += (fname,)
 
-    return resource_filename('nibabel', resource)
+    return files('nibabel').joinpath(*parts)
 
 
 # set path to example data

--- a/nibabel/tests/test_casting.py
+++ b/nibabel/tests/test_casting.py
@@ -233,10 +233,15 @@ def test_best_float():
 
 
 def test_longdouble_precision_improved():
-    # Just check that this can only be True on windows, msvc
-    from numpy.distutils.ccompiler import get_default_compiler
+    # Just check that this can only be True on Windows
 
-    if not (os.name == 'nt' and get_default_compiler() == 'msvc'):
+    # This previously used distutils.ccompiler.get_default_compiler to check for msvc
+    # In https://github.com/python/cpython/blob/3467991/Lib/distutils/ccompiler.py#L919-L956
+    # we see that this was implied by os.name == 'nt', so we can remove this deprecated
+    # call.
+    # However, there may be detectable conditions in Windows where we would expect this
+    # to be False as well.
+    if os.name != 'nt':
         assert not longdouble_precision_improved()
 
 

--- a/nibabel/tests/test_init.py
+++ b/nibabel/tests/test_init.py
@@ -1,7 +1,12 @@
+import pathlib
 from unittest import mock
 
 import pytest
-from pkg_resources import resource_filename
+
+try:
+    from importlib.resources import as_file, files
+except ImportError:
+    from importlib_resources import as_file, files
 
 import nibabel as nib
 
@@ -38,12 +43,11 @@ def test_nibabel_test_errors():
 
 
 def test_nibabel_bench():
-    expected_args = ['-c', '--pyargs', 'nibabel']
+    config_path = files('nibabel') / 'benchmarks/pytest.benchmark.ini'
+    if not isinstance(config_path, pathlib.Path):
+        raise unittest.SkipTest('Package is not unpacked; could get temp path')
 
-    try:
-        expected_args.insert(1, resource_filename('nibabel', 'benchmarks/pytest.benchmark.ini'))
-    except:
-        raise unittest.SkipTest('Not installed')
+    expected_args = ['-c', str(config_path), '--pyargs', 'nibabel']
 
     with mock.patch('pytest.main') as pytest_main:
         nib.bench(verbose=0)

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -15,8 +15,8 @@ from ..testing import (
     data_path,
     error_warnings,
     get_fresh_mod,
+    get_test_data,
     suppress_warnings,
-    test_data,
 )
 
 
@@ -171,22 +171,22 @@ def test_assert_re_in(regex, entries):
 
 
 def test_test_data():
-    assert str(test_data()) == str(data_path)  # Always get the same result
+    assert str(get_test_data()) == str(data_path)  # Always get the same result
     # Works the same as using __file__ and os.path utilities
-    assert str(test_data()) == os.path.abspath(
+    assert str(get_test_data()) == os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..', 'tests', 'data')
     )
     # Check action of subdir and that existence checks work
     for subdir in ('nicom', 'gifti', 'externals'):
-        assert test_data(subdir) == data_path.parent.parent / subdir / 'tests' / 'data'
-        assert os.path.exists(test_data(subdir))
-        assert not os.path.exists(test_data(subdir, 'doesnotexist'))
+        assert get_test_data(subdir) == data_path.parent.parent / subdir / 'tests' / 'data'
+        assert os.path.exists(get_test_data(subdir))
+        assert not os.path.exists(get_test_data(subdir, 'doesnotexist'))
 
     for subdir in ('freesurfer', 'doesnotexist'):
         with pytest.raises(ValueError):
-            test_data(subdir)
+            get_test_data(subdir)
 
-    assert not os.path.exists(test_data(None, 'doesnotexist'))
+    assert not os.path.exists(get_test_data(None, 'doesnotexist'))
 
     for subdir, fname in [
         ('gifti', 'ascii.gii'),
@@ -194,4 +194,4 @@ def test_test_data():
         ('externals', 'example_1.nc'),
         (None, 'empty.tck'),
     ]:
-        assert os.path.exists(test_data(subdir, fname))
+        assert os.path.exists(get_test_data(subdir, fname))

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -171,14 +171,14 @@ def test_assert_re_in(regex, entries):
 
 
 def test_test_data():
-    assert str(test_data()) == str(data_path)
+    assert str(test_data()) == str(data_path)  # Always get the same result
+    # Works the same as using __file__ and os.path utilities
     assert str(test_data()) == os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..', 'tests', 'data')
     )
+    # Check action of subdir and that existence checks work
     for subdir in ('nicom', 'gifti', 'externals'):
-        assert str(test_data(subdir)) == os.path.join(
-            data_path.parent.parent, subdir, 'tests', 'data'
-        )
+        assert test_data(subdir) == data_path.parent.parent / subdir / 'tests' / 'data'
         assert os.path.exists(test_data(subdir))
         assert not os.path.exists(test_data(subdir, 'doesnotexist'))
 

--- a/nibabel/tests/test_testing.py
+++ b/nibabel/tests/test_testing.py
@@ -171,12 +171,14 @@ def test_assert_re_in(regex, entries):
 
 
 def test_test_data():
-    assert test_data() == data_path
-    assert test_data() == os.path.abspath(
+    assert str(test_data()) == str(data_path)
+    assert str(test_data()) == os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..', 'tests', 'data')
     )
     for subdir in ('nicom', 'gifti', 'externals'):
-        assert test_data(subdir) == os.path.join(data_path[:-10], subdir, 'tests', 'data')
+        assert str(test_data(subdir)) == os.path.join(
+            data_path.parent.parent, subdir, 'tests', 'data'
+        )
         assert os.path.exists(test_data(subdir))
         assert not os.path.exists(test_data(subdir, 'doesnotexist'))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ maintainers = [{ name = "Christopher Markiewicz" }]
 readme = "README.rst"
 license = { text = "MIT License" }
 requires-python = ">=3.8"
-dependencies = ["numpy >=1.19", "packaging >=17", "setuptools"]
+dependencies = [
+  "numpy >=1.19",
+  "packaging >=17",
+  "importlib_resources; python_version < '3.9'",
+]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,14 @@ test = [
   "pytest-httpserver",
   "pytest-xdist",
 ]
-typing = ["mypy", "pytest", "types-setuptools", "types-Pillow", "pydicom"]
+typing = [
+  "mypy",
+  "pytest",
+  "types-setuptools",
+  "types-Pillow",
+  "pydicom",
+  "importlib_resources",
+]
 zstd = ["pyzstd >= 0.14.3"]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
`distutils` is removed in Python 3.12. Looking at https://github.com/python/cpython/blob/3467991/Lib/distutils/ccompiler.py#L919-L956, it turns out the single place we were still importing it was redundant with checking `os.name`.

Setuptools has recommended against using `pkg_resources` for some time, and it seems that `importlib.resources` has settled on an API that has been stable since Python 3.9. We can use the `importlib_resources` backport for Python 3.8.