### PR TITLE
CI: FORCE_COLOR for readable tox/pytest outputs, use OIDC PyPI uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,6 +199,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: "Package deployment"
     needs: [test, test-package]
+    permissions:
+      # Required for trusted publishing
+      id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
@@ -206,6 +209,3 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ defaults:
   run:
     shell: bash
 
+# Force tox and pytest to use color
+env:
+  FORCE_COLOR: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1637,9 +1637,7 @@ class Nifti1Header(SpmAnalyzeHeader):
         labels.remove('unknown')
 
         matching_labels = [
-            label
-            for label in labels
-            if np.all(st_order == self._slice_time_order(label, n_timed))
+            label for label in labels if np.all(st_order == self._slice_time_order(label, n_timed))
         ]
 
         if not matching_labels:

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,12 @@ pass_env =
   USERNAME
   # Environment variables we check for
   NIPY_EXTRA_TESTS
+  # Pass user color preferences through
+  PY_COLORS
+  FORCE_COLOR
+  NO_COLOR
+  CLICOLOR
+  CLICOLOR_FORCE
 extras = test
 deps =
   # General minimum dependencies: pin based on API usage

--- a/tox.ini
+++ b/tox.ini
@@ -139,8 +139,8 @@ deps =
   isort[colors]
 skip_install = true
 commands =
-  blue --diff --color nibabel
-  isort --diff --color nibabel
+  blue --check --diff --color nibabel
+  isort --check --diff --color nibabel
   flake8 nibabel
 
 [testenv:style-fix]


### PR DESCRIPTION
Two small cleanups for the CI run. One is to enable colored tox output for improved readability.

The other is to enable [trusted publishing](https://docs.pypi.org/trusted-publishers/) so that releases from this repository can be uploaded without relying on a maintainer having an active token scoped to the project in the repo secrets. We have a "Package deployment" environment that waits on a maintainer to approve upload.