### PR TITLE
DOC: Update instructions for building docs

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -3,7 +3,7 @@ Nibabel documentation
 #####################
 
 To build the documentation, change to the root directory (containing
-``setup.py``) and run::
+``pyproject.toml``) and run::
 
     pip install -r doc-requirements.txt
     make -C doc html

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -6,4 +6,4 @@ To build the documentation, change to the root directory (containing
 ``setup.py``) and run::
 
     pip install -r doc-requirements.txt
-    make html
+    make -C doc html


### PR DESCRIPTION
The top level `Makefile` is outdated. This circumvents its use.
