### PR TITLE
RF: Fix `ast` library type and attribute deprecation warnings

### DIFF
--- a/nibabel/nicom/ascconv.py
+++ b/nibabel/nicom/ascconv.py
@@ -91,7 +91,7 @@ def assign2atoms(assign_ast, default_class=int):
             prev_target_type = OrderedDict
         elif isinstance(target, ast.Subscript):
             if isinstance(target.slice, ast.Constant):  # PY39
-                index = target.slice.n
+                index = target.slice.value
             else:  # PY38
                 index = target.slice.value.n
             atoms.append(Atom(target, prev_target_type, index))
@@ -174,12 +174,10 @@ def obj_from_atoms(atoms, namespace):
 
 def _get_value(assign):
     value = assign.value
-    if isinstance(value, ast.Num):
-        return value.n
-    if isinstance(value, ast.Str):
-        return value.s
+    if isinstance(value, ast.Constant):
+        return value.value
     if isinstance(value, ast.UnaryOp) and isinstance(value.op, ast.USub):
-        return -value.operand.n
+        return -value.operand.value
     raise AscconvParseError(f'Unexpected RHS of assignment: {value}')
 
 


### PR DESCRIPTION
Fix `ast` library type and attribute deprecation warnings.

Fixes:
```
/home/runner/work/nibabel/nibabel/nibabel/nicom/ascconv.py:177:
 DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
  if isinstance(value, ast.Num):

/home/runner/work/nibabel/nibabel/nibabel/nicom/ascconv.py:179:
 DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
  if isinstance(value, ast.Str):

/home/runner/work/nibabel/nibabel/nibabel/nicom/ascconv.py:180:
 DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
  return value.s

/home/runner/work/nibabel/nibabel/nibabel/nicom/ascconv.py:94:
 DeprecationWarning: Attribute n is deprecated and will be removed in Python 3.14; use value instead
  index = target.slice.n

/home/runner/work/nibabel/nibabel/nibabel/nicom/ascconv.py:182:
 DeprecationWarning: Attribute n is deprecated and will be removed in Python 3.14; use value instead
  return -value.operand.n
```

raised for example in:
https://github.com/nipy/nibabel/actions/runs/9637811213/job/26577586721#step:7:207

Documentation:
https://docs.python.org/3/library/ast.html