### PR TITLE
ENH: Catch SVD failure and raise informative HeaderDataError

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1098,7 +1098,10 @@ class Nifti1Header(SpmAnalyzeHeader):
         # (a subtle requirement of the NIFTI format qform transform)
         # Transform below is polar decomposition, returning the closest
         # orthogonal matrix PR, to input R
-        P, S, Qs = npl.svd(R)
+        try:
+            P, S, Qs = npl.svd(R)
+        except np.linalg.LinAlgError as e:
+            raise HeaderDataError(f'Could not decompose affine:\n{affine}') from e
         PR = np.dot(P, Qs)
         if not strip_shears and not np.allclose(PR, R):
             raise HeaderDataError('Shears in affine and `strip_shears` is False')


### PR DESCRIPTION
This is mostly targeted at improving logging when an SVD failure arises. We may also want to consider using scipy's [SVD](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.svd.html) when scipy is available, as that allows the option for using the slower but less finicky gesvd algorithm.

No urgency on this, just want to make a patch available to inject into a container.