### PR TITLE
ENH: only warn about invalid Minc2 spacing declaration

### DIFF
--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -25,6 +25,7 @@ and compare against command line output of::
 
     mincstats my_funny.mnc
 """
+import warnings
 import numpy as np
 
 from .minc1 import Minc1File, Minc1Image, MincError, MincHeader
@@ -58,8 +59,12 @@ class Minc2File(Minc1File):
         # We don't currently support irregular spacing
         # https://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_File_Format_Reference#Dimension_variable_attributes
         for dim in self._dims:
-            if dim.spacing != b'regular__':
-                raise ValueError('Irregular spacing not supported')
+            if hasattr(dim, 'spacing'):
+                if dim.spacing == b'irregular':
+                    raise ValueError('Irregular spacing not supported')
+                elif dim.spacing != b'regular__':
+                    warnings.warn(f'Invalid spacing declaration: {dim.spacing}; assuming regular')
+
         self._spatial_dims = [name for name in self._dim_names if name.endswith('space')]
         self._image_max = image['image-max']
         self._image_min = image['image-min']


### PR DESCRIPTION
Accept other values (like `xspacing`), assuming regular spacing. #1236