### PR TITLE
ENH: Improve text for dicomwrapper errors in shape calculation

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -565,8 +565,11 @@ class MultiframeWrapper(Wrapper):
         ns_unique = [len(np.unique(row)) for row in self._frame_indices.T]
         shape = (rows, cols) + tuple(ns_unique)
         n_vols = np.prod(shape[3:])
-        if n_frames != n_vols * shape[2]:
-            raise WrapperError('Calculated shape does not match number of frames.')
+        n_frames_calc = n_vols * shape[2]
+        if n_frames != n_frames_calc:
+            raise WrapperError(
+                f'Calculated # of frames ({n_frames_calc}={n_vols}*{shape[2]}) of shape {shape} does not '
+                f'match NumberOfFrames {n_frames}.')
         return tuple(shape)
 
     @one_time

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -568,8 +568,9 @@ class MultiframeWrapper(Wrapper):
         n_frames_calc = n_vols * shape[2]
         if n_frames != n_frames_calc:
             raise WrapperError(
-                f'Calculated # of frames ({n_frames_calc}={n_vols}*{shape[2]}) of shape {shape} does not '
-                f'match NumberOfFrames {n_frames}.')
+                f'Calculated # of frames ({n_frames_calc}={n_vols}*{shape[2]}) '
+                f'of shape {shape} does not match NumberOfFrames {n_frames}.'
+            )
         return tuple(shape)
 
     @one_time


### PR DESCRIPTION
To make https://github.com/nipy/nibabel/issues/1211 more informative.

In the particular case at hand of [http://github.com/neurolabusc/dcm_qa_fmap](https://github.com/neurolabusc/dcm_qa_fmap)  IM_0027_fMAP.dcm we get 

```
nibabel.nicom.dicomwrappers.WrapperError: Calculated # of frames (128=4*32) of shape (64, 64, 32, 2, 2) does not match NumberOfFrames 64.
```

and my wild uneducated guess is that we need to filter out few more of those entries from frame_indices where we have 

```
> p dim_seq
[(0020, 9057), (2005, 106e), (2005, 1011)]
```

where only the first one "known" to pydicom's dictionary, and the other two something are likely something to filter out...
@neurolabusc -- what do you remember about that  `IM_0027_fMAP.dcm` or may be these particular DICOM tags?