### PR TITLE
BF: Support ragged voxel arrays in ParcelsAxis

### DIFF
--- a/nibabel/cifti2/cifti2_axes.py
+++ b/nibabel/cifti2/cifti2_axes.py
@@ -776,8 +776,8 @@ class ParcelsAxis(Axis):
         """
         self.name = np.asanyarray(name, dtype='U')
         self.voxels = np.empty(len(voxels), dtype='object')
-        for idx in range(len(voxels)):
-            self.voxels[idx] = voxels[idx]
+        for idx, vox in enumerate(voxels):
+            self.voxels[idx] = vox
         self.vertices = np.asanyarray(vertices, dtype='object')
         self.affine = np.asanyarray(affine) if affine is not None else None
         self.volume_shape = volume_shape

--- a/nibabel/cifti2/cifti2_axes.py
+++ b/nibabel/cifti2/cifti2_axes.py
@@ -775,14 +775,9 @@ class ParcelsAxis(Axis):
             maps names of surface elements to integers (not needed for volumetric CIFTI-2 files)
         """
         self.name = np.asanyarray(name, dtype='U')
-        as_array = np.asanyarray(voxels)
-        if as_array.ndim == 1:
-            voxels = as_array.astype('object')
-        else:
-            voxels = np.empty(len(voxels), dtype='object')
-            for idx in range(len(voxels)):
-                voxels[idx] = as_array[idx]
-        self.voxels = np.asanyarray(voxels, dtype='object')
+        self.voxels = np.empty(len(voxels), dtype='object')
+        for idx in range(len(voxels)):
+            self.voxels[idx] = voxels[idx]
         self.vertices = np.asanyarray(vertices, dtype='object')
         self.affine = np.asanyarray(affine) if affine is not None else None
         self.volume_shape = volume_shape

--- a/nibabel/cifti2/tests/test_axes.py
+++ b/nibabel/cifti2/tests/test_axes.py
@@ -494,13 +494,34 @@ def test_parcels():
     assert prc != prc_other
 
     # test direct initialisation
-    axes.ParcelsAxis(
+    test_parcel = axes.ParcelsAxis(
         voxels=[np.ones((3, 2), dtype=int)],
         vertices=[{}],
         name=['single_voxel'],
         affine=np.eye(4),
         volume_shape=(2, 3, 4),
     )
+    assert len(test_parcel) == 1
+
+    # test direct initialisation with multiple parcels
+    test_parcel = axes.ParcelsAxis(
+        voxels=[np.ones((3, 2), dtype=int), np.zeros((3, 2), dtype=int)],
+        vertices=[{}, {}],
+        name=['first_parcel', 'second_parcel'],
+        affine=np.eye(4),
+        volume_shape=(2, 3, 4),
+    )
+    assert len(test_parcel) == 2
+
+    # test direct initialisation with ragged voxel/vertices array
+    test_parcel = axes.ParcelsAxis(
+        voxels=[np.ones((3, 2), dtype=int), np.zeros((5, 2), dtype=int)],
+        vertices=[{}, {}],
+        name=['first_parcel', 'second_parcel'],
+        affine=np.eye(4),
+        volume_shape=(2, 3, 4),
+    )
+    assert len(test_parcel) == 2
 
     with pytest.raises(ValueError):
         axes.ParcelsAxis(


### PR DESCRIPTION
In the past we used `np.asanyarray(voxels)`, which would produce an array with dtype="object" if provided with a ragged array. 
This no longer works in numpy 1.24, where the following error is raised:
```
>       as_array = np.asanyarray(voxels)
E       ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (4,) + inhomogeneous part.

../nibabel/nibabel/cifti2/cifti2_axes.py:778: ValueError
```

I was notified of this bug by @pauldmccarthy .

I've adjusted the logic a bit to ensure that `self.voxels` is a 1D array. Dach element is supposed to be the set of voxels in that parcel (i.e., a (N, 3) array for N voxels in that parcel). This avoids calling `np.asanyarray` directly on the supplied voxels, which might produce a multi-dimensional rather than a 1D array if all parcels contain the same number of voxels.