### PR TITLE
WIP: generalize class for opening image

### DIFF
--- a/nibabel/fileholders.py
+++ b/nibabel/fileholders.py
@@ -23,6 +23,9 @@ class FileHolderError(Exception):
 class FileHolder:
     """class to contain filename, fileobj and file position"""
 
+    # Default image opener class / callable
+    make_image_opener = ImageOpener
+
     def __init__(
         self,
         filename: str | None = None,
@@ -68,10 +71,11 @@ class FileHolder:
            ``self.pos``
         """
         if self.fileobj is not None:
-            obj = ImageOpener(self.fileobj)  # for context manager
+            # for context manager
+            obj = self.make_image_opener(self.fileobj)
             obj.seek(self.pos)
         elif self.filename is not None:
-            obj = ImageOpener(self.filename, *args, **kwargs)
+            obj = self.make_image_opener(self.filename, *args, **kwargs)
             if self.pos != 0:
                 obj.seek(self.pos)
         else:


### PR DESCRIPTION
Allow FileHolder subclasses to change the ImageOpener class.

I wanted to do this to work with the `fsspec` file objects.

But - I couldn't see immediately what the right way to do the type checking is
- I was considering using OpenDef from `openers.py`, but that is only defined
if `ty.TYPE_CHECKING` is True.  I'd love some advice!