### PR TITLE
MAINT: Deprecations

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -39,7 +39,7 @@ For more detailed information see the :ref:`manual`.
 
 # module imports
 from . import analyze as ana
-from . import ecat, imagestats, mriutils
+from . import ecat, imagestats, mriutils, orientations
 from . import nifti1 as ni1
 from . import spm2analyze as spm2
 from . import spm99analyze as spm99

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -796,3 +796,10 @@ def ulp(val=np.float64(1.0)):
         fl2 = info['minexp']
     # 'nmant' value does not include implicit first bit
     return 2 ** (fl2 - info['nmant'])
+
+
+# Ported from np.compat
+def asstr(s):
+    if isinstance(s, bytes):
+        return s.decode('latin1')
+    return str(s)

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -796,10 +796,3 @@ def ulp(val=np.float64(1.0)):
         fl2 = info['minexp']
     # 'nmant' value does not include implicit first bit
     return 2 ** (fl2 - info['nmant'])
-
-
-# Ported from np.compat
-def asstr(s):
-    if isinstance(s, bytes):
-        return s.decode('latin1')
-    return str(s)

--- a/nibabel/nicom/utils.py
+++ b/nibabel/nicom/utils.py
@@ -1,7 +1,7 @@
 """Utilities for working with DICOM datasets
 """
 
-from numpy.compat.py3k import asstr
+from nibabel.casting import asstr
 
 
 def find_private_section(dcm_data, group_no, creator):

--- a/nibabel/nicom/utils.py
+++ b/nibabel/nicom/utils.py
@@ -17,7 +17,7 @@ def find_private_section(dcm_data, group_no, creator):
         ``tag``, ``VR``, ``value``
     group_no : int
         Group number in which to search
-    creator : bytes or regex
+    creator : str or regex
         Name of section - e.g. b'SIEMENS CSA HEADER' - or regex to search for
         section name.  Regex used via ``creator.search(element_value)`` where
         ``element_value`` is the decoded value of the data element.
@@ -29,8 +29,7 @@ def find_private_section(dcm_data, group_no, creator):
     """
     if hasattr(creator, 'search'):
         match_func = creator.search
-    else:  # assume bytes
-        creator = creator.decode('latin-1')
+    else:  # assume str
         match_func = creator.__eq__
     # Group elements assumed ordered by tag (groupno, elno)
     for element in dcm_data.group_dataset(group_no):
@@ -39,7 +38,7 @@ def find_private_section(dcm_data, group_no, creator):
             break
         if element.VR not in ('LO', 'OB'):
             continue
-        val = element.value.decode('latin-1')
+        val = element.value
         if match_func(val):
             return elno * 0x100
     return None

--- a/nibabel/nicom/utils.py
+++ b/nibabel/nicom/utils.py
@@ -17,10 +17,10 @@ def find_private_section(dcm_data, group_no, creator):
         ``tag``, ``VR``, ``value``
     group_no : int
         Group number in which to search
-    creator : str or regex
-        Name of section - e.g. b'SIEMENS CSA HEADER' - or regex to search for
+    creator : str or bytes or regex
+        Name of section - e.g. 'SIEMENS CSA HEADER' - or regex to search for
         section name.  Regex used via ``creator.search(element_value)`` where
-        ``element_value`` is the decoded value of the data element.
+        ``element_value`` is the value of the data element.
 
     Returns
     -------
@@ -29,7 +29,9 @@ def find_private_section(dcm_data, group_no, creator):
     """
     if hasattr(creator, 'search'):
         match_func = creator.search
-    else:  # assume str
+    else:
+        if isinstance(creator, bytes):
+            creator = creator.decode('latin-1')
         match_func = creator.__eq__
     # Group elements assumed ordered by tag (groupno, elno)
     for element in dcm_data.group_dataset(group_no):
@@ -39,6 +41,8 @@ def find_private_section(dcm_data, group_no, creator):
         if element.VR not in ('LO', 'OB'):
             continue
         val = element.value
+        if isinstance(val, bytes):
+            val = val.decode('latin-1')
         if match_func(val):
             return elno * 0x100
     return None

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1740,8 +1740,7 @@ class Nifti1Header(SpmAnalyzeHeader):
         magic = hdr['magic'].item()
         if magic in (hdr.pair_magic, hdr.single_magic):
             return hdr, rep
-        magic = magic.decode('latin-1')
-        rep.problem_msg = f'magic string "{magic}" is not valid'
+        rep.problem_msg = f'magic string {magic.decode("latin1")!r} is not valid'
         rep.problem_level = 45
         if fix:
             rep.fix_msg = 'leaving as is, but future errors are likely'

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -17,12 +17,11 @@ from io import BytesIO
 
 import numpy as np
 import numpy.linalg as npl
