### PR TITLE
RF: Replace OneTimeProperty/auto_attr with cached_property

### DIFF
--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -9,7 +9,7 @@ import re
 import sys
 
 # version comparison
-from distutils.version import LooseVersion as V
+from packaging.version import Version as V
 from os.path import join as pjoin
 
 # local imports
@@ -73,6 +73,8 @@ if __name__ == '__main__':
                 if re.match('^_version_(major|minor|micro|extra)', v)
             ]
         )
+
+    source_version = V(source_version)
     print('***', source_version)
 
     if source_version != installed_version:

--- a/nibabel/onetime.py
+++ b/nibabel/onetime.py
@@ -1,9 +1,12 @@
 """Descriptor support for NIPY
 
-Utilities to support special Python descriptors [1,2], in particular the use of
-a useful pattern for properties we call 'one time properties'.  These are
-object attributes which are declared as properties, but become regular
-attributes once they've been read the first time.  They can thus be evaluated
+Utilities to support special Python descriptors [1,2], in particular
+:func:`~functools.cached_property`, which has been available in the Python
+standard library since Python 3.8. We currently maintain aliases from
+earlier names for this descriptor, specifically `OneTimeProperty` and `auto_attr`.
+
+:func:`~functools.cached_property` creates properties that are computed once
+and then stored as regular attributes. They can thus be evaluated
 later in the object's life cycle, but once evaluated they become normal, static
 attributes with no function call overhead on access or any other constraints.
 
@@ -21,10 +24,7 @@ Hettinger. https://docs.python.org/howto/descriptor.html
 
 from __future__ import annotations
 
-import typing as ty
-
-InstanceT = ty.TypeVar('InstanceT')
-T = ty.TypeVar('T')
+from functools import cached_property
 
 from nibabel.deprecated import deprecate_with_version
 
@@ -34,22 +34,22 @@ from nibabel.deprecated import deprecate_with_version
 
 
 class ResetMixin:
-    """A Mixin class to add a .reset() method to users of OneTimeProperty.
+    """A Mixin class to add a .reset() method to users of cached_property.
 
-    By default, auto attributes once computed, become static.  If they happen
+    By default, cached properties, once computed, become static.  If they happen
     to depend on other parts of an object and those parts change, their values
     may now be invalid.
 
     This class offers a .reset() method that users can call *explicitly* when
     they know the state of their objects may have changed and they want to
     ensure that *all* their special attributes should be invalidated.  Once
-    reset() is called, all their auto attributes are reset to their
-    OneTimeProperty descriptors, and their accessor functions will be triggered
-    again.
+    reset() is called, all their cached properties are reset to their
+    :func:`~functools.cached_property` descriptors,
+    and their accessor functions will be triggered again.
 
     .. warning::
 
-       If a class has a set of attributes that are OneTimeProperty, but that
+       If a class has a set of attributes that are cached_property, but that
        can be initialized from any one of them, do NOT use this mixin!  For
        instance, UniformTimeSeries can be initialized with only sampling_rate
        and t0, sampling_interval and time are auto-computed.  But if you were
@@ -68,15 +68,15 @@ class ResetMixin:
     ...     def __init__(self,x=1.0):
     ...         self.x = x
     ...
-    ...     @auto_attr
+    ...     @cached_property
     ...     def y(self):
     ...         print('*** y computation executed ***')
     ...         return self.x / 2.0
-    ...
 
     >>> a = A(10)
 
     About to access y twice, the second time no computation is done:
+
     >>> a.y
     *** y computation executed ***
     5.0
@@ -84,17 +84,21 @@ class ResetMixin:
     5.0
 
     Changing x
+
     >>> a.x = 20
 
     a.y doesn't change to 10, since it is a static attribute:
+
     >>> a.y
     5.0
 
     We now reset a, and this will then force all auto attributes to recompute
     the next time we access them:
+
     >>> a.reset()
 
     About to access y twice again after reset():
+
     >>> a.y
     *** y computation executed ***
     10.0
@@ -103,88 +107,18 @@ class ResetMixin:
     """
 
     def reset(self) -> None:
-        """Reset all OneTimeProperty attributes that may have fired already."""
+        """Reset all cached_property attributes that may have fired already."""
         # To reset them, we simply remove them from the instance dict.  At that
         # point, it's as if they had never been computed.  On the next access,
         # the accessor function from the parent class will be called, simply
         # because that's how the python descriptor protocol works.
         for mname, mval in self.__class__.__dict__.items():
