### PR TITLE
RF: Prefer using `np.vstack` instead of `np.row_stack`

### DIFF
--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -391,7 +391,7 @@ class AFNIHeader(SpatialHeader):
         # AFNI default is RAI- == LPS+ == DICOM order.  We need to flip RA sign
         # to align with nibabel RAS+ system
         affine = np.asarray(self.info['IJK_TO_DICOM_REAL']).reshape(3, 4)
-        affine = np.row_stack((affine * [[-1], [-1], [1]], [0, 0, 0, 1]))
+        affine = np.vstack((affine * [[-1], [-1], [1]], [0, 0, 0, 1]))
         return affine
 
     def get_data_scaling(self):

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -390,7 +390,7 @@ def read_mlist(fileobj, endianness):
         mlist_index += n_rows
         if mlist_block_no <= 2:  # should block_no in (1, 2) be an error?
             break
-    return np.row_stack(mlists)
+    return np.vstack(mlists)
 
 
 def get_frame_order(mlist):


### PR DESCRIPTION
Prefer using `np.vstack` instead of `np.row_stack`.

Fixes:
```
nibabel/ecat.py: 3 warnings
  /home/runner/work/nibabel/nibabel/nibabel/ecat.py:393:
 DeprecationWarning: `row_stack` alias is deprecated. Use `np.vstack` directly.
    return np.row_stack(mlists)
```

and similar warnings.

Raised for example at:
https://github.com/nipy/nibabel/actions/runs/9637811213/job/26577586721#step:7:186

Documentation:
https://numpy.org/doc/1.26/reference/generated/numpy.row_stack.html

This helps preparing for full Numpy 2.0 compatibility. Documentation: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace