### PR TITLE
TYP: Annotate SpatialImage accepting affine=None

### DIFF
--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -481,7 +481,7 @@ class SpatialImage(DataobjImage):
     def __init__(
         self,
         dataobj: ArrayLike,
-        affine: np.ndarray,
+        affine: np.ndarray | None,
         header: FileBasedHeader | ty.Mapping | None = None,
         extra: ty.Mapping | None = None,
         file_map: FileMap | None = None,

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -566,6 +566,7 @@ class SpatialImage(DataobjImage):
 
     def _affine2header(self) -> None:
         """Unconditionally set affine into the header"""
+        assert self._affine is not None
         RZS = self._affine[:3, :3]
         vox = np.sqrt(np.sum(RZS * RZS, axis=0))
         hdr = self._header


### PR DESCRIPTION
This corrects the typing for the `SpatialImage` `__init__` function by allowing `None` for `affine`.