-            if mname in self.__dict__ and isinstance(mval, OneTimeProperty):
+            if mname in self.__dict__ and isinstance(mval, cached_property):
                 delattr(self, mname)
 
 
-class OneTimeProperty(ty.Generic[T]):
-    """A descriptor to make special properties that become normal attributes.
-
-    This is meant to be used mostly by the auto_attr decorator in this module.
-    """
-
-    def __init__(self, func: ty.Callable[[InstanceT], T]) -> None:
-        """Create a OneTimeProperty instance.
-
-        Parameters
-        ----------
-          func : method
-
-          The method that will be called the first time to compute a value.
-          Afterwards, the method's name will be a standard attribute holding
-          the value of this computation.
-        """
-        self.getter = func
-        self.name = func.__name__
-        self.__doc__ = func.__doc__
-
-    @ty.overload
-    def __get__(
-        self, obj: None, objtype: type[InstanceT] | None = None
-    ) -> ty.Callable[[InstanceT], T]: ...
-
-    @ty.overload
-    def __get__(self, obj: InstanceT, objtype: type[InstanceT] | None = None) -> T: ...
-
-    def __get__(
-        self, obj: InstanceT | None, objtype: type[InstanceT] | None = None
-    ) -> T | ty.Callable[[InstanceT], T]:
-        """This will be called on attribute access on the class or instance."""
-        if obj is None:
-            # Being called on the class, return the original function. This
-            # way, introspection works on the class.
-            return self.getter
-
-        # Errors in the following line are errors in setting a OneTimeProperty
-        val = self.getter(obj)
-
-        obj.__dict__[self.name] = val
-        return val
-
-
-def auto_attr(func: ty.Callable[[InstanceT], T]) -> OneTimeProperty[T]:
-    """Decorator to create OneTimeProperty attributes.
-
-    Parameters
-    ----------
-      func : method
-        The method that will be called the first time to compute a value.
-        Afterwards, the method's name will be a standard attribute holding the
-        value of this computation.
-
-    Examples
-    --------
-    >>> class MagicProp:
-    ...     @auto_attr
-    ...     def a(self):
-    ...         return 99
-    ...
-    >>> x = MagicProp()
-    >>> 'a' in x.__dict__
-    False
-    >>> x.a
-    99
-    >>> 'a' in x.__dict__
-    True
-    """
-    return OneTimeProperty(func)
-
+OneTimeProperty = cached_property
+auto_attr = cached_property
 
 # -----------------------------------------------------------------------------
 # Deprecated API

--- a/nibabel/tests/test_onetime.py
+++ b/nibabel/tests/test_onetime.py
@@ -1,5 +1,20 @@
-from nibabel.onetime import auto_attr, setattr_on_read
+from functools import cached_property
+
+from nibabel.onetime import ResetMixin, setattr_on_read
 from nibabel.testing import deprecated_to, expires
+
+
+class A(ResetMixin):
+    @cached_property
+    def y(self):
+        return self.x / 2.0
+
+    @cached_property
+    def z(self):
+        return self.x / 3.0
+
+    def __init__(self, x=1.0):
+        self.x = x
 
 
 @expires('5.0.0')
@@ -19,15 +34,14 @@ def test_setattr_on_read():
     assert x.a is obj
 
 
-def test_auto_attr():
-    class MagicProp:
-        @auto_attr
-        def a(self):
-            return object()
-
-    x = MagicProp()
-    assert 'a' not in x.__dict__
-    obj = x.a
-    assert 'a' in x.__dict__
-    # Each call to object() produces a unique object. Verify we get the same one every time.
-    assert x.a is obj
+def test_ResetMixin():
+    a = A(10)
+    assert 'y' not in a.__dict__
+    assert a.y == 5
+    assert 'y' in a.__dict__
+    a.x = 20
+    assert a.y == 5
+    # Call reset and no error should be raised even though z was never accessed
+    a.reset()
+    assert 'y' not in a.__dict__
+    assert a.y == 10


### PR DESCRIPTION
The type annotations of `nibabel.onetime.OneTimeProperty` have stopped checking with recent mypy. Given that this is redundant with `functools.cached_property`, it seems cleaner just to replace these synonyms directly with `cached_property`.

Also grabbed a test from nitime to verify that partial resets succeed.

Small fix for building docs with 3.12 *en passant*.