### PR TITLE
TYPE: Annotate file-handling modules

### DIFF
--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -15,10 +15,13 @@ import numpy as np
 
 from .arrayproxy import ArrayLike
 from .deprecated import deprecate_with_version
-from .filebasedimages import FileBasedHeader, FileBasedImage, FileMap, FileSpec
+from .filebasedimages import FileBasedHeader, FileBasedImage
+from .fileholders import FileMap
 
 if ty.TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
+
+    from .filename_parser import FileSpec
 
 ArrayImgT = ty.TypeVar('ArrayImgT', bound='DataobjImage')
 

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -10,17 +10,18 @@
 from __future__ import annotations
 
 import io
-import os
 import typing as ty
 from copy import deepcopy
 from typing import Type
 from urllib import request
 
 from .fileholders import FileHolder, FileMap
-from .filename_parser import TypesFilenamesError, splitext_addext, types_filenames
+from .filename_parser import TypesFilenamesError, _stringify_path, splitext_addext, types_filenames
 from .openers import ImageOpener
 
-FileSpec = ty.Union[str, os.PathLike]
+if ty.TYPE_CHECKING:  # pragma: no cover
+    from .filename_parser import ExtensionSpec, FileSpec
+
 FileSniff = ty.Tuple[bytes, str]
 
 ImgT = ty.TypeVar('ImgT', bound='FileBasedImage')
@@ -159,7 +160,7 @@ class FileBasedImage:
     header_class: Type[FileBasedHeader] = FileBasedHeader
     _header: FileBasedHeader
     _meta_sniff_len: int = 0
-    files_types: tuple[tuple[str, str | None], ...] = (('image', None),)
+    files_types: tuple[ExtensionSpec, ...] = (('image', None),)
     valid_exts: tuple[str, ...] = ()
     _compressed_suffixes: tuple[str, ...] = ()
 
@@ -410,7 +411,7 @@ class FileBasedImage:
         t_fnames = types_filenames(
             filename, klass.files_types, trailing_suffixes=klass._compressed_suffixes
         )
-        meta_fname = t_fnames.get('header', filename)
+        meta_fname = t_fnames.get('header', _stringify_path(filename))
 
         # Do not re-sniff if it would be from the same file
         if sniff is not None and sniff[1] == meta_fname:

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -16,12 +16,11 @@ from copy import deepcopy
 from typing import Type
 from urllib import request
 
-from .fileholders import FileHolder
+from .fileholders import FileHolder, FileMap
 from .filename_parser import TypesFilenamesError, splitext_addext, types_filenames
 from .openers import ImageOpener
 
 FileSpec = ty.Union[str, os.PathLike]
-FileMap = ty.Mapping[str, FileHolder]
 FileSniff = ty.Tuple[bytes, str]
 
 ImgT = ty.TypeVar('ImgT', bound='FileBasedImage')

--- a/nibabel/fileholders.py
+++ b/nibabel/fileholders.py
@@ -7,6 +7,10 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Fileholder class"""
+from __future__ import annotations
+
+import io
+import typing as ty
 from copy import copy
 
 from .openers import ImageOpener
@@ -19,7 +23,12 @@ class FileHolderError(Exception):
 class FileHolder:
     """class to contain filename, fileobj and file position"""
 
-    def __init__(self, filename=None, fileobj=None, pos=0):
+    def __init__(
+        self,
+        filename: str | None = None,
+        fileobj: io.IOBase | None = None,
+        pos: int = 0,
+    ):
         """Initialize FileHolder instance
 
         Parameters
@@ -37,7 +46,7 @@ class FileHolder:
         self.fileobj = fileobj
         self.pos = pos
 
-    def get_prepare_fileobj(self, *args, **kwargs):
+    def get_prepare_fileobj(self, *args, **kwargs) -> ImageOpener:
         """Return fileobj if present, or return fileobj from filename
 
         Set position to that given in self.pos
@@ -69,7 +78,7 @@ class FileHolder:
             raise FileHolderError('No filename or fileobj present')
         return obj
 
-    def same_file_as(self, other):
+    def same_file_as(self, other: FileHolder) -> bool:
         """Test if `self` refers to same files / fileobj as `other`
 
         Parameters
