### PR TITLE
Add ability to read/write freesurfer surface files in scanner ras

### DIFF
--- a/nibabel/freesurfer/io.py
+++ b/nibabel/freesurfer/io.py
@@ -57,7 +57,7 @@ def _read_volume_info(fobj):
     head = np.fromfile(fobj, '>i4', 1)
     if not np.array_equal(head, [20]):  # Read two bytes more
         head = np.concatenate([head, np.fromfile(fobj, '>i4', 2)])
-        if not np.array_equal(head, [2, 0, 20]):
+        if not (np.array_equal(head, [2, 0, 20]) or np.array_equal(head, [2, 1, 20])):
             warnings.warn('Unknown extension code.')
             return volume_info
 
@@ -604,6 +604,7 @@ def _serialize_volume_info(volume_info):
             if not (
                 np.array_equal(volume_info[key], [20])
                 or np.array_equal(volume_info[key], [2, 0, 20])
+                or np.array_equal(volume_info[key], [2, 1, 20])
             ):
                 warnings.warn('Unknown extension code.')
             strings.append(np.array(volume_info[key], dtype='>i4').tobytes())

--- a/nibabel/freesurfer/tests/test_io.py
+++ b/nibabel/freesurfer/tests/test_io.py
@@ -7,6 +7,7 @@ import unittest
 from os.path import isdir
 from os.path import join as pjoin
 from pathlib import Path
+import subprocess
 
 import numpy as np
 import pytest
@@ -89,6 +90,13 @@ def test_geometry():
             read_geometry(surf_path, read_metadata=True)
         assert any('volume information contained' in str(ww.message) for ww in w)
         assert any('extension code' in str(ww.message) for ww in w)
+
+        # Test reading/writing a surface file in scanner RAS
+        cmd = f"mris_convert --to-scanner {pjoin(data_path, 'surf', 'lh.inflated')} {surf_path}"
+        _ = subprocess.run(cmd.split(), capture_output=True)
+        _ ,_, metadata = read_geometry(surf_path, read_metadata=True)
+        np.testing.assert_array_equal(metadata["head"], [2, 1, 20])
+        write_geometry(surf_path, coords, faces, create_stamp, metadata)
 
         volume_info['head'] = [1, 2]
         with pytest.warns(UserWarning, match='Unknown extension'):


### PR DESCRIPTION
Previously, only freesurfer surface files with coordinates in unknown or surface ras/tkregister space could be read. Following #1419, this PR adds the ability to read surface files whose coordinates are stored in scanner ras as well.

Let me know if calling a freesurfer function via `subprocess` as part of the test is a problem - but I wasn't sure how to test this feature otherwise.