### PR TITLE
type: Track type of SpatialImage.affine, test type inference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,22 +239,18 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        check: ['style', 'doctest', 'typecheck', 'spellcheck']
+        check: ['style', 'doctest', 'typecheck', 'spellcheck', 'type-inference']
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install tox
+        run: uv tool install tox --with=tox-uv
       - name: Show tox config
-        run: pipx run tox c
-      - name: Show tox config (this call)
-        run: pipx run tox c -e ${{ matrix.check }}
+        run: tox c -e ${{ matrix.check }}
       - name: Run check
-        run: pipx run tox -e ${{ matrix.check }}
+        run: tox -e ${{ matrix.check }}
 
   publish:
     runs-on: ubuntu-latest

--- a/nibabel/_typing.py
+++ b/nibabel/_typing.py
@@ -1,0 +1,25 @@
+"""Helpers for typing compatibility across Python versions"""
+
+import sys
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+if sys.version_info < (3, 13):
+    from typing_extensions import TypeVar
+else:
+    from typing import TypeVar
+
+
+__all__ = [
+    'ParamSpec',
+    'Self',
+    'TypeVar',
+]

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -59,10 +59,11 @@ KEEP_FILE_OPEN_DEFAULT = False
 
 if ty.TYPE_CHECKING:
     import numpy.typing as npt
-    from typing_extensions import Self  # PY310
+
+    from ._typing import Self, TypeVar
 
     # Taken from numpy/__init__.pyi
-    _DType = ty.TypeVar('_DType', bound=np.dtype[ty.Any])
+    _DType = TypeVar('_DType', bound=np.dtype[ty.Any])
 
 
 class ArrayLike(ty.Protocol):

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from .arrayproxy import ArrayProxy
 from .fileslice import strided_scalar
-from .spatialimages import HeaderDataError, ImageDataError, SpatialHeader, SpatialImage
+from .spatialimages import Affine, HeaderDataError, ImageDataError, SpatialHeader, SpatialImage
 from .volumeutils import Recoder
 
 # used for doc-tests
@@ -453,7 +453,7 @@ class AFNIHeader(SpatialHeader):
         return labels
 
 
-class AFNIImage(SpatialImage):
+class AFNIImage(SpatialImage[Affine]):
     """
     AFNI Image file
 

--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -14,6 +14,7 @@ import typing as ty
 
 import numpy as np
 
+from ._typing import TypeVar
 from .deprecated import deprecate_with_version
 from .filebasedimages import FileBasedHeader, FileBasedImage
 
@@ -24,13 +25,13 @@ if ty.TYPE_CHECKING:
     from .fileholders import FileMap
     from .filename_parser import FileSpec
 
-    FT = ty.TypeVar('FT', bound=np.floating)
+    FT = TypeVar('FT', bound=np.floating)
     F16 = ty.Literal['float16', 'f2', '|f2', '=f2', '<f2', '>f2']
     F32 = ty.Literal['float32', 'f4', '|f4', '=f4', '<f4', '>f4']
     F64 = ty.Literal['float64', 'f8', '|f8', '=f8', '<f8', '>f8']
     Caching = ty.Literal['fill', 'unchanged']
 
-ArrayImgT = ty.TypeVar('ArrayImgT', bound='DataobjImage')
+ArrayImgT = TypeVar('ArrayImgT', bound='DataobjImage')
 
 
 class DataobjImage(FileBasedImage):

--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -24,6 +24,12 @@ if ty.TYPE_CHECKING:
     from .fileholders import FileMap
     from .filename_parser import FileSpec
 
+    FT = ty.TypeVar('FT', bound=np.floating)
+    F16 = ty.Literal['float16', 'f2', '|f2', '=f2', '<f2', '>f2']
+    F32 = ty.Literal['float32', 'f4', '|f4', '=f4', '<f4', '>f4']
+    F64 = ty.Literal['float64', 'f8', '|f8', '=f8', '<f8', '>f8']
+    Caching = ty.Literal['fill', 'unchanged']
+
 ArrayImgT = ty.TypeVar('ArrayImgT', bound='DataobjImage')
 
 
@@ -39,7 +45,7 @@ class DataobjImage(FileBasedImage):
         header: FileBasedHeader | ty.Mapping | None = None,
         extra: ty.Mapping | None = None,
         file_map: FileMap | None = None,
-    ):
+    ) -> None:
         """Initialize dataobj image
 
         The datobj image is a combination of (dataobj, header), with optional
