### PR TITLE
MNT: Apply Repo-Review suggestions

### DIFF
--- a/nibabel/_compression.py
+++ b/nibabel/_compression.py
@@ -17,7 +17,7 @@ import typing as ty
 from .optpkg import optional_package
 
 if ty.TYPE_CHECKING:  # pragma: no cover
-    import indexed_gzip  # type: ignore
+    import indexed_gzip  # type: ignore[import-not-found]
     import pyzstd
 
     HAVE_INDEXED_GZIP = True
@@ -40,7 +40,7 @@ COMPRESSION_ERRORS: tuple[type[BaseException], ...] = (
 if HAVE_INDEXED_GZIP:
     COMPRESSED_FILE_LIKES += (indexed_gzip.IndexedGzipFile,)
     COMPRESSION_ERRORS += (indexed_gzip.ZranError,)
-    from indexed_gzip import IndexedGzipFile  # type: ignore
+    from indexed_gzip import IndexedGzipFile  # type: ignore[import-not-found]
 else:
     IndexedGzipFile = gzip.GzipFile
 

--- a/nibabel/benchmarks/bench_arrayproxy_slicing.py
+++ b/nibabel/benchmarks/bench_arrayproxy_slicing.py
@@ -26,7 +26,7 @@ from .butils import print_git_title
 
 # if memory_profiler is installed, we get memory usage results
 try:
-    from memory_profiler import memory_usage  # type: ignore
+    from memory_profiler import memory_usage  # type: ignore[import-not-found]
 except ImportError:
     memory_usage = None
 

--- a/nibabel/cmdline/dicomfs.py
+++ b/nibabel/cmdline/dicomfs.py
@@ -25,7 +25,7 @@ class dummy_fuse:
 
 
 try:
-    import fuse  # type: ignore
+    import fuse  # type: ignore[import-not-found]
 
     uid = os.getuid()
     gid = os.getgid()

--- a/nibabel/externals/conftest.py
+++ b/nibabel/externals/conftest.py
@@ -6,7 +6,7 @@ except ImportError:  # PY310
     import os
     from contextlib import contextmanager
 
-    @contextmanager  # type: ignore
+    @contextmanager  # type: ignore[no-redef]
     def _chdir(path):
         cwd = os.getcwd()
         os.chdir(path)

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -163,7 +163,7 @@ class Minc2Image(Minc1Image):
     def from_file_map(klass, file_map, *, mmap=True, keep_file_open=None):
         # Import of h5py might take awhile for MPI-enabled builds
         # So we are importing it here "on demand"
-        import h5py  # type: ignore
+        import h5py  # type: ignore[import-not-found]
 
         holder = file_map['image']
         if holder.filename is None:

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1338,7 +1338,7 @@ class PARRECImage(SpatialImage):
             strict_sort=strict_sort,
         )
 
-    load = from_filename  # type: ignore
+    load = from_filename  # type: ignore[assignment]
 
 
 load = PARRECImage.from_filename

--- a/nibabel/pydicom_compat.py
+++ b/nibabel/pydicom_compat.py
@@ -42,7 +42,7 @@ Sequence: type | None = None
 
 if have_dicom:
     # Values not imported by default
-    import pydicom.values  # type: ignore
+    import pydicom.values  # type: ignore[import-not-found]
     from pydicom.dicomio import dcmread as read_file  # noqa:F401
     from pydicom.sequence import Sequence  # noqa:F401
 

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -275,7 +275,7 @@ class Spm99AnalyzeImage(analyze.AnalyzeImage):
             contents = matf.read()
         if len(contents) == 0:
             return ret
-        import scipy.io as sio  # type: ignore
+        import scipy.io as sio  # type: ignore[import-not-found]
 
         mats = sio.loadmat(BytesIO(contents))
         if 'mat' in mats:  # this overrides a 'M', and includes any flip

--- a/nibabel/tmpdirs.py
+++ b/nibabel/tmpdirs.py
@@ -15,7 +15,7 @@ try:
     from contextlib import chdir as _chdir
 except ImportError:  # PY310
 
-    @contextmanager  # type: ignore
+    @contextmanager  # type: ignore[no-redef]
     def _chdir(path):
         cwd = os.getcwd()
         os.chdir(path)

--- a/nibabel/xmlutils.py
+++ b/nibabel/xmlutils.py
@@ -32,7 +32,7 @@ class XmlSerializable:
             Additional keyword arguments to :func:`xml.etree.ElementTree.tostring`.
         """
         ele = self._to_xml_element()
-        return b'' if ele is None else tostring(ele, enc, **kwargs)
+        return tostring(ele, enc, **kwargs)
 
 
 class XmlBasedHeader(FileBasedHeader, XmlSerializable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ __version_tuple__ = version_tuple = {version_tuple!r}
 
 [tool.blue]
 line_length = 99
-target-version = ["py37"]
+target-version = ["py38"]
 force-exclude = """
 (
   _version.py
@@ -130,6 +130,8 @@ python_version = "3.11"
 exclude = [
   "/tests",
 ]
+warn_unreachable = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [tool.codespell]
 skip = "*/data/*,./nibabel-data"


### PR DESCRIPTION
Apply some [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=nipy%2Fnibabel&branch=master) suggestions.

I went for the low-hanging fruits, other changes are more invasive and deserve a PR of their own, such as using a formatter like ruff of black.

Also update minimal Python version for blue. By the way, isn't blue able to understand `requires-python`?

### Fixed issues

* [MY103](https://learn.scientific-python.org/development/guides/style#MY103): MyPy warn unreachable
  Must have `warn_unreachable = true` to pass this check. There are occasionally false positives (often due to platform or Python version static checks), so it's okay to ignore this check. But try it first - it can catch real bugs too.
  ```toml
  [tool.mypy]
  warn_unreachable = true
  ```
* [MY104](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
  Must have `"ignore-without-code"` in `enable_error_code = [...]`. This will force all skips in your project to include the error code, which makes them more readable, and avoids skipping something unintended.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [MY105](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr
  Must have `"redundant-expr"` in `enable_error_code = [...]`. This helps catch useless lines of code, like checking the same condition twice.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [MY106](https://learn.scientific-python.org/development/guides/style#MY106): MyPy enables truthy-bool
 Must have `"truthy-bool"` in `enable_error_code = []`. This catches mistakes in using a value as truthy if it cannot be falsey.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```

### Issues ignored

Left for later because it requires extensive fixes:
* [MY101](https://learn.scientific-python.org/development/guides/style#MY101): MyPy strict mode
  Must have `strict` in the mypy config. MyPy is best with strict or nearly strict configuration. If you are happy with the strictness of your settings already, ignore this check or set `strict = false` explicitly.
  ```toml
  [tool.mypy]
  strict = true
  ```
