### PR TITLE
CI: Begin testing on Python 3.12

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         architecture: ['x64', 'x86']
         install: ['pip']
         check: ['test']
@@ -54,6 +54,8 @@ jobs:
             architecture: x86
           - os: macos-latest
             architecture: x86
+          - python-version: '3.12'
+            architecture: x86
 
     env:
       DEPENDS: ${{ matrix.depends }}
@@ -72,6 +74,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
+          allow-prereleases: true
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Create virtual environment

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -78,6 +78,12 @@ class DeterministicGzipFile(gzip.GzipFile):
             mtime=mtime,
         )
 
+    def seek(self, pos: int, whence: int = 0, /) -> int:
+        # Work around bug (gh-180111) in Python 3.12rc1, where seeking without
+        # flushing can cause write of excess null bytes
+        self.flush()
+        return super().seek(pos, whence)
+
 
 def _gzip_open(
     filename: str,

--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -84,7 +84,7 @@ def setup():
     )
 
 
-def test_is_supported_detect_format():
+def test_is_supported_detect_format(tmp_path):
     # Test is_supported and detect_format functions
     # Empty file/string
     f = BytesIO()
@@ -103,7 +103,8 @@ def test_is_supported_detect_format():
 
     # Wrong extension but right magic number
     for tfile_cls in FORMATS.values():
-        with tempfile.TemporaryFile(mode='w+b', suffix='.txt') as f:
+        fpath = tmp_path / 'test.txt'
+        with open(fpath, 'w+b') as f:
             f.write(asbytes(tfile_cls.MAGIC_NUMBER))
             f.seek(0, os.SEEK_SET)
             assert nib.streamlines.is_supported(f)
@@ -111,7 +112,8 @@ def test_is_supported_detect_format():
 
     # Good extension but wrong magic number
     for ext, tfile_cls in FORMATS.items():
-        with tempfile.TemporaryFile(mode='w+b', suffix=ext) as f:
+        fpath = tmp_path / f'test{ext}'
+        with open(fpath, 'w+b') as f:
             f.write(b'pass')
             f.seek(0, os.SEEK_SET)
             assert not nib.streamlines.is_supported(f)

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -25,6 +25,7 @@ What is the image API?
 
 import io
 import pathlib
+import sys
 import warnings
 from functools import partial
 from itertools import product
@@ -579,6 +580,10 @@ class SerializeMixin:
         del img
         del rt_img
 
+    @pytest.mark.xfail(
+        sys.version_info >= (3, 12),
+        reason='Response type for file: urls is not a stream in Python 3.12',
+    )
     def validate_from_file_url(self, imaker, params):
         tmp_path = self.tmp_path
 

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -19,10 +19,10 @@ if [ -n "$EXTRA_PIP_FLAGS" ]; then
 fi
 
 if [ -n "$DEPENDS" ]; then
-    pip install ${EXTRA_PIP_FLAGS} --prefer-binary ${!DEPENDS}
+    pip install ${EXTRA_PIP_FLAGS} --only-binary :all: ${!DEPENDS}
     if [ -n "$OPTIONAL_DEPENDS" ]; then
         for DEP in ${!OPTIONAL_DEPENDS}; do
-            pip install ${EXTRA_PIP_FLAGS} --prefer-binary $DEP || true
+            pip install ${EXTRA_PIP_FLAGS} --only-binary :all: $DEP || true
 	done
     fi
 fi


### PR DESCRIPTION
Numpy 1.26b1 is out, allowing tests on Python 3.12.

Not yet ready to test on numpy 2.0, so leaving the nightly build URLs as-is for now.