@@ -86,12 +95,15 @@ class FileHolder:
         return (self.filename == other.filename) and (self.fileobj == other.fileobj)
 
     @property
-    def file_like(self):
+    def file_like(self) -> str | io.IOBase | None:
         """Return ``self.fileobj`` if not None, otherwise ``self.filename``"""
         return self.fileobj if self.fileobj is not None else self.filename
 
 
-def copy_file_map(file_map):
+FileMap = ty.Mapping[str, FileHolder]
+
+
+def copy_file_map(file_map: FileMap) -> FileMap:
     r"""Copy mapping of fileholders given by `file_map`
 
     Parameters
@@ -105,7 +117,4 @@ def copy_file_map(file_map):
        Copy of `file_map`, using shallow copy of ``FileHolder``\s
 
     """
-    fm_copy = {}
-    for key, fh in file_map.items():
-        fm_copy[key] = copy(fh)
-    return fm_copy
+    return {key: copy(fh) for key, fh in file_map.items()}

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -7,34 +7,48 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Context manager openers for various fileobject types"""
+from __future__ import annotations
+
 import gzip
-import warnings
+import io
+import typing as ty
 from bz2 import BZ2File
 from os.path import splitext
 
-from packaging.version import Version
-
 from nibabel.optpkg import optional_package
 
-# is indexed_gzip present and modern?
-try:
-    import indexed_gzip as igzip  # type: ignore
+if ty.TYPE_CHECKING:  # pragma: no cover
+    from types import TracebackType
 
-    version = igzip.__version__
+    import pyzstd
+    from _typeshed import WriteableBuffer
+
+    ModeRT = ty.Literal['r', 'rt']
+    ModeRB = ty.Literal['rb']
+    ModeWT = ty.Literal['w', 'wt']
+    ModeWB = ty.Literal['wb']
+    ModeR = ty.Union[ModeRT, ModeRB]
+    ModeW = ty.Union[ModeWT, ModeWB]
+    Mode = ty.Union[ModeR, ModeW]
+
+    OpenerDef = tuple[ty.Callable[..., io.IOBase], tuple[str, ...]]
+else:
+    pyzstd = optional_package('pyzstd')[0]
+
+
+@ty.runtime_checkable
+class Fileish(ty.Protocol):
+    def read(self, size: int = -1, /) -> bytes:
+        ...  # pragma: no cover
+
+    def write(self, b: bytes, /) -> int | None:
+        ...  # pragma: no cover
+
+
+try:
+    from indexed_gzip import IndexedGzipFile  # type: ignore
 
     HAVE_INDEXED_GZIP = True
-
-    # < 0.7 - no good
-    if Version(version) < Version('0.7.0'):
-        warnings.warn(f'indexed_gzip is present, but too old (>= 0.7.0 required): {version})')
-        HAVE_INDEXED_GZIP = False
-    # >= 0.8 SafeIndexedGzipFile renamed to IndexedGzipFile
-    elif Version(version) < Version('0.8.0'):
-        IndexedGzipFile = igzip.SafeIndexedGzipFile
-    else:
-        IndexedGzipFile = igzip.IndexedGzipFile
-    del igzip, version
-
 except ImportError:
     # nibabel.openers.IndexedGzipFile is imported by nibabel.volumeutils
     # to detect compressed file types, so we give a fallback value here.
@@ -49,35 +63,63 @@ class DeterministicGzipFile(gzip.GzipFile):
     to a modification time (``mtime``) of 0 seconds.
     """
 
-    def __init__(self, filename=None, mode=None, compresslevel=9, fileobj=None, mtime=0):
-        # These two guards are copied from
+    def __init__(
+        self,
+        filename: str | None = None,
+        mode: Mode | None = None,
+        compresslevel: int = 9,
+        fileobj: io.FileIO | None = None,
+        mtime: int = 0,
+    ):
+        if mode is None:
+            mode = 'rb'
+        modestr: str = mode
+
+        # These two guards are adapted from
         # https://github.com/python/cpython/blob/6ab65c6/Lib/gzip.py#L171-L174
