### PR TITLE
RF: Prefer using `getlocale()` instead of `getdefaultlocale()`

### DIFF
--- a/nibabel/cmdline/dicomfs.py
+++ b/nibabel/cmdline/dicomfs.py
@@ -37,7 +37,7 @@ from optparse import Option, OptionParser
 import nibabel as nib
 import nibabel.dft as dft
 
-encoding = locale.getdefaultlocale()[1]
+encoding = locale.getlocale()[1]
 
 fuse.fuse_python_api = (0, 2)
 


### PR DESCRIPTION
Prefer using `getlocale()` instead of `getdefaultlocale()`.

Fixes:
```
/home/runner/work/nibabel/nibabel/nibabel/cmdline/dicomfs.py:40:
 DeprecationWarning: 'locale.getdefaultlocale' is deprecated and
 slated for removal in Python 3.15. Use setlocale(), getencoding()
 and getlocale() instead.
      encoding = locale.getdefaultlocale()[1]
```

raised for example at:
https://github.com/nipy/nibabel/actions/runs/9637811213/job/26577586721#step:7:164