### PR TITLE
MNT: Update test dependencies for 3.12 and dev environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,19 +65,21 @@ pass_env =
   NIPY_EXTRA_TESTS
 extras = test
 deps =
+  # General minimum dependencies: pin based on API usage
+  min: packaging ==17
+  min: importlib_resources ==1.3; python_version < '3.9'
   # NEP29/SPEC0 + 1yr: Test on minor release series within the last 3 years
   # We're extending this to all optional dependencies
   # This only affects the range that we test on; numpy is the only non-optional
   # dependency, and will be the only one to affect pip environment resolution.
   min: numpy ==1.20
-  min: packaging ==17
-  min: importlib_resources ==1.3; python_version < '3.9'
-  min: scipy ==1.6
-  min: matplotlib ==3.4
   min: h5py ==2.10
-  min: pillow ==8.1
   min: indexed_gzip ==1.4
+  min: matplotlib ==3.4
+  min: pillow ==8.1
+  min: pydicom ==2.1
   min: pyzstd ==0.14.3
+  min: scipy ==1.6
   # Numpy 2.0 is a major breaking release; we cannot put much effort into
   # supporting until it's at least RC stable
   pre: numpy <2.0.dev0
@@ -91,7 +93,6 @@ deps =
   full,pre,dev: pillow >=8.1
   full,pre,dev: indexed_gzip >=1.4
   full,pre,dev: pyzstd >=0.14.3
-  min: pydicom ==2.1
   full,pre,dev: pydicom >=2.1
   # pydicom master seems to be breaking things
   # pre: pydicom @ git+https://github.com/pydicom/pydicom.git@main

--- a/tox.ini
+++ b/tox.ini
@@ -88,10 +88,9 @@ deps =
   py3{8,9}-full-x86,x64: matplotlib >=3.4
   # h5py stopped producing win32 wheels at py39
   py38-full-x86,x64: h5py >=2.10
-  full,pre: pillow >=8.1
-  # indexed_gzip missing py312 wheels
-  py3{8,9,10,11}-{full,pre}: indexed_gzip >=1.4
-  full,pre: pyzstd >=0.14.3
+  full,pre,dev: pillow >=8.1
+  full,pre,dev: indexed_gzip >=1.4
+  full,pre,dev: pyzstd >=0.14.3
   min: pydicom ==2.1
   full,pre,dev: pydicom >=2.1
   # pydicom master seems to be breaking things


### PR DESCRIPTION
`indexed_gzip` has 3.12 wheels now, and we should go ahead and check for interactions with numpy 2-dev for all optional dependencies.