### PR TITLE
FIX: Use np.asarray instead of np.array(..., copy=False)

### DIFF
--- a/nibabel/affines.py
+++ b/nibabel/affines.py
@@ -365,7 +365,7 @@ def rescale_affine(affine, shape, zooms, new_shape=None):
         A new affine transform with the specified voxel sizes
 
     """
-    shape = np.array(shape, copy=False)
+    shape = np.asarray(shape)
     new_shape = np.array(new_shape if new_shape is not None else shape)
 
     s = voxel_sizes(affine)

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -611,7 +611,7 @@ def int_abs(arr):
     >>> int_abs(np.array([-128, 127], dtype=np.float32))
     array([128., 127.], dtype=float32)
     """
-    arr = np.array(arr, copy=False)
+    arr = np.asarray(arr)
     dt = arr.dtype
     if dt.kind == 'u':
         return arr


### PR DESCRIPTION
Numpy 2 is changing `np.array(..., copy=False)` to error if the array cannot be made without copying. The semantics we want are `np.asarray(...)`, which will not make copies if the input is already an `ndarray`.

cc @larsoner