@@ -224,11 +230,33 @@ class DataobjImage(FileBasedImage):
             self._data_cache = data
         return data
 
+    # Types and dtypes, e.g., np.float64 or np.dtype('f8')
+    @ty.overload
+    def get_fdata(
+        self, *, caching: Caching = 'fill', dtype: type[FT] | np.dtype[FT]
+    ) -> npt.NDArray[FT]: ...
+    @ty.overload
+    def get_fdata(self, caching: Caching, dtype: type[FT] | np.dtype[FT]) -> npt.NDArray[FT]: ...
+    # Support string literals
+    @ty.overload
+    def get_fdata(self, caching: Caching, dtype: F16) -> npt.NDArray[np.float16]: ...
+    @ty.overload
+    def get_fdata(self, caching: Caching, dtype: F32) -> npt.NDArray[np.float32]: ...
+    @ty.overload
+    def get_fdata(self, *, caching: Caching = 'fill', dtype: F16) -> npt.NDArray[np.float16]: ...
+    @ty.overload
+    def get_fdata(self, *, caching: Caching = 'fill', dtype: F32) -> npt.NDArray[np.float32]: ...
+    # Double-up on float64 literals and the default (no arguments) case
+    @ty.overload
+    def get_fdata(
+        self, caching: Caching = 'fill', dtype: F64 = 'f8'
+    ) -> npt.NDArray[np.float64]: ...
+
     def get_fdata(
         self,
-        caching: ty.Literal['fill', 'unchanged'] = 'fill',
+        caching: Caching = 'fill',
         dtype: npt.DTypeLike = np.float64,
-    ) -> np.ndarray[ty.Any, np.dtype[np.floating]]:
+    ) -> npt.NDArray[np.floating]:
         """Return floating point image data with necessary scaling applied
 
         The image ``dataobj`` property can be an array proxy or an array.  An

--- a/nibabel/deprecated.py
+++ b/nibabel/deprecated.py
@@ -5,15 +5,11 @@ from __future__ import annotations
 import typing as ty
 import warnings
 
+from ._typing import ParamSpec
 from .deprecator import Deprecator
 from .pkg_info import cmp_pkg_version
 
-if ty.TYPE_CHECKING:
-    # PY39: ParamSpec is available in Python 3.10+
-    P = ty.ParamSpec('P')
-else:
-    # Just to keep the runtime happy
-    P = ty.TypeVar('P')
+P = ParamSpec('P')
 
 
 class ModuleProxy:

--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -10,8 +10,10 @@ import warnings
 from textwrap import dedent
 
 if ty.TYPE_CHECKING:
-    T = ty.TypeVar('T')
-    P = ty.ParamSpec('P')
+    from ._typing import ParamSpec, TypeVar
+
+    T = TypeVar('T')
+    P = ParamSpec('P')
 
 _LEADING_WHITE = re.compile(r'^(\s*)')
 

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 from urllib import request
 
 from ._compression import COMPRESSION_ERRORS
+from ._typing import TypeVar
 from .fileholders import FileHolder, FileMap
 from .filename_parser import TypesFilenamesError, _stringify_path, splitext_addext, types_filenames
 from .openers import ImageOpener
@@ -25,10 +26,10 @@ if ty.TYPE_CHECKING:
 
 FileSniff = tuple[bytes, str]
 
-ImgT = ty.TypeVar('ImgT', bound='FileBasedImage')
-HdrT = ty.TypeVar('HdrT', bound='FileBasedHeader')
+ImgT = TypeVar('ImgT', bound='FileBasedImage')
+HdrT = TypeVar('HdrT', bound='FileBasedHeader')
 
-StreamImgT = ty.TypeVar('StreamImgT', bound='SerializableImage')
+StreamImgT = TypeVar('StreamImgT', bound='SerializableImage')
 
 
 class ImageFileError(Exception):

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -22,7 +22,7 @@ from ..filebasedimages import SerializableImage
 from ..fileholders import FileHolder
 from ..filename_parser import _stringify_path
 from ..openers import ImageOpener
-from ..spatialimages import HeaderDataError, SpatialHeader, SpatialImage
+from ..spatialimages import Affine, HeaderDataError, SpatialHeader, SpatialImage
 from ..volumeutils import Recoder, array_from_file, array_to_file, endian_codes
 from ..wrapstruct import LabeledWrapStruct
 
@@ -459,7 +459,7 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
         return '\n'.join([report.message for report in reports if report.message])
 
 
-class MGHImage(SpatialImage, SerializableImage):
+class MGHImage(SpatialImage[Affine], SerializableImage):
     """Class for MGH format image"""
 
     header_class = MGHHeader

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -27,10 +27,11 @@ _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
 
 if ty.TYPE_CHECKING:
+    from ._typing import ParamSpec
     from .filebasedimages import FileBasedImage
     from .filename_parser import FileSpec
 
-    P = ty.ParamSpec('P')
+    P = ParamSpec('P')
 
     class Signature(ty.TypedDict):
         signature: bytes

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from .externals.netcdf import netcdf_file
 from .fileslice import canonical_slicers
-from .spatialimages import SpatialHeader, SpatialImage
+from .spatialimages import Affine, SpatialHeader, SpatialImage
 
 _dt_dict = {
     ('b', 'unsigned'): np.uint8,
@@ -299,7 +299,7 @@ class Minc1Header(MincHeader):
         return binaryblock[:4] == b'CDF\x01'
 
 
-class Minc1Image(SpatialImage):
+class Minc1Image(SpatialImage[Affine]):
     """Class for MINC1 format images
 
     The MINC1 image class uses the default header type, rather than a specific

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -14,7 +14,6 @@ NIfTI1 format defined at http://nifti.nimh.nih.gov/nifti-1/
 from __future__ import annotations
 
 import json