-from numpy.compat.py3k import asstr
 
 from . import analyze  # module import
 from .arrayproxy import get_obj_dtype
 from .batteryrunners import Report
-from .casting import have_binary128
+from .casting import have_binary128, asstr
 from .deprecated import alert_future_error
 from .filebasedimages import ImageFileError, SerializableImage
 from .optpkg import optional_package

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -21,7 +21,7 @@ import numpy.linalg as npl
 from . import analyze  # module import
 from .arrayproxy import get_obj_dtype
 from .batteryrunners import Report
-from .casting import have_binary128, asstr
+from .casting import have_binary128
 from .deprecated import alert_future_error
 from .filebasedimages import ImageFileError, SerializableImage
 from .optpkg import optional_package
@@ -1404,7 +1404,7 @@ class Nifti1Header(SpmAnalyzeHeader):
             raise TypeError('repr can be "label" or "code"')
         n_params = len(recoder.parameters[code]) if known_intent else 0
         params = (float(hdr['intent_p%d' % (i + 1)]) for i in range(n_params))
-        name = asstr(hdr['intent_name'].item())
+        name = hdr['intent_name'].item().decode('latin-1')
         return label, tuple(params), name
 
     def set_intent(self, code, params=(), name='', allow_unknown=False):
@@ -1740,7 +1740,8 @@ class Nifti1Header(SpmAnalyzeHeader):
         magic = hdr['magic'].item()
         if magic in (hdr.pair_magic, hdr.single_magic):
             return hdr, rep
-        rep.problem_msg = f'magic string "{asstr(magic)}" is not valid'
+        magic = magic.decode('latin-1')
+        rep.problem_msg = f'magic string "{magic}" is not valid'
         rep.problem_level = 45
         if fix:
             rep.fix_msg = 'leaving as is, but future errors are likely'

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -9,7 +9,6 @@ import warnings
 import numpy as np
 
 import nibabel as nib
-from nibabel.casting import asstr
 from nibabel.openers import Opener
 from nibabel.orientations import aff2axcodes, axcodes2ornt
 from nibabel.volumeutils import endian_codes, native_code, swapped_code
@@ -180,7 +179,7 @@ def decode_value_from_name(encoded_name):
     value : int
         Value decoded from the name.
     """
-    encoded_name = asstr(encoded_name)
+    encoded_name = encoded_name.decode('latin1')
     if len(encoded_name) == 0:
         return encoded_name, 0
 
@@ -740,14 +739,25 @@ class TrkFile(TractogramFile):
                     vars[attr] = vars[hdr_field]
 
         nb_scalars = self.header[Field.NB_SCALARS_PER_POINT]
-        scalar_names = [asstr(s) for s in vars['scalar_name'][:nb_scalars] if len(s) > 0]
+        scalar_names = [
+            s.decode('latin-1')
+            for s in vars['scalar_name'][:nb_scalars]
+            if len(s) > 0
+        ]
         vars['scalar_names'] = '\n  '.join(scalar_names)
         nb_properties = self.header[Field.NB_PROPERTIES_PER_STREAMLINE]
-        property_names = [asstr(s) for s in vars['property_name'][:nb_properties] if len(s) > 0]
+        property_names = [
+            s.decode('latin-1')
+            for s in vars['property_name'][:nb_properties]
+            if len(s) > 0
+        ]
         vars['property_names'] = '\n  '.join(property_names)
         # Make all byte strings into strings
         # Fixes recursion error on Python 3.3
-        vars = {k: asstr(v) if hasattr(v, 'decode') else v for k, v in vars.items()}
+        vars = {
+            k: v.decode('latin-1') if hasattr(v, 'decode') else v
+            for k, v in vars.items()
+        }
         return """\
 MAGIC NUMBER: {MAGIC_NUMBER}
 v.{version}

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -740,24 +740,17 @@ class TrkFile(TractogramFile):
 
         nb_scalars = self.header[Field.NB_SCALARS_PER_POINT]
         scalar_names = [
-            s.decode('latin-1')
-            for s in vars['scalar_name'][:nb_scalars]
-            if len(s) > 0
+            s.decode('latin-1') for s in vars['scalar_name'][:nb_scalars] if len(s) > 0
         ]
         vars['scalar_names'] = '\n  '.join(scalar_names)
         nb_properties = self.header[Field.NB_PROPERTIES_PER_STREAMLINE]
         property_names = [
-            s.decode('latin-1')
-            for s in vars['property_name'][:nb_properties]
-            if len(s) > 0
+            s.decode('latin-1') for s in vars['property_name'][:nb_properties] if len(s) > 0
         ]
         vars['property_names'] = '\n  '.join(property_names)
         # Make all byte strings into strings
         # Fixes recursion error on Python 3.3
