### PR TITLE
TEST: Chdir during doctest to avoid polluting the working dir

### DIFF
--- a/nibabel/externals/conftest.py
+++ b/nibabel/externals/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+try:
+    from contextlib import chdir as _chdir
+except ImportError:  # PY310
+    import os
+    from contextlib import contextmanager
+
+    @contextmanager  # type: ignore
+    def _chdir(path):
+        cwd = os.getcwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(cwd)
+
+
+@pytest.fixture(autouse=True)
+def chdir_tmpdir(request, tmp_path):
+    if request.node.__class__.__name__ == "DoctestItem":
+        with _chdir(tmp_path):
+            yield
+    else:
+        yield


### PR DESCRIPTION
Small cleanup. When running the test suite, `simple.nc` gets dropped into the working directory by the `netcdf` doctests. This detects a doctest in the externals directory and chdirs into a temporary directory to guard us against these, as we'd rather not modify the vendored files more than necessary.