-import sys
 import typing as ty
 import warnings
 from io import BytesIO
@@ -22,12 +21,8 @@ from io import BytesIO
 import numpy as np
 import numpy.linalg as npl
 
-if sys.version_info < (3, 13):
-    from typing_extensions import Self, TypeVar  # PY312
-else:
-    from typing import Self, TypeVar
-
 from . import analyze  # module import
+from ._typing import Self, TypeVar
 from .arrayproxy import get_obj_dtype
 from .batteryrunners import Report
 from .casting import have_binary128

--- a/nibabel/nifti2.py
+++ b/nibabel/nifti2.py
@@ -19,7 +19,7 @@ from .analyze import AnalyzeHeader
 from .batteryrunners import Report
 from .filebasedimages import ImageFileError
 from .nifti1 import Nifti1Header, Nifti1Image, Nifti1Pair
-from .spatialimages import HeaderDataError
+from .spatialimages import AffT, HeaderDataError
 
 r"""
 Header struct from : https://www.nitrc.org/forum/message.php?msg_id=3738
@@ -240,17 +240,19 @@ class Nifti2PairHeader(Nifti2Header):
     is_single = False
 
 
-class Nifti2Pair(Nifti1Pair):
+class Nifti2Pair(Nifti1Pair[AffT]):
     """Class for NIfTI2 format image, header pair"""
 
-    header_class = Nifti2PairHeader
+    header_class: type[Nifti2Header] = Nifti2PairHeader
+    header: Nifti2Header
     _meta_sniff_len = header_class.sizeof_hdr
 
 
-class Nifti2Image(Nifti1Image):
+class Nifti2Image(Nifti1Image[AffT]):
     """Class for single file NIfTI2 format image"""
 
-    header_class = Nifti2Header
+    header_class: type[Nifti2Header] = Nifti2Header
+    header: Nifti2Header
     _meta_sniff_len = header_class.sizeof_hdr
 
 

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -22,7 +22,8 @@ if ty.TYPE_CHECKING:
     from types import TracebackType
 
     from _typeshed import WriteableBuffer
-    from typing_extensions import Self
+
+    from ._typing import Self
 
     ModeRT = ty.Literal['r', 'rt']
     ModeRB = ty.Literal['rb']

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -134,7 +134,7 @@ from .eulerangles import euler2mat
 from .fileslice import fileslice, strided_scalar
 from .nifti1 import unit_codes
 from .openers import ImageOpener
-from .spatialimages import SpatialHeader, SpatialImage
+from .spatialimages import Affine, SpatialHeader, SpatialImage
 from .volumeutils import Recoder, array_from_file
 
 # PSL to RAS affine
@@ -1248,7 +1248,7 @@ class PARRECHeader(SpatialHeader):
         return sort_info
 
 
-class PARRECImage(SpatialImage):
+class PARRECImage(SpatialImage[Affine]):
     """PAR/REC image"""
 
     header_class = PARRECHeader

--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -31,9 +31,9 @@ from nibabel.fileslice import strided_scalar
 from nibabel.spatialimages import SpatialImage
 
 if ty.TYPE_CHECKING:
-    from typing_extensions import Self
+    from ._typing import Self, TypeVar
 
-    _DType = ty.TypeVar('_DType', bound=np.dtype[ty.Any])
+    _DType = TypeVar('_DType', bound=np.dtype[ty.Any])
 
 
 class CoordinateArray(ty.Protocol):

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -138,8 +138,8 @@ from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import TypeVar
 
+from ._typing import TypeVar
 from .casting import sctypes_aliases
 from .dataobj_images import DataobjImage
 from .filebasedimages import FileBasedHeader, FileBasedImage

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -137,6 +137,8 @@ from functools import cache
 from typing import Literal
 
 import numpy as np
+import numpy.typing as npt
+from typing_extensions import TypeVar
 
 from .casting import sctypes_aliases
 from .dataobj_images import DataobjImage
@@ -150,13 +152,17 @@ if ty.TYPE_CHECKING:
     import io
     from collections.abc import Sequence
 
-    import numpy.typing as npt
-
     from .arrayproxy import ArrayLike
     from .fileholders import FileMap
 
-SpatialImgT = ty.TypeVar('SpatialImgT', bound='SpatialImage')
-SpatialHdrT = ty.TypeVar('SpatialHdrT', bound='SpatialHeader')
+# Track whether the image is initialized with an affine or not
+# This will almost always be the case, but there are some exceptions
+# and some functions that will fail if the affine is not present
+Affine = npt.NDArray[np.floating]
+AffT = TypeVar('AffT', covariant=True, bound=ty.Union[Affine, None], default=Affine)
+SpatialImgT = TypeVar('SpatialImgT', bound='SpatialImage[Affine]')
+SpatialHdrT = TypeVar('SpatialHdrT', bound='SpatialHeader')
+AnySpatialImgT = TypeVar('AnySpatialImgT', bound='SpatialImage[Affine | None]')
 
 
 class HasDtype(ty.Protocol):
@@ -194,7 +200,7 @@ class SpatialHeader(FileBasedHeader, SpatialProtocol):
         data_dtype: npt.DTypeLike = np.float32,
         shape: Sequence[int] = (0,),
         zooms: Sequence[float] | None = None,
-    ):
+    ) -> None:
         self.set_data_dtype(data_dtype)
         self._zooms = ()
         self.set_data_shape(shape)
@@ -461,7 +467,7 @@ class SpatialFirstSlicer(ty.Generic[SpatialImgT]):
         return self.img.affine.dot(transform)
 
 
-class SpatialImage(DataobjImage):
+class SpatialImage(DataobjImage, ty.Generic[AffT]):
     """Template class for volumetric (3D/4D) images"""
 
     header_class: type[SpatialHeader] = SpatialHeader
@@ -473,11 +479,11 @@ class SpatialImage(DataobjImage):
     def __init__(
         self,
         dataobj: ArrayLike,
-        affine: np.ndarray | None,
+        affine: AffT,
         header: FileBasedHeader | ty.Mapping | None = None,
         extra: ty.Mapping | None = None,
         file_map: FileMap | None = None,
-    ):
+    ) -> None:
         """Initialize image
 
         The image is a combination of (array-like, affine matrix, header), with
