### PR TITLE
DOC: Link to logo with full URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 .. -*- rest -*-
 .. vim:syntax=rst
 
-.. image:: doc/pics/logo.png
+.. Use raw location to ensure image shows up on PyPI
+.. image:: https://raw.githubusercontent.com/nipy/nibabel/master/doc/pics/logo.png
    :target: https://nipy.org/nibabel
    :alt: NiBabel logo
 


### PR DESCRIPTION
The [PyPI upload of 5.1.0](https://pypi.org/project/nibabel/5.1.0/) shows 

![image](https://user-images.githubusercontent.com/83442/229563419-d4b3a048-1c5c-42f1-bcba-713b2d4398e2.png)

This change makes the link renderable in an isolated view of the README like PyPI.