### PR TITLE
Bunch of multiframe fixes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,33 @@ Eric Larson (EL), Demian Wassermann, Stephan Gerhard and Ross Markello (RM).
 
 References like "pr/298" refer to github pull request numbers.
 
+Upcoming release (To be determined)
+===================================
+
+New features
+------------
+
+Enhancements
+------------
+ * Ability to read data from many multiframe DICOM files that previously generated errors
+
+Bug fixes
+---------
+ * Fixed multiframe DICOM issue where data could be flipped along slice dimension relative to the
+   affine
+ * Fixed multiframe DICOM issue where ``image_position`` and the translation component in the
+   ``affine`` could be incorrect
+
+Documentation
+-------------
+
+Maintenance
+-----------
+
+API changes and deprecations
+----------------------------
+
+
 5.2.1 (Monday 26 February 2024)
 ===============================
 

--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -581,11 +581,10 @@ class MultiframeWrapper(Wrapper):
         frames_per_part = 1
         del_indices = {}
         for row_idx, row in enumerate(frame_indices.T):
-            if curr_parts == 1:
-                break
             unique = np.unique(row)
             count = len(unique)
-            if count == 1:
+            if count == 1 or curr_parts == 1:
+                del_indices[row_idx] = count
                 continue
             # Replace slice indices with order determined from slice positions along normal
             if len(shape) == 2:

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -488,10 +488,13 @@ def fake_shape_dependents(
         assert len(ipp_seq) == num_of_frames
     # create the DimensionIndexSequence
     dim_idx_seq = [DimIdxSeqElem()] * n_indices
+    # Add entry for InStackPositionNumber to DimensionIndexSequence
+    fcs_tag = pydicom.datadict.tag_for_keyword('FrameContentSequence')
+    isp_tag = pydicom.datadict.tag_for_keyword('InStackPositionNumber')
+    dim_idx_seq[slice_dim] = DimIdxSeqElem(isp_tag, fcs_tag)
     # add an entry for StackID into the DimensionIndexSequence
     if sid_dim is not None:
         sid_tag = pydicom.datadict.tag_for_keyword('StackID')
-        fcs_tag = pydicom.datadict.tag_for_keyword('FrameContentSequence')
         dim_idx_seq[sid_dim] = DimIdxSeqElem(sid_tag, fcs_tag)
     # create the PerFrameFunctionalGroupsSequence
     frames = [
@@ -546,6 +549,10 @@ class TestMultiFrameWrapper(TestCase):
         div_seq = ((1, 1, 2),)
         fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
         assert MFW(fake_mf).image_shape == (32, 64)
+        # Check 2D plus time
+        div_seq = ((1, 1, 1), (1, 1, 2), (1, 1, 3))
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
+        assert MFW(fake_mf).image_shape == (32, 64, 1, 3)
         # Check 3D shape when StackID index is 0
         div_seq = ((1, 1), (1, 2), (1, 3), (1, 4))
         fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -626,6 +626,35 @@ class TestMultiFrameWrapper(TestCase):
         )
         fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
         assert MFW(fake_mf).image_shape == (32, 64, 2, 3)
+        # Test invalid 4D indices
+        div_seq = ((1, 1, 1), (1, 2, 1), (1, 1, 2), (1, 2, 2), (1, 1, 3), (1, 2, 4))
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
+        with pytest.raises(didw.WrapperError):
+            MFW(fake_mf).image_shape
+        div_seq = ((1, 1, 1), (1, 2, 1), (1, 1, 2), (1, 2, 2), (1, 1, 3), (1, 2, 2))
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
+        with pytest.raises(didw.WrapperError):
+            MFW(fake_mf).image_shape
+        # Time index that is unique to each frame
+        div_seq = ((1, 1, 1), (1, 2, 2), (1, 1, 3), (1, 2, 4), (1, 1, 5), (1, 2, 6))
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
+        assert MFW(fake_mf).image_shape == (32, 64, 2, 3)
+        div_seq = (
+            (1, 1, 1, 1),
+            (1, 2, 2, 1),
+            (1, 1, 3, 1),
+            (1, 2, 4, 1),
+            (1, 1, 5, 1),
+            (1, 2, 6, 1),
+            (1, 1, 7, 2),
+            (1, 2, 8, 2),
+            (1, 1, 9, 2),
+            (1, 2, 10, 2),
+            (1, 1, 11, 2),
+            (1, 2, 12, 2),
+        )
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0))
+        assert MFW(fake_mf).image_shape == (32, 64, 2, 3, 2)
 
     def test_iop(self):
         # Test Image orient patient for multiframe

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -388,7 +388,7 @@ def fake_frames(seq_name, field_name, value_seq, frame_seq=None):
     class Fake:
         pass
 
-    if frame_seq == None:
+    if frame_seq is None:
         frame_seq = [Fake() for _ in range(len(value_seq))]
     for value, fake_frame in zip(value_seq, frame_seq):
         fake_element = Fake()
@@ -866,6 +866,11 @@ class TestMultiFrameWrapper(TestCase):
         dim_idxs = ((1, 4), (1, 2), (1, 3), (1, 1))
         fake_mf.update(fake_shape_dependents(dim_idxs, sid_dim=0))
         sorted_data = data[..., [3, 1, 2, 0]]
+        fake_mf['pixel_array'] = np.rollaxis(sorted_data, 2)
+        assert_array_equal(MFW(fake_mf).get_data(), data * 2.0 - 1)
+        # Check slice sorting with negative index / IPP correlation
+        fake_mf.update(fake_shape_dependents(dim_idxs, sid_dim=0, flip_ipp_idx_corr=True))
+        sorted_data = data[..., [0, 2, 1, 3]]
         fake_mf['pixel_array'] = np.rollaxis(sorted_data, 2)
         assert_array_equal(MFW(fake_mf).get_data(), data * 2.0 - 1)
         # 5D!


### PR DESCRIPTION
This fixes a bunch of issues with multiframe DICOM.

Instead of assuming the slice index is correct for ordering slices along the normal direction, I compute the slice location from the ImagePositionPatient for each frame and use that.  This avoids slice orientation flips. I also use the ImagePositionPatient value with the minimum slice location as the `image_position` property, instead of just using the one from the first frame.

Any DimensionIndexValues that don't help to sort the data are ignored, and at the end (if needed) we try combine these into a single tuple index. This approach allows the code to work with a number of real world data sets that previously caused errors.