### PR TITLE
Python 3.13: Account for dedented docstrings

### DIFF
--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -3,14 +3,25 @@ from __future__ import annotations
 
 import functools
 import re
+import sys
 import typing as ty
 import warnings
+from textwrap import dedent
 
 if ty.TYPE_CHECKING:  # pragma: no cover
     T = ty.TypeVar('T')
     P = ty.ParamSpec('P')
 
 _LEADING_WHITE = re.compile(r'^(\s*)')
+
+
+def _dedent_docstring(docstring):
+    """Compatibility with Python 3.13+.
+
+    xref: https://github.com/python/cpython/issues/81283
+    """
+    return '\n'.join([dedent(line) for line in docstring.split('\n')])
+
 
 TESTSETUP = """
 
@@ -31,6 +42,10 @@ TESTCLEANUP = """
     >>> _ = _suppress_warnings.__exit__(None, None, None)
 
 """
+
+if sys.version_info >= (3, 13):
+    TESTSETUP = _dedent_docstring(TESTSETUP)
+    TESTCLEANUP = _dedent_docstring(TESTCLEANUP)
 
 
 class ExpiredDeprecationError(RuntimeError):

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -14,12 +14,21 @@ from nibabel.deprecator import (
     Deprecator,
     ExpiredDeprecationError,
     _add_dep_doc,
+    _dedent_docstring,
     _ensure_cr,
 )
 
 from ..testing import clear_and_catch_warnings
 
 _OWN_MODULE = sys.modules[__name__]
+
+func_docstring = (
+    f'A docstring\n   \n   foo\n   \n{indent(TESTSETUP, "   ", lambda x: True)}'
+    f'   Some text\n{indent(TESTCLEANUP, "   ", lambda x: True)}'
+)
+
+if sys.version_info >= (3, 13):
+    func_docstring = _dedent_docstring(func_docstring)
 
 
 def test__ensure_cr():
@@ -92,11 +101,7 @@ class TestDeprecatorFunc:
         with pytest.deprecated_call() as w:
             assert func(1, 2) is None
             assert len(w) == 1
-        assert (
-            func.__doc__
-            == f'A docstring\n   \n   foo\n   \n{indent(TESTSETUP, "   ", lambda x: True)}'
-            f'   Some text\n{indent(TESTCLEANUP, "   ", lambda x: True)}'
-        )
+        assert func.__doc__ == func_docstring
 
         # Try some since and until versions
         func = dec('foo', '1.1')(func_no_doc)


### PR DESCRIPTION
- Dedent docstrings in Python 3.13+
- Fix #1311
- Ref: https://github.com/python/cpython/issues/81283
