### PR TITLE
MNT: `[:]` → `.copy()`

### DIFF
--- a/nibabel/spm2analyze.py
+++ b/nibabel/spm2analyze.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from . import spm99analyze as spm99  # module import
 
-image_dimension_dtd = spm99.image_dimension_dtd[:]
+image_dimension_dtd = spm99.image_dimension_dtd.copy()
 image_dimension_dtd[image_dimension_dtd.index(('funused2', 'f4'))] = ('scl_inter', 'f4')
 
 # Full header numpy dtype combined across sub-fields

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -22,10 +22,10 @@ have_scipy = optional_package('scipy')[1]
 """ Support subtle variations of SPM version of Analyze """
 header_key_dtd = analyze.header_key_dtd
 # funused1 in dime subfield is scalefactor
-image_dimension_dtd = analyze.image_dimension_dtd[:]
+image_dimension_dtd = analyze.image_dimension_dtd.copy()
 image_dimension_dtd[image_dimension_dtd.index(('funused1', 'f4'))] = ('scl_slope', 'f4')
 # originator text field used as image origin (translations)
-data_history_dtd = analyze.data_history_dtd[:]
+data_history_dtd = analyze.data_history_dtd.copy()
 data_history_dtd[data_history_dtd.index(('originator', 'S10'))] = ('origin', 'i2', (5,))
 
 # Full header numpy dtype combined across sub-fields


### PR DESCRIPTION
Apply a refurb suggestion that does make the intent clearer:
> [FURB145]: Replace `x[:]` with `x.copy()`