### PR TITLE
STY: Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/nibabel/streamlines/__init__.py
+++ b/nibabel/streamlines/__init__.py
@@ -131,7 +131,7 @@ def save(tractogram, filename, **kwargs):
             warnings.warn(msg, ExtensionWarning)
 
         if kwargs:
-            msg = "A 'TractogramFile' object was provided, no need for" ' keyword arguments.'
+            msg = "A 'TractogramFile' object was provided, no need for keyword arguments."
             raise ValueError(msg)
 
     tractogram_file.save(filename)

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -441,7 +441,7 @@ def array_from_file(
     True
     """
     if mmap not in (True, False, 'c', 'r', 'r+'):
-        raise ValueError("mmap value should be one of True, False, 'c', " "'r', 'r+'")
+        raise ValueError("mmap value should be one of True, False, 'c', 'r', 'r+'")
     in_dtype = np.dtype(in_dtype)
     # Get file-like object from Opener instance
     infile = getattr(infile, 'fobj', infile)


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter:
	https://github.com/astral-sh/ruff/issues/8272