@@ -510,7 +516,7 @@ class SpatialImage(DataobjImage):
             # do need 4,4.
             # Copy affine to isolate from environment.  Specify float type to
             # avoid surprising integer rounding when setting values into affine
-            affine = np.array(affine, dtype=np.float64, copy=True)
+            affine = np.array(affine, dtype=np.float64, copy=True)  # type: ignore[assignment]
             if not affine.shape == (4, 4):
                 raise ValueError('Affine should be shape 4,4')
         self._affine = affine
@@ -524,7 +530,7 @@ class SpatialImage(DataobjImage):
         self._data_cache = None
 
     @property
-    def affine(self):
+    def affine(self) -> AffT:
         return self._affine
 
     def update_header(self) -> None:
@@ -586,7 +592,7 @@ metadata:
         self._header.set_data_dtype(dtype)
 
     @classmethod
-    def from_image(klass: type[SpatialImgT], img: SpatialImage | FileBasedImage) -> SpatialImgT:
+    def from_image(klass: type[AnySpatialImgT], img: FileBasedImage) -> AnySpatialImgT:
         """Class method to create new instance of own class from `img`
 
         Parameters
@@ -629,7 +635,7 @@ metadata:
         """
         return self.ImageSlicer(self)
 
-    def __getitem__(self, idx: object) -> None:
+    def __getitem__(self, idx: object) -> ty.Never:
         """No slicing or dictionary interface for images
 
         Use the slicer attribute to perform cropping and subsampling at your

--- a/nibabel/spm2analyze.py
+++ b/nibabel/spm2analyze.py
@@ -10,7 +10,8 @@
 
 import numpy as np
 
-from . import spm99analyze as spm99  # module import
+from . import spm99analyze as spm99
+from .spatialimages import AffT
 
 image_dimension_dtd = spm99.image_dimension_dtd.copy()
 image_dimension_dtd[image_dimension_dtd.index(('funused2', 'f4'))] = ('scl_inter', 'f4')
@@ -125,7 +126,7 @@ class Spm2AnalyzeHeader(spm99.Spm99AnalyzeHeader):
         )
 
 
-class Spm2AnalyzeImage(spm99.Spm99AnalyzeImage):
+class Spm2AnalyzeImage(spm99.Spm99AnalyzeImage[AffT]):
     """Class for SPM2 variant of basic Analyze image"""
 
     header_class = Spm2AnalyzeHeader

--- a/nibabel/spm99analyze.py
+++ b/nibabel/spm99analyze.py
@@ -16,7 +16,7 @@ import numpy as np
 from . import analyze  # module import
 from .batteryrunners import Report
 from .optpkg import optional_package
-from .spatialimages import HeaderDataError, HeaderTypeError
+from .spatialimages import AffT, HeaderDataError, HeaderTypeError
 
 have_scipy = optional_package('scipy')[1]
 
@@ -224,7 +224,7 @@ class Spm99AnalyzeHeader(SpmAnalyzeHeader):
         return hdr, rep
 
 
-class Spm99AnalyzeImage(analyze.AnalyzeImage):
+class Spm99AnalyzeImage(analyze.AnalyzeImage[AffT]):
     """Class for SPM99 variant of basic Analyze image"""
 
     header_class = Spm99AnalyzeHeader

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -28,11 +28,13 @@ if ty.TYPE_CHECKING:
 
     import numpy.typing as npt
 
+    from ._typing import TypeVar
+
     Scalar = np.number | float
 
-    K = ty.TypeVar('K')
-    V = ty.TypeVar('V')
-    DT = ty.TypeVar('DT', bound=np.generic)
+    K = TypeVar('K')
+    V = TypeVar('V')
+    DT = TypeVar('DT', bound=np.generic)
 
 sys_is_le = sys.byteorder == 'little'
 native_code: ty.Literal['<', '>'] = '<' if sys_is_le else '>'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ test = [
   "pytest-httpserver >=1.0.7",
   "pytest-xdist >=3.5",
   "coverage[toml]>=7.2",
+  "pytest-mypy-testing>=0.1.3",
 ]
 # Remaining: Simpler to centralize in tox
 dev = ["tox"]

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 200

--- a/tests/typing/test_spatialimage_api.py
+++ b/tests/typing/test_spatialimage_api.py
@@ -1,0 +1,80 @@
+import typing as ty
+
+import numpy as np
+import pytest
+
+from nibabel import AnalyzeImage, Spm99AnalyzeImage, Spm2AnalyzeImage, Nifti1Image, Nifti2Image, MGHImage
+from nibabel.spatialimages import SpatialImage
+
+if ty.TYPE_CHECKING:
+    from typing import reveal_type
+else:
+
+    def reveal_type(x: ty.Any) -> None:
+        pass
+
+
+@pytest.mark.mypy_testing
+def test_affine_tracking() -> None:
+    img_with_affine = SpatialImage(np.empty((5, 5, 5)), np.eye(4))
+    img_without_affine = SpatialImage(np.empty((5, 5, 5)), None)
+
+    reveal_type(img_with_affine)  # R: nibabel.spatialimages.SpatialImage[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(img_without_affine)  # R: nibabel.spatialimages.SpatialImage[None]
+
+
+@pytest.mark.mypy_testing
+def test_SpatialImageAPI() -> None:
+    img = SpatialImage(np.empty((5, 5, 5)), np.eye(4))
+
+    # Affine
+    reveal_type(img.affine)  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+    reveal_type(SpatialImage(np.empty((5, 5, 5)), None).affine)  # R: None
+
+    # Data
+    reveal_type(img.dataobj)  # R: nibabel.arrayproxy.ArrayLike
+    reveal_type(img.get_fdata())  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+    reveal_type(img.get_fdata(dtype=np.float32))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.floating[numpy._typing._nbit_base._32Bit]]]
+    reveal_type(img.get_fdata(dtype=np.float64))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+    reveal_type(img.get_fdata(dtype=np.dtype(np.float32)))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.floating[numpy._typing._nbit_base._32Bit]]]
+    reveal_type(img.get_fdata(dtype=np.dtype(np.float64)))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+    reveal_type(img.get_fdata(dtype=np.dtype("f4")))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.floating[numpy._typing._nbit_base._32Bit]]]
+    reveal_type(img.get_fdata(dtype=np.dtype("f8")))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+    reveal_type(img.get_fdata(dtype="f4"))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.floating[numpy._typing._nbit_base._32Bit]]]
+    reveal_type(img.get_fdata(dtype="f8"))  # R: numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]
+
+    # Indirect header
+    reveal_type(img.shape)  # R: builtins.tuple[builtins.int, ...]
+    reveal_type(img.ndim)  # R: builtins.int
+
+    # SpatialHeader fields
+    reveal_type(img.header.get_data_dtype())  # R: numpy.dtype[Any]
+    reveal_type(img.header.get_data_shape())  # R: builtins.tuple[builtins.int, ...]
+    reveal_type(img.header.get_zooms())  # R: builtins.tuple[builtins.float, ...]
+
+
+@pytest.mark.mypy_testing
+def test_image_and_header_types() -> None:
+    analyze_img = AnalyzeImage(np.empty((5, 5, 5)), np.eye(4))
+    reveal_type(analyze_img)  # R: nibabel.analyze.AnalyzeImage[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(analyze_img.header)  # R: nibabel.analyze.AnalyzeHeader
+
+    spm99_img = Spm99AnalyzeImage(np.empty((5, 5, 5)), np.eye(4))
+    reveal_type(spm99_img)  # R: nibabel.spm99analyze.Spm99AnalyzeImage[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(spm99_img.header)  # R: nibabel.spm99analyze.Spm99AnalyzeHeader
+
+    spm2_img = Spm2AnalyzeImage(np.empty((5, 5, 5)), np.eye(4))
+    reveal_type(spm2_img)  # R: nibabel.spm2analyze.Spm2AnalyzeImage[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(spm2_img.header)  # R: nibabel.spm2analyze.Spm2AnalyzeHeader
+
+    ni1_img = Nifti1Image(np.empty((5, 5, 5)), np.eye(4))
+    reveal_type(ni1_img)  # R: nibabel.nifti1.Nifti1Image[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(ni1_img.header)  # R: nibabel.nifti1.Nifti1Header
+
+    ni2_img = Nifti2Image(np.empty((5, 5, 5)), np.eye(4))
+    reveal_type(ni2_img)  # R: nibabel.nifti2.Nifti2Image[numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.float64]]]
+    reveal_type(ni2_img.header)  # R: nibabel.nifti2.Nifti2Header
+
+    mgh_img = MGHImage(np.empty((5, 5, 5), dtype=np.float32), np.eye(4))
+    reveal_type(mgh_img)  # R: nibabel.freesurfer.mghformat.MGHImage
+    reveal_type(mgh_img.header)  # R: nibabel.freesurfer.mghformat.MGHHeader

--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,7 @@ commands =
     --cov nibabel --cov-report xml:cov.xml \
     --junitxml test-results.xml \
     --durations=20 --durations-min=1.0 \
+    --dist worksteal \
     --pyargs nibabel {posargs:-n auto}
 
 [testenv:install]
@@ -190,6 +191,7 @@ commands =
     --cov tests --cov nibabel --cov-report xml:cov.xml \
     --junitxml test-results.xml \
     --durations=20 --durations-min=1.0 \
+    --dist loadgroup \
     tests/ {posargs:-n auto}
 
 [testenv:build{,-strict}]

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ envlist =
   doctest
   style
   typecheck
+  type-inference
 skip_missing_interpreters = true
 
 # Configuration that allows us to split tests across GitHub runners effectively
@@ -178,6 +179,18 @@ deps =
 skip_install = true
 commands =
   mypy nibabel
+
+[testenv:type-inference]
+description = Check type inference
+labels = test
+deps =
+  pytest-mypy-testing @ git+https://github.com/effigies/pytest-mypy-testing@rf/global-mypy-run
+commands =
+  python -m pytest \
+    --cov tests --cov nibabel --cov-report xml:cov.xml \
+    --junitxml test-results.xml \
+    --durations=20 --durations-min=1.0 \
+    tests/ {posargs:-n auto}
 
 [testenv:build{,-strict}]
 labels =


### PR DESCRIPTION
This PR lays some groundwork for further type annotations. The main thing it does is make `SpatialImage` generic over its affine type, which can either be `Affine` (an alias for ndarray that might be refined in the future) or `None`.

This is a somewhat pedantic thing to track, as it is extremely rare not to provide an affine to an image, but there are cases where it is the correct thing to do. This allows for a forthcoming PR to annotate functions that require an affine or can accept an image with `None` in it.

It also introduces tests where we specifically test for what `mypy` says the types of variables are, which lets us verify not only that our types are internally valid, but that they expose what we expect to downstream users.