### PR TITLE
FIX: Catch random bad slice when testing image slicing

### DIFF
--- a/nibabel/tests/test_spatialimages.py
+++ b/nibabel/tests/test_spatialimages.py
@@ -540,15 +540,15 @@ class TestSpatialImage:
                     sliceobj = tuple(np.random.choice(slice_elems, n_elems))
                     try:
                         sliced_img = img.slicer[sliceobj]
-                    except (IndexError, ValueError):
-                        # Only checking valid slices
-                        pass
-                    else:
-                        sliced_data = in_data[sliceobj]
-                        assert (sliced_data == sliced_img.get_fdata()).all()
-                        assert (sliced_data == sliced_img.dataobj).all()
-                        assert (sliced_data == img.dataobj[sliceobj]).all()
-                        assert (sliced_data == img.get_fdata()[sliceobj]).all()
+                    except (IndexError, ValueError, HeaderDataError):
+                        # Skip invalid slices or images that can't be created
+                        continue
+
+                    sliced_data = in_data[sliceobj]
+                    assert np.array_equal(sliced_data, sliced_img.get_fdata())
+                    assert np.array_equal(sliced_data, sliced_img.dataobj)
+                    assert np.array_equal(sliced_data, img.dataobj[sliceobj])
+                    assert np.array_equal(sliced_data, img.get_fdata()[sliceobj])
 
 
 class MmapImageMixin:


### PR DESCRIPTION
We have an apparent Heisenbug that would occasionally cause Windows tests to fail on Python 3.10.

After booting up a Windows machine and running ~30k tests with different `PYTHONHASHSEED`s, it turns out it's a regular old bug based on a random selection that has nothing to do with Windows and Python 3.10. If the dimensionality of the sliced dataobj (can go up with `None`s) exceeds 7, Analyze-like images can't represent it.