### PR TITLE
ENH: Make imagestats module available on ``import nibabel``

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -44,6 +44,7 @@ from . import nifti1 as ni1
 from . import spm2analyze as spm2
 from . import spm99analyze as spm99
 from . import streamlines, viewers
+from . import imagestats
 
 # isort: split
 

--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -39,12 +39,11 @@ For more detailed information see the :ref:`manual`.
 
 # module imports
 from . import analyze as ana
-from . import ecat, mriutils
+from . import ecat, imagestats, mriutils
 from . import nifti1 as ni1
 from . import spm2analyze as spm2
 from . import spm99analyze as spm99
 from . import streamlines, viewers
-from . import imagestats
 
 # isort: split
 


### PR DESCRIPTION
this add the import of imagestats to __init__.py

context of imagestats: #952 

Solve #1207 
