### PR TITLE
TYP: Add a version stub to allow mypy to run without building

### DIFF
--- a/nibabel/_version.pyi
+++ b/nibabel/_version.pyi
@@ -1,0 +1,4 @@
+__version__: str
+__version_tuple__: tuple[str, ...]
+version: str
+version_tuple: tuple[str, ...]


### PR DESCRIPTION
Thanks to @Factral in https://github.com/nipy/nibabel/pull/1208#issuecomment-1447182785 I realized that we could probably make the contribution process a little nicer to people not wanting to `pip install -e` or `hatch build --hooks-only` just to make the pre-commit hooks run cleanly.

This adds a `_version.pyi` that `mypy` will respect without even checking whether `_version.py` is present.

The biggest potential risk is `setuptools-scm` changing the contents of `_version.py` in the future, but that seems low and a thing we can deal with if it comes up.

No need to backport unless we get contributors to a maintenance branch.

<details><summary>Verifying:</summary>

```console
~/Projects/nipy 
❯ git clone nibabel/.git nibabel-mypy-test
Cloning into 'nibabel-mypy-test'...
done.
~/Projects/nipy 
❯ cd nibabel-mypy-test 
nibabel-mypy-test on typ/version_stub 
❯ pre-commit install
pre-commit installed at .git/hooks/pre-commit
nibabel-mypy-test on typ/version_stub 
❯ pre-commit run --all
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check toml...............................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check vcs permalinks.....................................................Passed
blue.....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
```

Reverting to `master`:

```console
❯ git checkout master
Branch 'master' set up to track remote branch 'master' from 'origin'.
Switched to a new branch 'master'
nibabel-mypy-test on master 
❯ pre-commit run --all               
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check toml...............................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check vcs permalinks.....................................................Passed
blue.....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

nibabel/pkg_info.py:9: error: Cannot find implementation or library stub for module named "nibabel._version"  [import]
nibabel/pkg_info.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 107 source files)
```

</details>