### PR TITLE
TYP: Address some recent numpy/mypy type complaints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ".*/data/.*"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,15 +13,18 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.6.4
     hooks:
       - id: ruff
-        args: [--fix, --show-fixes, --exit-non-zero-on-fix]
+        args: [ --fix ]
         exclude: = ["doc", "tools"]
       - id: ruff-format
         exclude: = ["doc", "tools"]
+      - id: ruff
+        args: [ --select, ISC001, --fix ]
+        exclude: = ["doc", "tools"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.11.2
     hooks:
       - id: mypy
         # Sync with project.optional-dependencies.typing
@@ -36,7 +39,7 @@ repos:
         args: ["nibabel"]
         pass_filenames: false
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -101,7 +101,11 @@ class Pointset:
         """The dimensionality of the space the coordinates are in"""
         return self.coordinates.shape[1] - self.homogeneous
 
-    def __rmatmul__(self, affine: np.ndarray) -> Self:
+    # Use __rmatmul__ to prefer to compose affines. Mypy does not like that
+    # this conflicts with ndarray.__matmul__. We will need some more feedback
+    # on how this plays out for type-checking or code suggestions before we
+    # can do better than ignore.
+    def __rmatmul__(self, affine: np.ndarray) -> Self:  # type: ignore[misc]
         """Apply an affine transformation to the pointset
 
         This will return a new pointset with an updated affine matrix only.

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -624,7 +624,7 @@ def array_to_file(
             # pre scale thresholds
             mn, mx = _dt_min_max(in_dtype, mn, mx)
             mn_out, mx_out = _dt_min_max(out_dtype)
-            pre_clips = max(mn, mn_out), min(mx, mx_out)
+            pre_clips = max(mn, mn_out), min(mx, mx_out)  # type: ignore[type-var]
             return _write_data(data, fileobj, out_dtype, order, pre_clips=pre_clips)
         # In any case, we do not want to check for nans because we've already
         # disallowed scaling that generates nans


### PR DESCRIPTION
The first issue is related to https://github.com/python/typeshed/issues/12562.

The `__rmatmul__`/`__matmul__` issue needs more consideration, but with the attention I can give this at the moment, I'm more worried about introducing subtle breakages or API commitments we might regret in the future, so ignoring the type error is the conservative choice.