### PR TITLE
RF: Support "flat" ASCII-encoded GIFTI DataArrays

### DIFF
--- a/nibabel/gifti/gifti.py
+++ b/nibabel/gifti/gifti.py
@@ -745,7 +745,7 @@ class GiftiImage(xml.XmlSerializable, SerializableImage):
         >>> triangles_2 = surf_img.agg_data('triangle')
         >>> triangles_3 = surf_img.agg_data(1009)  # Numeric code for pointset
         >>> print(np.array2string(triangles))
-        [0 1 2]
+        [[0 1 2]]
         >>> np.array_equal(triangles, triangles_2)
         True
         >>> np.array_equal(triangles, triangles_3)

--- a/nibabel/gifti/parse_gifti_fast.py
+++ b/nibabel/gifti/parse_gifti_fast.py
@@ -74,6 +74,10 @@ def read_data_block(darray, fname, data, mmap):
         # GIFTI_ENCODING_ASCII
         c = StringIO(data)
         da = np.loadtxt(c, dtype=dtype)
+        # Reshape to dims specified in GiftiDataArray attributes, but preserve
+        # existing behaviour of loading as 1D for arrays with a dimension of
+        # length 1
+        da = da.reshape(darray.dims).squeeze()
         return da  # independent of the endianness
     elif enclabel not in ('B64BIN', 'B64GZ', 'External'):
         return 0

--- a/nibabel/gifti/tests/data/ascii_flat_data.gii
+++ b/nibabel/gifti/tests/data/ascii_flat_data.gii
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE GIFTI SYSTEM "http://www.nitrc.org/frs/download.php/115/gifti.dtd">
+<GIFTI Version="1.0"  NumberOfDataArrays="2">
+   <MetaData>
+      <MD>
+         <Name><![CDATA[Caret-Version]]></Name>
+         <Value><![CDATA[5.512]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[date]]></Name>
+         <Value><![CDATA[Thu Dec 27 14:27:43 2007]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[encoding]]></Name>
+         <Value><![CDATA[XML]]></Value>
+      </MD>
+   </MetaData>
+   <LabelTable/>
+   <DataArray Intent="NIFTI_INTENT_POINTSET"
+              DataType="NIFTI_TYPE_FLOAT32"
+              ArrayIndexingOrder="RowMajorOrder"
+              Dimensionality="2"
+              Dim0="10"
+              Dim1="3"
+              Encoding="ASCII"
+              Endian="LittleEndian"
+              ExternalFileName=""
+              ExternalFileOffset="">
+      <MetaData>
+         <MD>
+            <Name><![CDATA[AnatomicalStructurePrimary]]></Name>
+            <Value><![CDATA[CortexLeft]]></Value>
+         </MD>
+         <MD>
+            <Name><![CDATA[AnatomicalStructureSecondary]]></Name>
+            <Value><![CDATA[Pial]]></Value>
+         </MD>
+         <MD>
+            <Name><![CDATA[GeometricType]]></Name>
+            <Value><![CDATA[Anatomical]]></Value>
+         </MD>
+         <MD>
+            <Name><![CDATA[UniqueID]]></Name>
+            <Value><![CDATA[{70e032e9-4123-47ee-965d-5b29107cbd83}]]></Value>
+         </MD>
+      </MetaData>
+      <CoordinateSystemTransformMatrix>
+         <DataSpace><![CDATA[NIFTI_XFORM_TALAIRACH]]></DataSpace>
+         <TransformedSpace><![CDATA[NIFTI_XFORM_TALAIRACH]]></TransformedSpace>
+         <MatrixData>1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000</MatrixData>
+      </CoordinateSystemTransformMatrix>
+      <Data>155.17539978 135.58103943 98.30715179 140.33973694 190.0491333 73.24776459 157.3598938 196.97969055 83.65809631 171.46174622 137.43661499 78.4709549 148.54592896 97.06752777 65.96373749 123.45701599 111.46841431 66.3571167 135.30892944 202.28720093 36.38148499 178.28155518 162.59469604 37.75128937 178.11087036 115.28820038 57.17986679 142.81582642 82.82115173 31.02205276</Data>
+   </DataArray>
+   <DataArray Intent="NIFTI_INTENT_TRIANGLE"
+              DataType="NIFTI_TYPE_INT32"
+              ArrayIndexingOrder="RowMajorOrder"
+              Dimensionality="2"
+              Dim0="10"
+              Dim1="3"
+              Encoding="ASCII"
+              Endian="LittleEndian"
+              ExternalFileName=""
+              ExternalFileOffset="">
+      <MetaData>
+         <MD>
+            <Name><![CDATA[TopologicalType]]></Name>
+            <Value><![CDATA[CLOSED]]></Value>
+         </MD>
+         <MD>
+            <Name><![CDATA[UniqueID]]></Name>
+            <Value><![CDATA[{747d8015-455b-43ad-82ac-dcfb7606004a}]]></Value>
+         </MD>
+      </MetaData>
+      <Data>6402 17923 25602 14085 25602 17923 25602 14085 4483 17923 1602 14085 4483 25603 25602 25604 25602 25603 25602 25604 6402 25603 3525 25604 1123 17922 12168 25604 12168 17922 </Data>
+   </DataArray>
+</GIFTI>

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -39,9 +39,10 @@ DATA_FILE4 = pjoin(IO_DATA_PATH, 'rh.shape.curv.gii')
 DATA_FILE5 = pjoin(IO_DATA_PATH, 'base64bin.gii')
 DATA_FILE6 = pjoin(IO_DATA_PATH, 'rh.aparc.annot.gii')
 DATA_FILE7 = pjoin(IO_DATA_PATH, 'external.gii')
