### PR TITLE
MNT: Apply Repo-Review suggestion MY101

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ python_version = "3.11"
 exclude = [
   "/tests",
 ]
+strict = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 


### PR DESCRIPTION
MY101: MyPy strict mode

Must have `strict` in the mypy config. MyPy is best with strict or nearly strict configuration. If you are happy with the strictness of your settings already, ignore this check or set `strict = false` explicitly.