-        vars = {
-            k: v.decode('latin-1') if hasattr(v, 'decode') else v
-            for k, v in vars.items()
-        }
+        vars = {k: v.decode('latin-1') if hasattr(v, 'decode') else v for k, v in vars.items()}
         return """\
 MAGIC NUMBER: {MAGIC_NUMBER}
 v.{version}

--- a/nibabel/streamlines/trk.py
+++ b/nibabel/streamlines/trk.py
@@ -7,9 +7,9 @@ import struct
 import warnings
 
 import numpy as np
-from numpy.compat.py3k import asstr
 
 import nibabel as nib
+from nibabel.casting import asstr
 from nibabel.openers import Opener
 from nibabel.orientations import aff2axcodes, axcodes2ornt
 from nibabel.volumeutils import endian_codes, native_code, swapped_code

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -251,7 +251,7 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
         fhdr, message, raiser = self.log_chk(hdr, 45)
         assert fhdr['magic'] == b'ooh'
         assert (
-            message == 'magic string "ooh" is not valid; '
+            message == "magic string 'ooh' is not valid; "
             'leaving as is, but future errors are likely'
         )
         # For pairs, any offset is OK, but should be divisible by 16

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -17,9 +17,9 @@ from io import BytesIO, UnsupportedOperation
 from unittest import mock
 
 import pytest
-from numpy.compat.py3k import asbytes, asstr
 from packaging.version import Version
 
+from ..casting import asstr
 from ..deprecator import ExpiredDeprecationError
 from ..openers import HAVE_INDEXED_GZIP, BZ2File, DeterministicGzipFile, ImageOpener, Opener
 from ..optpkg import optional_package
@@ -342,7 +342,7 @@ virginia
         for input, does_t in files_to_test:
             with Opener(input, 'wb') as fobj:
                 for line in lines:
-                    fobj.write(asbytes(line + os.linesep))
+                    fobj.write(bytes(line + os.linesep, 'ascii'))
             with Opener(input, 'rb') as fobj:
                 for back_line, line in zip(fobj, lines):
                     assert asstr(back_line).rstrip() == line

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -19,7 +19,6 @@ from unittest import mock
 import pytest
 from packaging.version import Version
 
-from ..casting import asstr
 from ..deprecator import ExpiredDeprecationError
 from ..openers import HAVE_INDEXED_GZIP, BZ2File, DeterministicGzipFile, ImageOpener, Opener
 from ..optpkg import optional_package
@@ -345,7 +344,7 @@ virginia
                     fobj.write(bytes(line + os.linesep, 'ascii'))
             with Opener(input, 'rb') as fobj:
                 for back_line, line in zip(fobj, lines):
-                    assert asstr(back_line).rstrip() == line
+                    assert back_line.decode('latin-1').rstrip() == line
             if not does_t:
                 continue
             with Opener(input, 'rt') as fobj:

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -341,10 +341,10 @@ virginia
         for input, does_t in files_to_test:
             with Opener(input, 'wb') as fobj:
                 for line in lines:
-                    fobj.write(bytes(line + os.linesep, 'ascii'))
+                    fobj.write(str.encode(line + os.linesep))
             with Opener(input, 'rb') as fobj:
                 for back_line, line in zip(fobj, lines):
-                    assert back_line.decode('latin-1').rstrip() == line
+                    assert back_line.decode().rstrip() == line
             if not does_t:
                 continue
             with Opener(input, 'rt') as fobj:

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -228,7 +228,7 @@ def test_nib_nifti_dx():
     expected = f"""Picky header check output for "{dirty_hdr}"
 
 pixdim[0] (qfac) should be 1 (default) or -1
-magic string "" is not valid
+magic string '' is not valid
 sform_code 11776 not valid"""
     # Split strings to remove line endings
     assert stdout == expected


### PR DESCRIPTION
1. Recently for some reason in some joblib-parallel runs I've gotten:

   ```
   ../mne-python/mne/_freesurfer.py:89: in _reorient_image
       ornt = nib.orientations.axcodes2ornt(
   E   AttributeError: module 'nibabel' has no attribute 'orientations'
   ```
   Why this started happening just recently is a mystery to me, but this PR adds `from . import orientations` to `nibabel/__init__.py` which hopefully seems reasonable. (It has worked in MNE for at least a year, not sure why it just became an issue...)
2. Deals with warnings of the form:
   ```
   ../nibabel/nibabel/nifti1.py:20: in <module>
       from numpy.compat.py3k import asstr
   ../virtualenvs/base/lib/python3.11/site-packages/numpy/compat/__init__.py:21: in <module>
       warnings.warn(
   E   DeprecationWarning: `np.compat`, which was used during the Python 2 to 3 transition, is deprecated since 1.26.0, and will be removed
   ```