### PR TITLE
Filter upstream warning raised by `np.finfo(np.longdouble)` on WSL1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -391,6 +391,11 @@
     },
     {
       "name": "freec84"
+    },
+    {
+      "affiliation": "Polytechnique Montréal, Montréal, CA",
+      "name": "Newton, Joshua",
+      "orcid": "0009-0005-6963-3812"
     }
   ],
   "keywords": [

--- a/nibabel/casting.py
+++ b/nibabel/casting.py
@@ -6,7 +6,7 @@ casting.  Others work round numpy casting to and from python ints
 from __future__ import annotations
 
 import warnings
-from platform import machine, processor, uname
+from platform import machine, processor
 
 import numpy as np
 
@@ -275,12 +275,10 @@ def type_info(np_type):
             width=width,
         )
     # Mitigate warning from WSL1 when checking `np.longdouble` (#1309)
-    # src for '-Microsoft': https://github.com/microsoft/WSL/issues/4555#issuecomment-536862561
     with warnings.catch_warnings():
-        if uname().release.endswith('-Microsoft'):
-            warnings.filterwarnings(
-                action='ignore', category=UserWarning, message='Signature.*numpy.longdouble'
-            )
+        warnings.filterwarnings(
+            action='ignore', category=UserWarning, message='Signature.*numpy.longdouble'
+        )
         info = np.finfo(dt)
 
     # Trust the standard IEEE types


### PR DESCRIPTION
## Description

This PR filters an upstream warning regarding broken support for `np.longdouble`, raised by `np.finfo(np.longdouble)` when `numpy>=1.25` is used on WSL1.

>```
> UserWarning: Signature b'\x00\xd0\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf\x00\x00\x00\x00\x00\x00' for
> <class 'numpy.longdouble'> does not match any known type: falling back to type probe function.
> This warnings indicates broken support for the dtype!
>  machar = _get_machar(dtype)
>```

NB: The context in which `type_info` is called on `np.longdouble` is here:

https://github.com/nipy/nibabel/blob/0e925abb15e2dfbeecaaca4e7c2479b9d3e2cec0/nibabel/casting.py#L664-L670

https://github.com/nipy/nibabel/blob/0e925abb15e2dfbeecaaca4e7c2479b9d3e2cec0/nibabel/casting.py#L685

Given that `nibabel` already tries to avoid `np.longdouble` on Windows, I think it should be fine to filter this warning?

Notes:

- ~I've tried to detect WSL1 to avoid filtering warnings for any other platforms -- I wanted this to be as minimal a change as is necessary. But, maybe checking `uname` is a bit overkill. :sweat_smile:~ EDIT: Removed.
- I've tested that the filter works for our downstream package here: https://github.com/spinalcordtoolbox/spinalcordtoolbox/compare/master...jn/4411-test-upstream-nibabel-pr-np.longdouble
    - Before: https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/8399514483/job/23005708102#step:9:474
   - After: https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/8399514483/job/23011239904#step:9:474
- I've run the style checks, too. :)

## Related issues/PRs

Fixes #1309.