### PR TITLE
TYP: Annotate loadsave and image header classes

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -896,6 +896,7 @@ class AnalyzeImage(SpatialImage):
     """Class for basic Analyze format image"""
 
     header_class: Type[AnalyzeHeader] = AnalyzeHeader
+    header: AnalyzeHeader
     _meta_sniff_len = header_class.sizeof_hdr
     files_types: tuple[tuple[str, str], ...] = (('image', '.img'), ('header', '.hdr'))
     valid_exts: tuple[str, ...] = ('.img', '.hdr')

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -83,8 +83,6 @@ constrain the affine.
 """
 from __future__ import annotations
 
-from typing import Type
-
 import numpy as np
 
 from .arrayproxy import ArrayProxy
@@ -895,7 +893,7 @@ class AnalyzeHeader(LabeledWrapStruct, SpatialHeader):
 class AnalyzeImage(SpatialImage):
     """Class for basic Analyze format image"""
 
-    header_class: Type[AnalyzeHeader] = AnalyzeHeader
+    header_class: type[AnalyzeHeader] = AnalyzeHeader
     header: AnalyzeHeader
     _meta_sniff_len = header_class.sizeof_hdr
     files_types: tuple[tuple[str, str], ...] = (('image', '.img'), ('header', '.hdr'))

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -475,6 +475,7 @@ class AFNIImage(SpatialImage):
     """
 
     header_class = AFNIHeader
+    header: AFNIHeader
     valid_exts = ('.brik', '.head')
     files_types = (('image', '.brik'), ('header', '.head'))
     _compressed_suffixes = ('.gz', '.bz2', '.Z', '.zst')

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -1411,6 +1411,7 @@ class Cifti2Image(DataobjImage, SerializableImage):
     """Class for single file CIFTI-2 format image"""
 
     header_class = Cifti2Header
+    header: Cifti2Header
     valid_exts = Nifti2Image.valid_exts
     files_types = Nifti2Image.files_types
     makeable = False

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -751,7 +751,7 @@ class EcatImage(SpatialImage):
     valid_exts = ('.v',)
     files_types = (('image', '.v'), ('header', '.v'))
 
-    _header: EcatHeader
+    header: EcatHeader
     _subheader: EcatSubHeader
 
     ImageArrayProxy = EcatImageArrayProxy

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import io
 import typing as ty
 from copy import deepcopy
-from typing import Type
 from urllib import request
 
 from ._compression import COMPRESSION_ERRORS
@@ -158,7 +157,7 @@ class FileBasedImage:
     work.
     """
 
-    header_class: Type[FileBasedHeader] = FileBasedHeader
+    header_class: type[FileBasedHeader] = FileBasedHeader
     _meta_sniff_len: int = 0
     files_types: tuple[ExtensionSpec, ...] = (('image', None),)
     valid_exts: tuple[str, ...] = ()

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -159,7 +159,6 @@ class FileBasedImage:
     """
 
     header_class: Type[FileBasedHeader] = FileBasedHeader
-    _header: FileBasedHeader
     _meta_sniff_len: int = 0
     files_types: tuple[ExtensionSpec, ...] = (('image', None),)
     valid_exts: tuple[str, ...] = ()

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -462,6 +462,7 @@ class MGHImage(SpatialImage, SerializableImage):
     """Class for MGH format image"""
 
     header_class = MGHHeader
+    header: MGHHeader
     valid_exts = ('.mgh', '.mgz')
     # Register that .mgz extension signals gzip compression
     ImageOpener.compress_ext_map['.mgz'] = ImageOpener.gz_def

