### PR TITLE
STYLE: Fix type checking errors in `volumeutils.rec2dict`

### DIFF
--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -16,6 +16,7 @@ import warnings
 from functools import reduce
 from operator import getitem, mul
 from os.path import exists, splitext
+from typing import Any
 
 import numpy as np
 
@@ -1365,7 +1366,7 @@ def shape_zoom_affine(
     return aff
 
 
-def rec2dict(rec: np.ndarray) -> dict[str, np.generic | np.ndarray]:
+def rec2dict(rec: np.ndarray) -> dict[str, Any]:
     """Convert recarray to dictionary
 
     Also converts scalar values to scalars
@@ -1387,7 +1388,9 @@ def rec2dict(rec: np.ndarray) -> dict[str, np.generic | np.ndarray]:
     >>> d == {'x': 0, 's': b''}
     True
     """
-    dct = {}
+    dct: dict[str, Any] = {}
+    if rec.dtype.fields is None:
+        return dct
     for key in rec.dtype.fields:
         val = rec[key]
         try:

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -16,7 +16,6 @@ import warnings
 from functools import reduce
 from operator import getitem, mul
 from os.path import exists, splitext
-from typing import Any
 
 import numpy as np
 
@@ -1366,7 +1365,7 @@ def shape_zoom_affine(
     return aff
 
 
-def rec2dict(rec: np.ndarray) -> dict[str, Any]:
+def rec2dict(rec: np.record) -> dict[str, np.generic | np.ndarray]:
     """Convert recarray to dictionary
 
     Also converts scalar values to scalars
@@ -1388,10 +1387,8 @@ def rec2dict(rec: np.ndarray) -> dict[str, Any]:
     >>> d == {'x': 0, 's': b''}
     True
     """
-    dct: dict[str, Any] = {}
-    if rec.dtype.fields is None:
-        return dct
-    for key in rec.dtype.fields:
+    dct = {}
+    for key in rec.dtype.fields or ():
         val = rec[key]
         try:
             val = val.item()


### PR DESCRIPTION
Fix type checking errors in `volumeutils.rec2dict`:
- Ensure that the recarray is iterable; return immediately if no fields are found.
- Accomodate `Any` type in return the dictionary type

Fixes:
```
nibabel/volumeutils.py:1391: error:
 Item "None" of "MappingProxyType[str, tuple[dtype[Any], int] | tuple[dtype[Any], int, Any]] | None"
 has no attribute "__iter__" (not iterable)  [union-attr]
```

and
```
nibabel/volumeutils.py:1398: error:
 Incompatible return value type (got "dict[str | Any, ndarray[tuple[Any, ...], dtype[Any]]]",
 expected "dict[str, generic[Any] | ndarray[tuple[Any, ...], dtype[Any]]]")  [return-value]
nibabel/volumeutils.py:1398: note: Perhaps you need a type annotation for "dct"?
 Suggestion: "dict[str, generic[Any] | ndarray[tuple[Any, ...], dtype[Any]]]"
```

raised for example in:
https://github.com/nipy/nibabel/actions/runs/16092302666/job/45410655458?pr=1422#step:7:22