-        if mode and 'b' not in mode:
-            mode += 'b'
+        if 'b' not in modestr:
+            modestr = f'{mode}b'
         if fileobj is None:
-            fileobj = self.myfileobj = open(filename, mode or 'rb')
+            if filename is None:
+                raise TypeError('Must define either fileobj or filename')
+            # Cast because GzipFile.myfileobj has type io.FileIO while open returns ty.IO
+            fileobj = self.myfileobj = ty.cast(io.FileIO, open(filename, modestr))
         return super().__init__(
-            filename='', mode=mode, compresslevel=compresslevel, fileobj=fileobj, mtime=mtime
+            filename='',
+            mode=modestr,
+            compresslevel=compresslevel,
+            fileobj=fileobj,
+            mtime=mtime,
         )
 
 
-def _gzip_open(filename, mode='rb', compresslevel=9, mtime=0, keep_open=False):
+def _gzip_open(
+    filename: str,
+    mode: Mode = 'rb',
+    compresslevel: int = 9,
+    mtime: int = 0,
+    keep_open: bool = False,
+) -> gzip.GzipFile:
+
+    if not HAVE_INDEXED_GZIP or mode != 'rb':
+        gzip_file = DeterministicGzipFile(filename, mode, compresslevel, mtime=mtime)
 
     # use indexed_gzip if possible for faster read access.  If keep_open ==
     # True, we tell IndexedGzipFile to keep the file handle open. Otherwise
     # the IndexedGzipFile will close/open the file on each read.
-    if HAVE_INDEXED_GZIP and mode == 'rb':
-        gzip_file = IndexedGzipFile(filename, drop_handles=not keep_open)
-
-    # Fall-back to built-in GzipFile
     else:
-        gzip_file = DeterministicGzipFile(filename, mode, compresslevel, mtime=mtime)
+        gzip_file = IndexedGzipFile(filename, drop_handles=not keep_open)
 
     return gzip_file
 
 
-def _zstd_open(filename, mode='r', *, level_or_option=None, zstd_dict=None):
-    pyzstd = optional_package('pyzstd')[0]
+def _zstd_open(
+    filename: str,
+    mode: Mode = 'r',
+    *,
+    level_or_option: int | dict | None = None,
+    zstd_dict: pyzstd.ZstdDict | None = None,
+) -> pyzstd.ZstdFile:
     return pyzstd.ZstdFile(filename, mode, level_or_option=level_or_option, zstd_dict=zstd_dict)
 
 
@@ -104,7 +146,7 @@ class Opener:
     gz_def = (_gzip_open, ('mode', 'compresslevel', 'mtime', 'keep_open'))
     bz2_def = (BZ2File, ('mode', 'buffering', 'compresslevel'))
     zstd_def = (_zstd_open, ('mode', 'level_or_option', 'zstd_dict'))