--- a/nibabel/imageclasses.py
+++ b/nibabel/imageclasses.py
@@ -7,9 +7,13 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Define supported image classes and names"""
+from __future__ import annotations
+
 from .analyze import AnalyzeImage
 from .brikhead import AFNIImage
 from .cifti2 import Cifti2Image
+from .dataobj_images import DataobjImage
+from .filebasedimages import FileBasedImage
 from .freesurfer import MGHImage
 from .gifti import GiftiImage
 from .minc1 import Minc1Image
@@ -21,7 +25,7 @@ from .spm2analyze import Spm2AnalyzeImage
 from .spm99analyze import Spm99AnalyzeImage
 
 # Ordered by the load/save priority.
-all_image_classes = [
+all_image_classes: list[type[FileBasedImage]] = [
     Nifti1Pair,
     Nifti1Image,
     Nifti2Pair,
@@ -41,7 +45,7 @@ all_image_classes = [
 # Image classes known to require spatial axes to be first in index ordering.
 # When adding an image class, consider whether the new class should be listed
 # here.
-KNOWN_SPATIAL_FIRST = (
+KNOWN_SPATIAL_FIRST: tuple[type[FileBasedImage], ...] = (
     Nifti1Pair,
     Nifti1Image,
     Nifti2Pair,
@@ -55,7 +59,7 @@ KNOWN_SPATIAL_FIRST = (
 )
 
 
-def spatial_axes_first(img):
+def spatial_axes_first(img: DataobjImage) -> bool:
     """True if spatial image axes for `img` always precede other axes
 
     Parameters

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -308,6 +308,7 @@ class Minc1Image(SpatialImage):
     """
 
     header_class: Type[MincHeader] = Minc1Header
+    header: MincHeader
     _meta_sniff_len: int = 4
     valid_exts: tuple[str, ...] = ('.mnc',)
     files_types: tuple[tuple[str, str], ...] = (('image', '.mnc'),)

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 from numbers import Integral
-from typing import Type
 
 import numpy as np
 
@@ -307,7 +306,7 @@ class Minc1Image(SpatialImage):
     load.
     """
 
-    header_class: Type[MincHeader] = Minc1Header
+    header_class: type[MincHeader] = Minc1Header
     header: MincHeader
     _meta_sniff_len: int = 4
     valid_exts: tuple[str, ...] = ('.mnc',)

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -150,6 +150,7 @@ class Minc2Image(Minc1Image):
     # MINC2 does not do compressed whole files
     _compressed_suffixes = ()
     header_class = Minc2Header
+    header: Minc2Header
 
     @classmethod
     def from_file_map(klass, file_map, *, mmap=True, keep_file_open=None):

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import warnings
 from io import BytesIO
-from typing import Type
 
 import numpy as np
 import numpy.linalg as npl
@@ -90,8 +89,8 @@ header_dtype = np.dtype(header_dtd)
 # datatypes not in analyze format, with codes
 if have_binary128():
     # Only enable 128 bit floats if we really have IEEE binary 128 longdoubles
-    _float128t: Type[np.generic] = np.longdouble
-    _complex256t: Type[np.generic] = np.longcomplex
+    _float128t: type[np.generic] = np.longdouble
+    _complex256t: type[np.generic] = np.longcomplex
 else:
     _float128t = np.void
     _complex256t = np.void

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1817,7 +1817,8 @@ class Nifti1PairHeader(Nifti1Header):
 class Nifti1Pair(analyze.AnalyzeImage):
     """Class for NIfTI1 format image, header pair"""
 
-    header_class: Type[Nifti1Header] = Nifti1PairHeader
+    header_class: type[Nifti1Header] = Nifti1PairHeader
+    header: Nifti1Header
     _meta_sniff_len = header_class.sizeof_hdr
     rw = True
 

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1253,6 +1253,7 @@ class PARRECImage(SpatialImage):
     """PAR/REC image"""
 
     header_class = PARRECHeader
+    header: PARRECHeader
     valid_exts = ('.rec', '.par')
     files_types = (('image', '.rec'), ('header', '.par'))
 

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -476,6 +476,7 @@ class SpatialImage(DataobjImage):
     ImageSlicer: type[SpatialFirstSlicer] = SpatialFirstSlicer
 
     _header: SpatialHeader
+    header: SpatialHeader
 
     def __init__(
         self,

--- a/nibabel/spm2analyze.py
+++ b/nibabel/spm2analyze.py
@@ -128,6 +128,7 @@ class Spm2AnalyzeImage(spm99.Spm99AnalyzeImage):
     """Class for SPM2 variant of basic Analyze image"""
 
     header_class = Spm2AnalyzeHeader
+    header: Spm2AnalyzeHeader
 
 
 load = Spm2AnalyzeImage.from_filename

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -227,6 +227,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
     """Class for SPM99 variant of basic Analyze image"""
 
     header_class = Spm99AnalyzeHeader
+    header: Spm99AnalyzeHeader
     files_types = (('image', '.img'), ('header', '.hdr'), ('mat', '.mat'))
     has_affine = True
     makeable = True


### PR DESCRIPTION
`nb.load()` and (to some extent) `nb.save()` are probably the most used functions. They should have some signatures, though the usefulness is bounded as the type checker can't infer the resulting type from the filename.

While testing this on a code base I'm writing to be type-checked from the start, I found that everything declared itself as having a `FileBasedHeader`, which is not very useful. I can't come up with something type-variable-ish so that we can deduplicate these and rely on the `header_class`, but oh well.