### PR TITLE
FIX: Conditionally drop derived volumes from DWI sequences

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "nibabel-data/nitest-dicom"]
 	path = nibabel-data/nitest-dicom
 	url = https://github.com/effigies/nitest-dicom
+[submodule "nibabel-data/dcm_qa_xa30"]
+	path = nibabel-data/dcm_qa_xa30
+	url = https://github.com/neurolabusc/dcm_qa_xa30.git

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -509,11 +509,14 @@ class MultiframeWrapper(Wrapper):
         if hasattr(first_frame, 'get') and first_frame.get([0x18, 0x9117]):
             # DWI image may include derived isotropic, ADC or trace volume
             try:
-                self.frames = pydicom.Sequence(
+                anisotropic = pydicom.Sequence(
                     frame
                     for frame in self.frames
                     if frame.MRDiffusionSequence[0].DiffusionDirectionality != 'ISOTROPIC'
                 )
+                # Image contains DWI volumes followed by derived images; remove derived images
+                if len(anisotropic) != 0:
+                    self.frames = anisotropic
             except IndexError:
                 # Sequence tag is found but missing items!
                 raise WrapperError('Diffusion file missing information')

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -35,6 +35,11 @@ DATA_FILE_4D = pjoin(IO_DATA_PATH, '4d_multiframe_test.dcm')
 DATA_FILE_EMPTY_ST = pjoin(IO_DATA_PATH, 'slicethickness_empty_string.dcm')
 DATA_FILE_4D_DERIVED = pjoin(get_nibabel_data(), 'nitest-dicom', '4d_multiframe_with_derived.dcm')
 DATA_FILE_CT = pjoin(get_nibabel_data(), 'nitest-dicom', 'siemens_ct_header_csa.dcm')
+DATA_FILE_SIEMENS_TRACE = pjoin(
+    get_nibabel_data(),
+    'dcm_qa_xa30',
+    'In/20_DWI_dir80_AP/0001_1.3.12.2.1107.5.2.43.67093.2022071112140611403312307.dcm',
+)
 
 # This affine from our converted image was shown to match our image spatially
 # with an image from SPM DICOM conversion. We checked the matching with SPM
@@ -655,6 +660,13 @@ class TestMultiFrameWrapper(TestCase):
         dw = didw.wrapper_from_file(DATA_FILE_4D_DERIVED)
         with pytest.warns(UserWarning, match='Derived images found and removed'):
             assert dw.image_shape == (96, 96, 60, 33)
+
+    @dicom_test
+    @needs_nibabel_data('dcm_qa_xa30')
+    def test_data_trace(self):
+        # Test that a standalone trace volume is found and not dropped
+        dw = didw.wrapper_from_file(DATA_FILE_SIEMENS_TRACE)
+        assert dw.image_shape == (72, 72, 39, 1)
 
     @dicom_test
     @needs_nibabel_data('nitest-dicom')


### PR DESCRIPTION
#795 cast a wide net, based on Phillips DICOMs that concatenated derived volumes to diffusion series. This causes problems for Siemens sequences where only derived volumes are contained in an image.

This is a pretty minimal fix that changes the rule to "if raw and derived are present, drop derived, otherwise keep whatever we have".

Fixes #1245.