### PR TITLE
Adapt to functools.partial becoming a method descriptor in Python 3.14

### DIFF
--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -161,7 +161,7 @@ foo
 class TestDeprecatorMaker:
     """Test deprecator class creation with custom warnings and errors"""
 
-    dep_maker = partial(Deprecator, cmp_func)
+    dep_maker = staticmethod(partial(Deprecator, cmp_func))
 
     def test_deprecator_maker(self):
         dec = self.dep_maker(warn_class=UserWarning)


### PR DESCRIPTION
From https://docs.python.org/dev/whatsnew/3.14.html#changes-in-the-python-api:

> [functools.partial](https://docs.python.org/dev/library/functools.html#functools.partial) is now a method descriptor. Wrap it in [staticmethod()](https://docs.python.org/dev/library/functions.html#staticmethod) if you want to preserve the old behavior. (Contributed by Serhiy Storchaka and Dominykas Grigonis in [gh-121027](https://github.com/python/cpython/issues/121027).)

This was reported downstream in Fedora as https://bugzilla.redhat.com/show_bug.cgi?id=2322407.

It’s hard to test this change in a virtualenv since there are some dependencies like numpy that are nontrivial to compile from source and haven’t published binary wheels for Python 3.14. However, I tested this PR as a patch for nibabel 5.3.2 in Fedora’s early Python 3.14 testing and got a [successful build with no regressions](https://copr.fedorainfracloud.org/coprs/g/python/python3.14/build/8315861/) using Python 3.14.0a2.