+DATA_FILE8 = pjoin(IO_DATA_PATH, 'ascii_flat_data.gii')
 
-datafiles = [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4, DATA_FILE5, DATA_FILE6, DATA_FILE7]
-numDA = [2, 1, 1, 1, 2, 1, 2]
+datafiles = [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4, DATA_FILE5, DATA_FILE6, DATA_FILE7, DATA_FILE8]
+numDA = [2, 1, 1, 1, 2, 1, 2, 2]
 
 DATA_FILE1_darr1 = np.array(
     [
@@ -151,6 +152,10 @@ DATA_FILE7_darr2 = np.array(
     ],
     dtype=np.int32,
 )
+
+DATA_FILE8_darr1 = np.copy(DATA_FILE5_darr1)
+
+DATA_FILE8_darr2 = np.copy(DATA_FILE5_darr2)
 
 
 def assert_default_types(loaded):
@@ -448,3 +453,9 @@ def test_load_compressed():
         img7 = load(fn)
         assert_array_almost_equal(img7.darrays[0].data, DATA_FILE7_darr1)
         assert_array_almost_equal(img7.darrays[1].data, DATA_FILE7_darr2)
+
+
+def test_load_flat_ascii_data():
+    img = load(DATA_FILE8)
+    assert_array_almost_equal(img.darrays[0].data, DATA_FILE8_darr1)
+    assert_array_almost_equal(img.darrays[1].data, DATA_FILE8_darr2)

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -41,7 +41,16 @@ DATA_FILE6 = pjoin(IO_DATA_PATH, 'rh.aparc.annot.gii')
 DATA_FILE7 = pjoin(IO_DATA_PATH, 'external.gii')
 DATA_FILE8 = pjoin(IO_DATA_PATH, 'ascii_flat_data.gii')
 
-datafiles = [DATA_FILE1, DATA_FILE2, DATA_FILE3, DATA_FILE4, DATA_FILE5, DATA_FILE6, DATA_FILE7, DATA_FILE8]
+datafiles = [
+    DATA_FILE1,
+    DATA_FILE2,
+    DATA_FILE3,
+    DATA_FILE4,
+    DATA_FILE5,
+    DATA_FILE6,
+    DATA_FILE7,
+    DATA_FILE8,
+]
 numDA = [2, 1, 1, 1, 2, 1, 2, 2]
 
 DATA_FILE1_darr1 = np.array(
@@ -51,7 +60,7 @@ DATA_FILE1_darr1 = np.array(
         [-17.614349, -65.401642, 21.071466],
     ]
 )
-DATA_FILE1_darr2 = np.array([0, 1, 2])
+DATA_FILE1_darr2 = np.array([[0, 1, 2]])
 
 DATA_FILE2_darr1 = np.array(
     [


### PR DESCRIPTION
Hi @effigies I hope you're well!

I had a report from a FSLeyes user who has used a [MATLAB GIfTI library](https://github.com/gllmflndn/gifti) to generate some `.gii` files that were failing to load in FSLeyes. The GIfTI files that this library generates are ASCII-encoded, but without any newlines to separate elements along the first dimension, e.g.. instead of the conventional:

```xml
<DataArray Dimensionality="2"
           Dim0="3"
           Dim1="3"
           Encoding="ASCII">
  <Data>155.17539978 135.58103943 98.30715179
        140.33973694 190.0491333  73.24776459
        157.3598938  196.97969055 83.65809631
  </Data>
</DataArray>
```
these files instead contain
```xml
<DataArray Dimensionality="2"
           Dim0="3"
           Dim1="3"
           Encoding="ASCII">
  <Data>155.17539978 135.58103943 98.30715179 140.33973694 190.0491333 73.24776459 157.3598938 196.97969055 83.65809631</Data>
</DataArray>
```

Once again, the GIfTI specification is light on details as to the expected format of ASCII-encoded data arrays - all it says is (from Section *2.3.4.5 Encoding*):
 
> The Data element contains ASCII text with each value separated by whitespace

But every ASCII-encoded GIfTI file I've encountered has contained newlines to separate elements along the first dimension.

In any case, when using nibabel to load such a file (e.g. the `ascii_flat_data.gii` test file in this PR), the loaded data arrays are one dimensional, e.g.:

```python
import nibabel as nib
img = nib.load('ascii_flat_data.gii')
print('Expected shape:', img.darrays[0].dims)
print('Actual shape:  ', img.darrays[0].data.shape)
```
```
>> Expected shape: [10, 3]
>> Actual shape:   (30,)
```

It turns out that, for non-ASCII-encoded data arrays, the `nibabel.gifit.parse_gifti_fast.read_data_block` function [will ensure](https://github.com/nipy/nibabel/blob/27c24272661be944598eb93a9f278f7fa0fd0022/nibabel/gifti/parse_gifti_fast.py#L135-L137) that the loaded array has the shape specified in the `DataArray` attributes. But [this is not the case](https://github.com/nipy/nibabel/blob/27c24272661be944598eb93a9f278f7fa0fd0022/nibabel/gifti/parse_gifti_fast.py#L73-L77)  for ASCII-encoded arrays.

This PR contains a small patch which ensures that ASCII-encoded arrays are reshaped to the expected dimensionality. 

There is a slight complexity in that [one of the existing unit tests](https://github.com/nipy/nibabel/blob/27c24272661be944598eb93a9f278f7fa0fd0022/nibabel/gifti/tests/test_parse_gifti_fast.py#L53) is expecting the result to be 1D when loading a file [that contains an array of shape `(1, 3)`](https://github.com/nipy/nibabel/blob/27c24272661be944598eb93a9f278f7fa0fd0022/nibabel/gifti/tests/data/ascii.gii#L66-L68). 

I added the `.squeeze()` call in to preserve this behaviour, but I'm not sure whether a better option is to always return the shape specified in the `DataArray` attributes. I'm not sure how widely used ASCII-encoded GIFTIs, so am unsure of the potential impact of such a change. It's obviously unlikely that one would encounter a `POINTSET` or `TRIANGLE` array with a dimension of length 1, but it could occur with `SHAPE` or `TIMESERIES` arrays.