### PR TITLE
TEST: Only use stable argsorts in PARREC tests

### DIFF
--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -173,8 +173,6 @@ DTI_PAR_BVECS = np.array(
 
 # DTI.PAR values for bvecs
 DTI_PAR_BVALS = [1000] * 6 + [0, 1000]
-# Numpy's argsort can be unstable so write indices manually
-DTI_PAR_BVALS_SORT_IDCS = [6, 0, 1, 2, 3, 4, 5, 7]
 
 EXAMPLE_IMAGES = [
     # Parameters come from load of Philips' conversion to NIfTI
@@ -526,7 +524,10 @@ def test_diffusion_parameters_strict_sort():
     # DTI_PAR_BVECS gives bvecs copied from first slice each vol in DTI.PAR
     # Permute to match bvec directions to acquisition directions
     # note that bval sorting occurs prior to bvec sorting
-    assert_almost_equal(bvecs, DTI_PAR_BVECS[np.ix_(DTI_PAR_BVALS_SORT_IDCS, [2, 0, 1])])
+    assert_almost_equal(
+        bvecs,
+        DTI_PAR_BVECS[np.ix_(np.argsort(DTI_PAR_BVALS, kind='stable'), [2, 0, 1])],
+    )
     # Check q vectors
     assert_almost_equal(dti_hdr.get_q_vectors(), bvals[:, None] * bvecs)
 

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -27,7 +27,7 @@ from ..testing import assert_data_similar, assert_dt_equal, assert_re_in
 from ..tmpdirs import InTemporaryDirectory
 from .nibabel_data import needs_nibabel_data
 from .scriptrunner import ScriptRunner
-from .test_parrec import DTI_PAR_BVALS, DTI_PAR_BVECS
+from .test_parrec import DTI_PAR_BVALS, DTI_PAR_BVALS_SORT_IDCS, DTI_PAR_BVECS
 from .test_parrec import EXAMPLE_IMAGES as PARREC_EXAMPLES
 from .test_parrec_data import AFF_OFF, BALLS
 
@@ -418,7 +418,7 @@ def test_parrec2nii_with_data():
         assert_almost_equal(np.loadtxt('DTI.bvals'), np.sort(DTI_PAR_BVALS))
         img = load('DTI.nii')
         data_sorted = img.get_fdata()
-        assert_almost_equal(data[..., np.argsort(DTI_PAR_BVALS)], data_sorted)
+        assert_almost_equal(data[..., DTI_PAR_BVALS_SORT_IDCS], data_sorted)
         del img
 
         # Writes .ordering.csv if requested

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -27,7 +27,7 @@ from ..testing import assert_data_similar, assert_dt_equal, assert_re_in
 from ..tmpdirs import InTemporaryDirectory
 from .nibabel_data import needs_nibabel_data
 from .scriptrunner import ScriptRunner
-from .test_parrec import DTI_PAR_BVALS, DTI_PAR_BVALS_SORT_IDCS, DTI_PAR_BVECS
+from .test_parrec import DTI_PAR_BVALS, DTI_PAR_BVECS
 from .test_parrec import EXAMPLE_IMAGES as PARREC_EXAMPLES
 from .test_parrec_data import AFF_OFF, BALLS
 
@@ -418,7 +418,7 @@ def test_parrec2nii_with_data():
         assert_almost_equal(np.loadtxt('DTI.bvals'), np.sort(DTI_PAR_BVALS))
         img = load('DTI.nii')
         data_sorted = img.get_fdata()
-        assert_almost_equal(data[..., DTI_PAR_BVALS_SORT_IDCS], data_sorted)
+        assert_almost_equal(data[..., np.argsort(DTI_PAR_BVALS, kind='stable')], data_sorted)
         del img
 
         # Writes .ordering.csv if requested


### PR DESCRIPTION
numpy/numpy#23707 introduced an optimized argsort that will be used on some platforms, including GitHub actions' runners, making this a nasty issue to figure out. I'm very glad that it wasn't on some obscure architecture that one user hit, as I have no idea how I would have debugged that.

----

~~Between the last good and first bad runs, numpy released 1.25 and GitHub Actions released new Python images. First starting by verifying that the previous versions of both resolve the issue. Then will relax numpy.~~