### PR TITLE
MNT: Add py.typed to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,11 @@ typing = [
 zstd = ["pyzstd >= 0.14.3"]
 
 [tool.hatch.build.targets.sdist]
-exclude = [".git_archival.txt"]
+exclude = [
+  ".git_archival.txt",
+  # Submodules with large files; if we don't want them in the repo...
+  "nibabel-data/",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["nibabel", "nisext"]


### PR DESCRIPTION
This should allow downstream tools to use our annotations.

Note that not all public interfaces are annotated, so there is the possibility that future annotations will break currently-passing type checks.

With thanks for the nudge from @fepegar.