-    compress_ext_map = {
+    compress_ext_map: dict[str | None, OpenerDef] = {
         '.gz': gz_def,
         '.bz2': bz2_def,
         '.zst': zstd_def,
@@ -121,19 +163,19 @@ class Opener:
         'w': default_zst_compresslevel,
     }
     #: whether to ignore case looking for compression extensions
-    compress_ext_icase = True
+    compress_ext_icase: bool = True
 
-    def __init__(self, fileish, *args, **kwargs):
-        if self._is_fileobj(fileish):
+    fobj: io.IOBase
+
+    def __init__(self, fileish: str | io.IOBase, *args, **kwargs):
+        if isinstance(fileish, (io.IOBase, Fileish)):
             self.fobj = fileish
             self.me_opened = False
-            self._name = None
+            self._name = getattr(fileish, 'name', None)
             return
         opener, arg_names = self._get_opener_argnames(fileish)
         # Get full arguments to check for mode and compresslevel
-        full_kwargs = kwargs.copy()
-        n_args = len(args)
-        full_kwargs.update(dict(zip(arg_names[:n_args], args)))
+        full_kwargs = {**kwargs, **dict(zip(arg_names, args))}
         # Set default mode
         if 'mode' not in full_kwargs:
             mode = 'rb'
@@ -155,7 +197,7 @@ class Opener:
         self._name = fileish
         self.me_opened = True
 
-    def _get_opener_argnames(self, fileish):
+    def _get_opener_argnames(self, fileish: str) -> OpenerDef:
         _, ext = splitext(fileish)
         if self.compress_ext_icase:
             ext = ext.lower()
@@ -168,16 +210,12 @@ class Opener:
             return self.compress_ext_map[ext]
         return self.compress_ext_map[None]
 
-    def _is_fileobj(self, obj):
-        """Is `obj` a file-like object?"""
-        return hasattr(obj, 'read') and hasattr(obj, 'write')
-
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self.fobj.closed
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         """Return ``self.fobj.name`` or self._name if not present
 
         self._name will be None if object was created with a fileobj, otherwise
@@ -186,42 +224,53 @@ class Opener:
         return self._name
 
     @property
-    def mode(self):
-        return self.fobj.mode
+    def mode(self) -> str:
+        # Check and raise our own error for type narrowing purposes
+        if hasattr(self.fobj, 'mode'):
+            return self.fobj.mode
+        raise AttributeError(f'{self.fobj.__class__.__name__} has no attribute "mode"')
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self.fobj.fileno()
 
-    def read(self, *args, **kwargs):
-        return self.fobj.read(*args, **kwargs)
+    def read(self, size: int = -1, /) -> bytes:
+        return self.fobj.read(size)
 
-    def readinto(self, *args, **kwargs):
-        return self.fobj.readinto(*args, **kwargs)
+    def readinto(self, buffer: WriteableBuffer, /) -> int | None:
+        # Check and raise our own error for type narrowing purposes
+        if hasattr(self.fobj, 'readinto'):
+            return self.fobj.readinto(buffer)
+        raise AttributeError(f'{self.fobj.__class__.__name__} has no attribute "readinto"')
 
-    def write(self, *args, **kwargs):
-        return self.fobj.write(*args, **kwargs)
+    def write(self, b: bytes, /) -> int | None:
+        return self.fobj.write(b)
 
-    def seek(self, *args, **kwargs):
-        return self.fobj.seek(*args, **kwargs)
+    def seek(self, pos: int, whence: int = 0, /) -> int:
+        return self.fobj.seek(pos, whence)
 
-    def tell(self, *args, **kwargs):
-        return self.fobj.tell(*args, **kwargs)
+    def tell(self, /) -> int:
+        return self.fobj.tell()
 
-    def close(self, *args, **kwargs):
-        return self.fobj.close(*args, **kwargs)
+    def close(self, /) -> None:
+        return self.fobj.close()
 
-    def __iter__(self):
+    def __iter__(self) -> ty.Iterator[bytes]:
         return iter(self.fobj)
 
-    def close_if_mine(self):
+    def close_if_mine(self) -> None:
         """Close ``self.fobj`` iff we opened it in the constructor"""
         if self.me_opened:
             self.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Opener:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.close_if_mine()
 
 

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -140,7 +140,8 @@ import numpy as np
 
 from .arrayproxy import ArrayLike
 from .dataobj_images import DataobjImage
-from .filebasedimages import FileBasedHeader, FileBasedImage, FileMap
+from .filebasedimages import FileBasedHeader, FileBasedImage
+from .fileholders import FileMap
 from .fileslice import canonical_slicers
 from .orientations import apply_orientation, inv_ornt_aff
 from .viewers import OrthoSlicer3D

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -38,7 +38,7 @@ class Lunk:
     def write(self):
         pass
 
-    def read(self):
+    def read(self, size=-1, /):
         return self.message
 
 


### PR DESCRIPTION
This PR annotates the following modules:

* `filename_parser`, which covers coercion of `os.PathLike`s to `str`, and detecting related files based on extensions
* `fileholders`, which allows us to carry around filenames or open streams somewhat agnostically
* `openers`, which allows us to read/write from filenames or open streams, and transparently enables compression