### PR TITLE
Support ushort for the mgh/mgz reader

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -62,6 +62,7 @@ _dtdefs = (  # code, conversion function, dtype, bytes per voxel
     (4, 'int16', '>i2', '2', 'MRI_SHORT', np.int16, np.dtype('i2'), np.dtype('>i2')),
     (1, 'int32', '>i4', '4', 'MRI_INT', np.int32, np.dtype('i4'), np.dtype('>i4')),
     (3, 'float', '>f4', '4', 'MRI_FLOAT', np.float32, np.dtype('f4'), np.dtype('>f4')),
+    (10, 'int16', '>i2', '2', 'MRI_SHORT', np.int16, np.dtype('i2'), np.dtype('>i2')),
 )
 
 # make full code alias bank, including dtype column

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -57,6 +57,10 @@ hf_dtype = np.dtype(header_dtd + footer_dtd)
 
 # caveat: Note that it's ambiguous to get the code given the bytespervoxel
 # caveat 2: Note that the bytespervox you get is in str ( not an int)
+# FreeSurfer historically defines codes 0-10 [1], but only a subset is well supported.
+# Here we use FreeSurfer's MATLAB loader [2] as an indication of current support.
+# [1] https://github.com/freesurfer/freesurfer/blob/v8.0.0/include/mri.h#L53-L63
+# [2] https://github.com/freesurfer/freesurfer/blob/v8.0.0/matlab/load_mgh.m#L195-L207
 _dtdefs = (  # code, conversion function, dtype, bytes per voxel
     (0, 'uint8', '>u1', '1', 'MRI_UCHAR', np.uint8, np.dtype('u1'), np.dtype('>u1')),
     (1, 'int32', '>i4', '4', 'MRI_INT', np.int32, np.dtype('i4'), np.dtype('>i4')),

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -59,10 +59,10 @@ hf_dtype = np.dtype(header_dtd + footer_dtd)
 # caveat 2: Note that the bytespervox you get is in str ( not an int)
 _dtdefs = (  # code, conversion function, dtype, bytes per voxel
     (0, 'uint8', '>u1', '1', 'MRI_UCHAR', np.uint8, np.dtype('u1'), np.dtype('>u1')),
-    (4, 'int16', '>i2', '2', 'MRI_SHORT', np.int16, np.dtype('i2'), np.dtype('>i2')),
     (1, 'int32', '>i4', '4', 'MRI_INT', np.int32, np.dtype('i4'), np.dtype('>i4')),
     (3, 'float', '>f4', '4', 'MRI_FLOAT', np.float32, np.dtype('f4'), np.dtype('>f4')),
-    (10, 'int16', '>i2', '2', 'MRI_SHORT', np.int16, np.dtype('i2'), np.dtype('>i2')),
+    (4, 'int16', '>i2', '2', 'MRI_SHORT', np.int16, np.dtype('i2'), np.dtype('>i2')),
+    (10, 'uint16', '>u2', '2', 'MRI_USHRT', np.uint16, np.dtype('u2'), np.dtype('>u2')),
 )
 
 # make full code alias bank, including dtype column

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -172,11 +172,11 @@ def test_set_zooms():
 
 def bad_dtype_mgh():
     """This function raises an MGHError exception because
-    uint16 is not a valid MGH datatype.
+    float64 is not a valid MGH datatype.
     """
     # try to write an unsigned short and make sure it
     # raises MGHError
-    v = np.ones((7, 13, 3, 22), np.uint16)
+    v = np.ones((7, 13, 3, 22), np.float64)
     # form a MGHImage object using data
     # and the default affine matrix (Note the "None")
     MGHImage(v, None)


### PR DESCRIPTION
Hi,

nibabel currently crashes when loading an mgh/mgz file of type unsigned short.
As an consequence, recent FreeSurfer 7.4/8 clinical pipelines (that uses nibabel) now crashes on uint16 input MRIs (of any format, e.g nifti1) with an unfriendly python traceback, _because it can't read back the mgz it just converted its input to_.

I noted a bit of conflicting opinion on whether ushort should be supported for the MGH/MGZ file format.
- Nibabel's freesurfer explicitly (e.g test_mghformat.py:bad_dtype_mgh) forbids it for new object creation. And ANTs ITK-based tools refuse both to read and to write ushort mgz.
- But on the other hand, Freesurfer's own "mri_info" fully handle it, as so do other tools. In particular "mri_convert" obviously too (though not for explicit cast, ie. the -odt option!) considering FreeSurfer itself may create such ushort mgz out of well-supported regular ushort nifti files - without user's easily actionable workaround.

Therefore, officially supported or not, i suggest there is little drawback in nibabel not crashing when loading such ushort mgz.
The attached one-liner do that.