### PR TITLE
ENH: Allow ~/ in paths

### DIFF
--- a/nibabel/filename_parser.py
+++ b/nibabel/filename_parser.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import os
+import pathlib
 import typing as ty
 
 if ty.TYPE_CHECKING:  # pragma: no cover
@@ -37,9 +38,7 @@ def _stringify_path(filepath_or_buffer: FileSpec) -> str:
     Adapted from:
     https://github.com/pandas-dev/pandas/blob/325dd68/pandas/io/common.py#L131-L160
     """
-    if isinstance(filepath_or_buffer, os.PathLike):
-        return filepath_or_buffer.__fspath__()
-    return filepath_or_buffer
+    return str(pathlib.Path(filepath_or_buffer).expanduser().resolve())
 
 
 def types_filenames(

--- a/nibabel/filename_parser.py
+++ b/nibabel/filename_parser.py
@@ -38,7 +38,8 @@ def _stringify_path(filepath_or_buffer: FileSpec) -> str:
     Adapted from:
     https://github.com/pandas-dev/pandas/blob/325dd68/pandas/io/common.py#L131-L160
     """
-    return str(pathlib.Path(filepath_or_buffer).expanduser())
+    full_path = pathlib.Path(filepath_or_buffer).expanduser()
+    return str(full_path)
 
 
 def types_filenames(

--- a/nibabel/filename_parser.py
+++ b/nibabel/filename_parser.py
@@ -38,7 +38,7 @@ def _stringify_path(filepath_or_buffer: FileSpec) -> str:
     Adapted from:
     https://github.com/pandas-dev/pandas/blob/325dd68/pandas/io/common.py#L131-L160
     """
-    return str(pathlib.Path(filepath_or_buffer).expanduser().resolve())
+    return str(pathlib.Path(filepath_or_buffer).expanduser())
 
 
 def types_filenames(

--- a/nibabel/tests/test_filename_parser.py
+++ b/nibabel/tests/test_filename_parser.py
@@ -7,10 +7,11 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Tests for filename container"""
+import pathlib
 
 import pytest
 
-from ..filename_parser import TypesFilenamesError, parse_filename, splitext_addext, types_filenames
+from ..filename_parser import TypesFilenamesError, parse_filename, splitext_addext, types_filenames, _stringify_path
 
 
 def test_filenames():
@@ -123,3 +124,26 @@ def test_splitext_addext():
     assert res == ('..', '', '')
     res = splitext_addext('...')
     assert res == ('...', '', '')
+
+
+def test__stringify_path():
+    current_directory = pathlib.Path.cwd()
+    res = _stringify_path('')
+    assert res == str(current_directory)
+    res = _stringify_path('fname.ext.gz')
+    assert res == str(current_directory / 'fname.ext.gz')
+    res = _stringify_path(pathlib.Path('fname.ext.gz'))
+    assert res == str(current_directory / 'fname.ext.gz')
+
+    home = pathlib.Path.home()
+    res = _stringify_path(pathlib.Path('~/fname.ext.gz'))
+    assert res == str(home) + '/fname.ext.gz'
+
+    res = _stringify_path(pathlib.Path('./fname.ext.gz'))
+    assert res == str(current_directory / 'fname.ext.gz')
+    res = _stringify_path(pathlib.Path('../fname.ext.gz'))
+    assert res == str(current_directory.parent / 'fname.ext.gz')
+    
+
+
+

--- a/nibabel/tests/test_filename_parser.py
+++ b/nibabel/tests/test_filename_parser.py
@@ -128,21 +128,19 @@ def test_splitext_addext():
 
 def test__stringify_path():
     current_directory = pathlib.Path.cwd()
-    res = _stringify_path('')
-    assert res == str(current_directory)
     res = _stringify_path('fname.ext.gz')
-    assert res == str(current_directory / 'fname.ext.gz')
+    assert res == 'fname.ext.gz'
     res = _stringify_path(pathlib.Path('fname.ext.gz'))
-    assert res == str(current_directory / 'fname.ext.gz')
+    assert res == 'fname.ext.gz'
 
     home = pathlib.Path.home()
     res = _stringify_path(pathlib.Path('~/fname.ext.gz'))
     assert res == str(home) + '/fname.ext.gz'
 
     res = _stringify_path(pathlib.Path('./fname.ext.gz'))
-    assert res == str(current_directory / 'fname.ext.gz')
+    assert res == 'fname.ext.gz'
     res = _stringify_path(pathlib.Path('../fname.ext.gz'))
-    assert res == str(current_directory.parent / 'fname.ext.gz')
+    assert res == '../fname.ext.gz'
     
 
 


### PR DESCRIPTION
This PR modifies `_stringify_path` to allow it to expand home directories (`~/`). Its output should remain the same on all other valid inputs. 

Tests are included to validate a variety of cases. As no prior tests existed for this function I cannot confirm that its behavior remains identical in all other cases. 