### PR TITLE
ENH: Add TriangularMesh data structure [BIAP9]

### DIFF
--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -53,7 +53,7 @@ class HasMeshAttrs(ty.Protocol):
     triangles: CoordinateArray
 
 
-@dataclass
+@dataclass(init=False)
 class Pointset:
     """A collection of points described by coordinates.
 
@@ -70,7 +70,7 @@ class Pointset:
 
     coordinates: CoordinateArray
     affine: np.ndarray
-    homogeneous: bool = False
+    homogeneous: bool
 
     # Force use of __rmatmul__ with numpy arrays
     __array_priority__ = 99
@@ -149,6 +149,7 @@ class Pointset:
         return coords
 
 
+@dataclass(init=False)
 class TriangularMesh(Pointset):
     triangles: CoordinateArray
 

--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -169,8 +169,9 @@ class TriangularMesh(Pointset):
         mesh: tuple[CoordinateArray, CoordinateArray],
         affine: np.ndarray | None = None,
         homogeneous: bool = False,
+        **kwargs,
     ) -> Self:
-        return cls(mesh[0], mesh[1], affine=affine, homogeneous=homogeneous)
+        return cls(mesh[0], mesh[1], affine=affine, homogeneous=homogeneous, **kwargs)
 
     @classmethod
     def from_object(
@@ -178,8 +179,11 @@ class TriangularMesh(Pointset):
         mesh: HasMeshAttrs,
         affine: np.ndarray | None = None,
         homogeneous: bool = False,
+        **kwargs,
     ) -> Self:
-        return cls(mesh.coordinates, mesh.triangles, affine=affine, homogeneous=homogeneous)
+        return cls(
+            mesh.coordinates, mesh.triangles, affine=affine, homogeneous=homogeneous, **kwargs
+        )
 
     @property
     def n_triangles(self):
@@ -198,9 +202,10 @@ class TriangularMesh(Pointset):
 
 
 class CoordinateFamilyMixin(Pointset):
-    def __init__(self, *args, **kwargs):
-        self._coords = {}
+    def __init__(self, *args, name='original', **kwargs):
+        mapping = kwargs.pop('mapping', {})
         super().__init__(*args, **kwargs)
+        self._coords = {name: self.coordinates, **mapping}
 
     def get_names(self):
         """List of surface names that can be passed to :meth:`with_name`"""

--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -212,7 +212,12 @@ class CoordinateFamilyMixin(Pointset):
         return list(self._coords)
 
     def with_name(self, name: str) -> Self:
-        new = replace(self, coordinates=self._coords[name])
+        new_coords = self._coords[name]
+        if new_coords is self.coordinates:
+            return self
+        # Make a copy, preserving all dataclass fields
+        new = replace(self, coordinates=new_coords)
+        # Conserve exact _coords mapping
         new._coords = self._coords
         return new
 

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -182,3 +182,159 @@ class TestGrids(TestPointsets):
             ],
         )
         assert np.array_equal(mask_img.affine, np.eye(4))
+
+
+class TestTriangularMeshes(TestPointsets):
+    ...
+
+
+class H5ArrayProxy:
+    def __init__(self, file_like, dataset_name):
+        self.file_like = file_like
+        self.dataset_name = dataset_name
+        with h5.File(file_like, 'r') as h5f:
+            arr = h5f[dataset_name]
+            self._shape = arr.shape
+            self._dtype = arr.dtype
+
+    @property
+    def is_proxy(self):
+        return True
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __array__(self, dtype=None):
+        with h5.File(self.file_like, 'r') as h5f:
+            return np.asanyarray(h5f[self.dataset_name], dtype)
+
+    def __getitem__(self, slicer):
+        with h5.File(self.file_like, 'r') as h5f:
+            return h5f[self.dataset_name][slicer]
+
+
+class H5Geometry(ps.TriMeshFamily):
+    """Simple Geometry file structure that combines a single topology
+    with one or more coordinate sets
+    """
+
+    @classmethod
+    def from_filename(klass, pathlike):
+        meshes = {}
+        with h5.File(pathlike, 'r') as h5f:
+            triangles = H5ArrayProxy(pathlike, '/topology')
+            for name in h5f['coordinates']:
+                meshes[name] = (H5ArrayProxy(pathlike, f'/coordinates/{name}'), triangles)
+        return klass(meshes)
+
+    def to_filename(self, pathlike):
+        with h5.File(pathlike, 'w') as h5f:
+            h5f.create_dataset('/topology', data=self.get_triangles())
+            for name, coord in self._coords.items():
+                h5f.create_dataset(f'/coordinates/{name}', data=coord)
+
+
+class FSGeometryProxy:
+    def __init__(self, pathlike):
+        self._file_like = str(Path(pathlike))
+        self._offset = None
+        self._vnum = None
+        self._fnum = None
+
+    def _peek(self):
+        from nibabel.freesurfer.io import _fread3
+
+        with open(self._file_like, 'rb') as fobj:
+            magic = _fread3(fobj)
+            if magic != 16777214:
+                raise NotImplementedError('Triangle files only!')
+            fobj.readline()
+            fobj.readline()
+            self._vnum = np.fromfile(fobj, '>i4', 1)[0]
+            self._fnum = np.fromfile(fobj, '>i4', 1)[0]
+            self._offset = fobj.tell()
+
+    @property
+    def vnum(self):
+        if self._vnum is None:
+            self._peek()
+        return self._vnum
+
+    @property
+    def fnum(self):
+        if self._fnum is None:
+            self._peek()
+        return self._fnum
+
+    @property
+    def offset(self):
+        if self._offset is None:
+            self._peek()
+        return self._offset
+
+    @auto_attr
+    def coords(self):
+        ap = ArrayProxy(self._file_like, ((self.vnum, 3), '>f4', self.offset))
+        ap.order = 'C'
+        return ap
+
+    @auto_attr
+    def triangles(self):
+        offset = self.offset + 12 * self.vnum
+        ap = ArrayProxy(self._file_like, ((self.fnum, 3), '>i4', offset))
+        ap.order = 'C'
+        return ap
+
+
+class FreeSurferHemisphere(ps.TriMeshFamily):
+    @classmethod
+    def from_filename(klass, pathlike):
+        path = Path(pathlike)
+        hemi, default = path.name.split('.')
+        mesh_names = (
+            'orig',
+            'white',
+            'smoothwm',
+            'pial',
+            'inflated',
+            'sphere',
+            'midthickness',
+            'graymid',
+        )  # Often created
+        if default not in mesh_names:
+            mesh_names.append(default)
+        meshes = {}
+        for mesh in mesh_names:
+            fpath = path.parent / f'{hemi}.{mesh}'
+            if fpath.exists():
+                meshes[mesh] = FSGeometryProxy(fpath)
+        hemi = klass(meshes)
+        hemi._default = default
+        return hemi
+
+
+def test_FreeSurferHemisphere():
+    lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
+    assert lh.n_coords == 163842
+    assert lh.n_triangles == 327680
+
+
+@skipUnless(has_h5py, reason='Test requires h5py')
+def test_make_H5Geometry(tmp_path):
+    lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
+    h5geo = H5Geometry({name: lh.get_mesh(name) for name in ('white', 'pial')})
+    h5geo.to_filename(tmp_path / 'geometry.h5')
+
+    rt_h5geo = H5Geometry.from_filename(tmp_path / 'geometry.h5')
+    assert set(h5geo._coords) == set(rt_h5geo._coords)
+    assert np.array_equal(lh.get_coords('white'), rt_h5geo.get_coords('white'))
+    assert np.array_equal(lh.get_triangles(), rt_h5geo.get_triangles())

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -250,12 +250,27 @@ class TestCoordinateFamilyMixin(TestPointsets):
         assert np.allclose(cfm.with_name('original').coordinates, coords)
 
         cfm.add_coordinates('shifted', coords + 1)
-        assert cfm.get_names() == ['original', 'shifted']
+        assert set(cfm.get_names()) == {'original', 'shifted'}
         shifted = cfm.with_name('shifted')
         assert np.allclose(shifted.coordinates, coords + 1)
-        assert shifted.get_names() == ['original', 'shifted']
+        assert set(shifted.get_names()) == {'original', 'shifted'}
         original = shifted.with_name('original')
         assert np.allclose(original.coordinates, coords)
+
+        # Avoid duplicating objects
+        assert original.with_name('original') is original
+        # But don't try too hard
+        assert original.with_name('original') is not cfm
+
+        # with_name() preserves the exact coordinate mapping of the source object.
+        # Modifications of one are immediately available to all others.
+        # This is currently an implementation detail, and the expectation is that
+        # a family will be created once and then queried, but this behavior could
+        # potentially become confusing or relied upon.
+        # Change with care.
+        shifted.add_coordinates('shifted-again', coords + 2)
+        shift2 = shifted.with_name('shifted-again')
+        shift3 = cfm.with_name('shifted-again')
 
 
 class H5ArrayProxy:

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -186,7 +186,7 @@ class TestGrids(TestPointsets):
 
 
 class TestTriangularMeshes:
-    def test_init(self):
+    def test_api(self):
         # Tetrahedron
         coords = np.array(
             [
@@ -226,6 +226,36 @@ class TestTriangularMeshes:
         assert tm1.n_triangles == 4
         assert tm2.n_triangles == 4
         assert tm3.n_triangles == 4
+
+        out_coords, out_tris = tm1.get_mesh()
+        # Currently these are the exact arrays, but I don't think we should
+        # bake that assumption into the tests
+        assert np.allclose(out_coords, coords)
+        assert np.allclose(out_tris, triangles)
+
+
+class TestCoordinateFamilyMixin(TestPointsets):
+    def test_names(self):
+        coords = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+        cfm = ps.CoordinateFamilyMixin(coords)
+
+        assert cfm.get_names() == ['original']
+        assert np.allclose(cfm.with_name('original').coordinates, coords)
+
+        cfm.add_coordinates('shifted', coords + 1)
+        assert cfm.get_names() == ['original', 'shifted']
+        shifted = cfm.with_name('shifted')
+        assert np.allclose(shifted.coordinates, coords + 1)
+        assert shifted.get_names() == ['original', 'shifted']
+        original = shifted.with_name('original')
+        assert np.allclose(original.coordinates, coords)
 
 
 class H5ArrayProxy:

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -322,17 +322,16 @@ class FSGeometryProxy:
         return self._offset
 
     @auto_attr
-    def coords(self):
-        ap = ArrayProxy(self._file_like, ((self.vnum, 3), '>f4', self.offset))
-        ap.order = 'C'
-        return ap
+    def coordinates(self):
+        return ArrayProxy(self._file_like, ((self.vnum, 3), '>f4', self.offset), order='C')
 
     @auto_attr
     def triangles(self):
-        offset = self.offset + 12 * self.vnum
-        ap = ArrayProxy(self._file_like, ((self.fnum, 3), '>i4', offset))
-        ap.order = 'C'
-        return ap
+        return ArrayProxy(
+            self._file_like,
+            ((self.fnum, 3), '>i4', self.offset + 12 * self.vnum),
+            order='C',
+        )
 
 
 class FreeSurferHemisphere(ps.TriMeshFamily):

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -13,7 +13,7 @@ from nibabel.fileslice import strided_scalar
 from nibabel.onetime import auto_attr
 from nibabel.optpkg import optional_package
 from nibabel.spatialimages import SpatialImage
-from nibabel.tests.nibabel_data import get_nibabel_data
+from nibabel.tests.nibabel_data import get_nibabel_data, needs_nibabel_data
 
 h5, has_h5py, _ = optional_package('h5py')
 
@@ -360,6 +360,7 @@ class FreeSurferHemisphere(ps.TriangularMesh, ps.CoordinateFamilyMixin):
         return self
 
 
+@needs_nibabel_data('nitest-freesurfer')
 def test_FreeSurferHemisphere():
     lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
     assert lh.n_coords == 163842
@@ -367,6 +368,7 @@ def test_FreeSurferHemisphere():
 
 
 @skipUnless(has_h5py, reason='Test requires h5py')
+@needs_nibabel_data('nitest-freesurfer')
 def test_make_H5Geometry(tmp_path):
     lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
     h5geo = H5Geometry.from_object(lh)

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from math import prod
 from pathlib import Path
 from unittest import skipUnless
@@ -184,8 +185,47 @@ class TestGrids(TestPointsets):
         assert np.array_equal(mask_img.affine, np.eye(4))
 
 
-class TestTriangularMeshes(TestPointsets):
-    ...
+class TestTriangularMeshes:
+    def test_init(self):
+        # Tetrahedron
+        coords = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+        triangles = np.array(
+            [
+                [0, 2, 1],
+                [0, 3, 2],
+                [0, 1, 3],
+                [1, 2, 3],
+            ]
+        )
+
+        mesh = namedtuple('mesh', ('coordinates', 'triangles'))(coords, triangles)
+
+        tm1 = ps.TriangularMesh(coords, triangles)
+        tm2 = ps.TriangularMesh.from_tuple(mesh)
+        tm3 = ps.TriangularMesh.from_object(mesh)
+
+        assert np.allclose(tm1.affine, np.eye(4))
+        assert np.allclose(tm2.affine, np.eye(4))
+        assert np.allclose(tm3.affine, np.eye(4))
+
+        assert tm1.homogeneous is False
+        assert tm2.homogeneous is False
+        assert tm3.homogeneous is False
+
+        assert (tm1.n_coords, tm1.dim) == (4, 3)
+        assert (tm2.n_coords, tm2.dim) == (4, 3)
+        assert (tm3.n_coords, tm3.dim) == (4, 3)
+
+        assert tm1.n_triangles == 4
+        assert tm2.n_triangles == 4
+        assert tm3.n_triangles == 4
 
 
 class H5ArrayProxy:


### PR DESCRIPTION
#1251 Added `Pointset` and `Grid`. #1090 also proposes `TriangularMesh`, but with the refactoring seen in #1251, that seemed like a bit of extra work for minimal benefit to the transformations use-case. This PR re-adds triangular meshes.

Overall, the approach of multiple names feels clunky and pushes the concerns of surface families into pointsets. #1251 removed that, and this PR extends this by keeping `TriangularMesh` focused on the base data structure and moves `TriangularMeshFamily` logic into a `CoordinateFamilyMixin` class that permits swapping out coordinates with a `.with_name()` method (open to bikeshedding). Hence, we would change:

```Python
left_surfaces.get_coords(name='pial')
```

to:

```Python
left_surfaces.with_name('pial').get_coords()
```

It also follows the lead of `Grid` and gets rid of the omni-`__init__` in favor of targeted factory classmethods.

----

Notes from previous discussion:

* @oesteban wrote: "As a note, if some time we support other meshes with more than three edges, then n_triangles should be better named n_faces."
   * This was part of early discussions of BIAP9. IIRC the universality of triangular meshes makes them worth special-casing for now. FreeSurfer has old formats that use non-triangular meshes, and both FreeSurfer and we convert them to triangular on load: https://github.com/nipy/nibabel/blob/590b226d7d29c8086c45cc82ece76181e598c474/nibabel/freesurfer/io.py#L145-L168