### PR TITLE
ENH: Add Nifti2 capabilities to nib-nifti-dx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: v0.3.4
     hooks:
       - id: ruff
-        args: [--fix, --show-fix, --exit-non-zero-on-fix]
+        args: [--fix, --show-fixes, --exit-non-zero-on-fix]
         exclude: = ["doc", "tools"]
       - id: ruff-format
         exclude: = ["doc", "tools"]

--- a/nibabel/cmdline/nifti_dx.py
+++ b/nibabel/cmdline/nifti_dx.py
@@ -9,8 +9,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Print nifti diagnostics for header files"""
 
-import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 import nibabel as nib
 
@@ -21,15 +20,27 @@ __license__ = 'MIT'
 
 def main(args=None):
     """Go go team"""
-    parser = OptionParser(
-        usage=f'{sys.argv[0]} [FILE ...]\n\n' + __doc__, version='%prog ' + nib.__version__
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('--version', action='version', version=f'%(prog)s {nib.__version__}')
+    parser.add_argument(
+        '-1',
+        '--nifti1',
+        dest='header_class',
+        action='store_const',
+        const=nib.Nifti1Header,
+        default=nib.Nifti1Header,
     )
-    (opts, files) = parser.parse_args(args=args)
+    parser.add_argument(
+        '-2', '--nifti2', dest='header_class', action='store_const', const=nib.Nifti2Header
+    )
+    parser.add_argument('files', nargs='*', metavar='FILE', help='Nifti file names')
 
-    for fname in files:
+    args = parser.parse_args(args=args)
+
+    for fname in args.files:
         with nib.openers.ImageOpener(fname) as fobj:
-            hdr = fobj.read(nib.nifti1.header_dtype.itemsize)
-        result = nib.Nifti1Header.diagnose_binaryblock(hdr)
+            hdr = fobj.read(args.header_class.template_dtype.itemsize)
+        result = args.header_class.diagnose_binaryblock(hdr)
         if len(result):
             print(f'Picky header check output for "{fname}"\n')
             print(result + '\n')

--- a/nibabel/tests/test_scripts.py
+++ b/nibabel/tests/test_scripts.py
@@ -202,7 +202,7 @@ def test_help():
         code, stdout, stderr = run_command([cmd, '--help'])
         assert code == 0
         assert_re_in(f'.*{cmd}', stdout)
-        assert_re_in('.*Usage', stdout)
+        assert_re_in('.*[uU]sage', stdout)
         # Some third party modules might like to announce some Deprecation
         # etc warnings, see e.g. https://travis-ci.org/nipy/nibabel/jobs/370353602
         if 'warning' not in stderr.lower():


### PR DESCRIPTION
Was having trouble understanding why some NIfTIs were behaving weirdly, when I realized they were NIfTI-2.

Could spend a little more time adding auto-detection, but for right now being able to toggle 1/2 is enough for me. Still defaults to 1.