### PR TITLE
CI: Add 3.13-nogil build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Show tox config
         run: tox c
       - name: Run tox
-        run: tox -v --exit-and-dump-after 1200
+        run: tox -vv --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,9 +125,9 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             dependencies: 'min'
-          # NumPy 2.0
+          # NoGIL
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.13-dev'
             dependencies: 'dev'
         exclude:
           # x86 for Windows + Python<3.12
@@ -168,11 +168,18 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
+        if: "!endsWith(matrix.python-version, '-dev')"
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
           allow-prereleases: true
+      - name: Set up Python ${{ matrix.python-version }}
+        if: endsWith(matrix.python-version, '-dev')
+        uses: deadsnakes/action@v3.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          nogil: true
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install tox

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,8 @@ description = Pytest with coverage
 labels = test
 install_command =
   python -I -m pip install -v \
-  --only-binary numpy,scipy,h5py,pillow,matplotlib \
+  dev: --only-binary numpy,scipy,h5py \
+  !dev: --only-binary numpy,scipy,h5py,pillow,matplotlib \
   pre,dev: --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
     {opts} {packages}
 pip_pre =
@@ -90,15 +91,15 @@ deps =
   # Numpy 2.0 is a major breaking release; we cannot put much effort into
   # supporting until it's at least RC stable
   pre: numpy <2.0.dev0
-  dev: numpy >=2.0.dev0
+  dev: numpy >=2.1.dev0
   # Scipy stopped producing win32 wheels at py310
   py3{8,9}-full-x86,x64,arm64: scipy >=1.6
   # Matplotlib depends on scipy, so cannot be built for py310 on x86
   py3{8,9}-full-x86,x64,arm64: matplotlib >=3.4
   # h5py stopped producing win32 wheels at py39
-  py38-full-x86,x64,arm64: h5py >=2.10
+  py38-full-x86,{full,pre}-{x64,arm64}: h5py >=2.10
   full,pre,dev: pillow >=8.1
-  full,pre,dev: indexed_gzip >=1.4
+  full,pre: indexed_gzip >=1.4
   full,pre,dev: pyzstd >=0.14.3
   full,pre: pydicom >=2.1
   dev: pydicom @ git+https://github.com/pydicom/pydicom.git@main

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
   # x64-only range
   py312-{full,pre}-x64
   # Special environment for numpy 2.0-dev testing
-  py312-dev-x64
+  py313-dev-x64
   install
   doctest
   style
@@ -31,6 +31,7 @@ python =
   3.10: py310
   3.11: py311
   3.12: py312
+  3.13: py313
 
 [gh-actions:env]
 DEPENDS =

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,8 @@ pass_env =
   NO_COLOR
   CLICOLOR
   CLICOLOR_FORCE
+set_env =
+  py313: PYTHON_GIL=0
 extras = test
 deps =
   # General minimum dependencies: pin based on API usage


### PR DESCRIPTION
Closes #1322.

This initial job installs and tests:

* [x] numpy (nightly wheel)
* [x] scipy (nightly wheel)
* [x] pillow (sdist; no cp313t wheel issue/PR to link)
* [x] matplotlib (sdist, pending https://github.com/matplotlib/matplotlib/pull/28293)
* [x] pyzstd (sdist)
* [x] pydicom (git)

We do not currently test:

* [ ] h5py (pending https://github.com/h5py/h5py/pull/2449)
* [ ] indexed_gzip