### PR TITLE
Replace deprecated setup() and teardown()

### DIFF
--- a/nibabel/streamlines/tests/test_streamlines.py
+++ b/nibabel/streamlines/tests/test_streamlines.py
@@ -20,7 +20,7 @@ from .test_tractogram import assert_tractogram_equal
 DATA = {}
 
 
-def setup():
+def setup_module():
     global DATA
     DATA['empty_filenames'] = [pjoin(data_path, 'empty' + ext) for ext in FORMATS.keys()]
     DATA['simple_filenames'] = [pjoin(data_path, 'simple' + ext) for ext in FORMATS.keys()]

--- a/nibabel/tests/test_deprecated.py
+++ b/nibabel/tests/test_deprecated.py
@@ -14,12 +14,12 @@ from nibabel.deprecated import (
 from nibabel.tests.test_deprecator import TestDeprecatorFunc as _TestDF
 
 
-def setup():
+def setup_module():
     # Hack nibabel version string
     pkg_info.cmp_pkg_version.__defaults__ = ('2.0',)
 
 
-def teardown():
+def teardown_module():
     # Hack nibabel version string back again
     pkg_info.cmp_pkg_version.__defaults__ = (pkg_info.__version__,)
 

--- a/nibabel/tests/test_dft.py
+++ b/nibabel/tests/test_dft.py
@@ -26,7 +26,7 @@ PImage, have_pil, _ = optional_package('PIL.Image')
 data_dir = pjoin(dirname(__file__), 'data')
 
 
-def setUpModule():
+def setup_module():
     if os.name == 'nt':
         raise unittest.SkipTest('FUSE not available for windows, skipping dft tests')
     if not have_dicom:


### PR DESCRIPTION
Those were compatibility functions for porting from nose. They are now
deprecated and have been removed from pytest.

This will make all tests compatible with pytests 8.x.