### PR TITLE
DOC: Fix typos found by codespell

### DIFF
--- a/doc/source/dicom/dicom_intro.rst
+++ b/doc/source/dicom/dicom_intro.rst
@@ -228,22 +228,22 @@ Here is the start of the relevant section from PS 3.5:
 
   7.8.1 PRIVATE DATA ELEMENT TAGS
 
-  It is possible that multiple implementors may define Private Elements with the
+  It is possible that multiple implementers may define Private Elements with the
   same (odd) group number.  To avoid conflicts, Private Elements shall be
   assigned Private Data Element Tags according to the following rules.
 
   a) Private Creator Data Elements numbered (gggg,0010-00FF) (gggg is odd) shall
   be used to reserve a block of Elements with Group Number gggg for use by an
-  individual implementor.  The implementor shall insert an identification code
+  individual implementer.  The implementer shall insert an identification code
   in the first unused (unassigned) Element in this series to reserve a block of
   Private Elements. The VR of the private identification code shall be LO (Long
   String) and the VM shall be equal to 1.
 
   b) Private Creator Data Element (gggg,0010), is a Type 1 Data Element that
-  identifies the implementor reserving element (gggg,1000-10FF), Private Creator
-  Data Element (gggg,0011) identifies the implementor reserving elements
+  identifies the implementer reserving element (gggg,1000-10FF), Private Creator
+  Data Element (gggg,0011) identifies the implementer reserving elements
   (gggg,1100-11FF), and so on, until Private Creator Data Element (gggg,00FF)
-  identifies the implementor reserving elements (gggg,FF00- FFFF).
+  identifies the implementer reserving elements (gggg,FF00- FFFF).
 
   c) Encoders of Private Data Elements shall be able to dynamically assign
   private data to any available (unreserved) block(s) within the Private group,

--- a/doc/source/external/nifti1.h
+++ b/doc/source/external/nifti1.h
@@ -869,7 +869,7 @@ typedef struct { unsigned char r,g,b; } rgb_byte ;
      as a displacement field or vector:
        - dataset must have a 5th dimension
        - intent_code must be NIFTI_INTENT_DISPVECT
-       - dim[5] must be the dimensionality of the displacment
+       - dim[5] must be the dimensionality of the displacement
          vector (e.g., 3 for spatial displacement, 2 for in-plane) */
 
 #define NIFTI_INTENT_DISPVECT  1006   /* specifically for displacements */

--- a/doc/source/old/format_design.txt
+++ b/doc/source/old/format_design.txt
@@ -13,7 +13,7 @@ The Image and the Format objects form a `bridge pattern
 diagram
 <https://en.wikipedia.org/wiki/File:Bridge_UML_class_diagram.svg>`_ the
 Image class plays the role of the Abstraction, and the Format plays the
-role of the implementor.
+role of the implementer.
 
 The Format object provides an interface to the underlying file format.
 

--- a/nibabel/cifti2/cifti2_axes.py
+++ b/nibabel/cifti2/cifti2_axes.py
@@ -59,7 +59,7 @@ We can create brain models covering the left cortex and left thalamus using:
 In this very simple case ``bm_cortex`` describes a left cortical surface skipping the second
 out of four vertices. ``bm_thal`` contains all voxels in a 2x2x2 volume.
 
-Brain structure names automatically get converted to valid CIFTI-2 indentifiers using
+Brain structure names automatically get converted to valid CIFTI-2 identifiers using
 :meth:`BrainModelAxis.to_cifti_brain_structure_name`.
 A 1-dimensional mask will be automatically interpreted as a surface element and a 3-dimensional
 mask as a volume element.

--- a/nibabel/tests/test_loadsave.py
+++ b/nibabel/tests/test_loadsave.py
@@ -192,7 +192,7 @@ def test_read_img_data_nifti():
                 assert_array_equal(actual_unscaled, read_img_data(img_back, prefer='unscaled'))
             # Check the offset too
             img.header.set_data_offset(1024)
-            # Delete arrays still pointing to file, so Windows can re-use
+            # Delete arrays still pointing to file, so Windows can reuse
             del actual_unscaled, unscaled_back
             img.to_file_map()
             # Write an integer of zeros after

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1169,7 +1169,7 @@ class TestNifti1Pair(tana.TestAnalyzeImage, tspm.ImageScalingMixin):
             assert img.get_data_dtype() == alias
             img_rt = bytesio_round_trip(img)
             assert img_rt.get_data_dtype() == effective_dt
-            # Seralizing does not finalize the source image
+            # Serializing does not finalize the source image
             assert img.get_data_dtype() == alias
 
     def test_static_dtype_aliases(self):

--- a/nibabel/tests/test_processing.py
+++ b/nibabel/tests/test_processing.py
@@ -222,7 +222,7 @@ def test_resample_from_to(caplog):
 
 @needs_scipy
 def test_resample_to_output(caplog):
-    # Test routine to sample iamges to output space
+    # Test routine to sample images to output space
     # Image aligned to output axes - no-op
     data = np.arange(24, dtype='int32').reshape((2, 3, 4))
     img = Nifti1Image(data, np.eye(4))


### PR DESCRIPTION
About `implementor` → `implementer`: Both seem acceptable, but most dictionaries suggest `implementer` alone or as a first choice ([Cambridge](https://dictionary.cambridge.org/fr/dictionnaire/anglais/implementer), [Merriam-Webster](https://www.merriam-webster.com/dictionary/implementor)) and the Google Books Ngram database suggests that `implementer` outdistanced `implementor` around 2000, and curiously even more in American than British English:
https://books.google.com/ngrams/graph?content=implementer%2Cimplementor&year_start=1800&year_end=2019&corpus=en-2019