### PR TITLE
ENH: Add copy() method to ArrayProxy

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -217,6 +217,15 @@ class ArrayProxy(ArrayLike):
         )
         self._lock = RLock()
 
+    def copy(self):
+        spec = self._shape, self._dtype, self._offset, self._slope, self._inter
+        return ArrayProxy(
+            self.file_like,
+            spec,
+            mmap=self._mmap,
+            keep_file_open=self._keep_file_open,
+        )
+
     def __del__(self):
         """If this ``ArrayProxy`` was created with ``keep_file_open=True``,
         the open file object is closed if necessary.

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -553,12 +553,13 @@ def test_keep_file_open_true_false_invalid():
                     ArrayProxy(fname, ((10, 10, 10), dtype))
 
 
+def islock(l):
+    # isinstance doesn't work on threading.Lock?
+    return hasattr(l, 'acquire') and hasattr(l, 'release')
+
+
 def test_pickle_lock():
     # Test that ArrayProxy can be pickled, and that thread lock is created
-
-    def islock(l):
-        # isinstance doesn't work on threading.Lock?
-        return hasattr(l, 'acquire') and hasattr(l, 'release')
 
     proxy = ArrayProxy('dummyfile', ((10, 10, 10), np.float32))
     assert islock(proxy._lock)
@@ -566,3 +567,22 @@ def test_pickle_lock():
     unpickled = pickle.loads(pickled)
     assert islock(unpickled._lock)
     assert proxy._lock is not unpickled._lock
+
+
+def test_copy():
+    # Test copying array proxies
+
+    # If the file-like is a file name, get a new lock
+    proxy = ArrayProxy('dummyfile', ((10, 10, 10), np.float32))
+    assert islock(proxy._lock)
+    copied = proxy.copy()
+    assert islock(copied._lock)
+    assert proxy._lock is not copied._lock
+
+    # If an open filehandle, the lock should be shared to
+    # avoid changing filehandle state in critical sections
+    proxy = ArrayProxy(BytesIO(), ((10, 10, 10), np.float32))
+    assert islock(proxy._lock)
+    copied = proxy.copy()
+    assert islock(copied._lock)
+    assert proxy._lock is copied._lock

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -23,7 +23,7 @@ from packaging.version import Version
 from .. import __version__
 from ..arrayproxy import ArrayProxy, get_obj_dtype, is_proxy, reshape_dataobj
 from ..deprecator import ExpiredDeprecationError
-from ..nifti1 import Nifti1Header
+from ..nifti1 import Nifti1Header, Nifti1Image
 from ..openers import ImageOpener
 from ..testing import memmap_after_ufunc
 from ..tmpdirs import InTemporaryDirectory
@@ -586,3 +586,20 @@ def test_copy():
     copied = proxy.copy()
     assert islock(copied._lock)
     assert proxy._lock is copied._lock
+
+
+def test_copy_with_indexed_gzip_handle(tmp_path):
+    indexed_gzip = pytest.importorskip('indexed_gzip')
+
+    spec = ((50, 50, 50, 50), np.float32, 352, 1, 0)
+    data = np.arange(np.prod(spec[0]), dtype=spec[1]).reshape(spec[0])
+    fname = str(tmp_path / 'test.nii.gz')
+    Nifti1Image(data, np.eye(4)).to_filename(fname)
+
+    with indexed_gzip.IndexedGzipFile(fname) as fobj:
+        proxy = ArrayProxy(fobj, spec)
+        copied = proxy.copy()
+
+        assert proxy.file_like is copied.file_like
+        assert np.array_equal(proxy[0, 0, 0], copied[0, 0, 0])
+        assert np.array_equal(proxy[-1, -1, -1], copied[-1, -1, -1])


### PR DESCRIPTION
Small addition to ArrayProxy class to allow copying. Used in #1090, but not central to it.