### PR TITLE
PL: Add stub file for top-level `__init__.py`

### DIFF
--- a/nibabel/__init__.pyi
+++ b/nibabel/__init__.pyi
@@ -44,11 +44,6 @@ from nibabel.pkg_info import get_pkg_info as _get_pkg_info
 from nibabel.spm2analyze import Spm2AnalyzeHeader, Spm2AnalyzeImage
 from nibabel.spm99analyze import Spm99AnalyzeHeader, Spm99AnalyzeImage
 
-try:
-    from pytest import ExitCode  # type: ignore[import]  # noqa: PT013
-except (ImportError, ModuleNotFoundError):
-    class ExitCode(int): ...  # type: ignore[no-redef]
-
 def get_info() -> dict[str, str]: ...
 def test(
     label: Any = None,
@@ -58,10 +53,10 @@ def test(
     coverage: bool = False,
     raise_warnings: Any = None,
     timer: Any = False,
-) -> ExitCode: ...
+) -> int: ...
 def bench(
     label: Any = None, verbose: int = 1, extra_argv: list[Any] | None = None
-) -> ExitCode: ...
+) -> int: ...
 
 __all__ = [
     'AnalyzeHeader',

--- a/nibabel/__init__.pyi
+++ b/nibabel/__init__.pyi
@@ -54,9 +54,7 @@ def test(
     raise_warnings: Any = None,
     timer: Any = False,
 ) -> int: ...
-def bench(
-    label: Any = None, verbose: int = 1, extra_argv: list[Any] | None = None
-) -> int: ...
+def bench(label: Any = None, verbose: int = 1, extra_argv: list[Any] | None = None) -> int: ...
 
 __all__ = [
     'AnalyzeHeader',

--- a/nibabel/__init__.pyi
+++ b/nibabel/__init__.pyi
@@ -1,0 +1,117 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the NiBabel package for the
+#   copyright and license terms.
+#
+### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import os
+from typing import Any
+
+# module imports
+from nibabel import analyze as ana
+from nibabel import ecat, imagestats, mriutils, orientations, streamlines, viewers
+from nibabel import nifti1 as ni1
+from nibabel import spm2analyze as spm2
+from nibabel import spm99analyze as spm99
+
+# object imports
+from nibabel.analyze import AnalyzeHeader, AnalyzeImage
+from nibabel.arrayproxy import is_proxy
+from nibabel.cifti2 import Cifti2Header, Cifti2Image
+from nibabel.fileholders import FileHolder, FileHolderError
+from nibabel.freesurfer import MGHImage
+from nibabel.funcs import as_closest_canonical, concat_images, four_to_three, squeeze_image
+from nibabel.gifti import GiftiImage
+from nibabel.imageclasses import all_image_classes
+from nibabel.info import long_description as __doc__
+from nibabel.loadsave import load, save
+from nibabel.minc1 import Minc1Image
+from nibabel.minc2 import Minc2Image
+from nibabel.nifti1 import Nifti1Header, Nifti1Image, Nifti1Pair
+from nibabel.nifti2 import Nifti2Header, Nifti2Image, Nifti2Pair
+from nibabel.orientations import (
+    OrientationError,
+    aff2axcodes,
+    apply_orientation,
+    flip_axis,
+    io_orientation,
+)
+from nibabel.pkg_info import __version__
+from nibabel.pkg_info import get_pkg_info as _get_pkg_info
+from nibabel.spm2analyze import Spm2AnalyzeHeader, Spm2AnalyzeImage
+from nibabel.spm99analyze import Spm99AnalyzeHeader, Spm99AnalyzeImage
+
+try:
+    from pytest import ExitCode  # type: ignore[import]  # noqa: PT013
+except (ImportError, ModuleNotFoundError):
+    class ExitCode(int): ...  # type: ignore[no-redef]
+
+def get_info() -> dict[str, str]: ...
+def test(
+    label: Any = None,
+    verbose: int = 1,
+    extra_argv: list[Any] | None = None,
+    doctests: bool = False,
+    coverage: bool = False,
+    raise_warnings: Any = None,
+    timer: Any = False,
+) -> ExitCode: ...
+def bench(
+    label: Any = None, verbose: int = 1, extra_argv: list[Any] | None = None
+) -> ExitCode: ...
+
+__all__ = [
+    'AnalyzeHeader',
+    'AnalyzeImage',
+    'Cifti2Header',
+    'Cifti2Image',
+    'FileHolder',
+    'FileHolderError',
+    'GiftiImage',
+    'MGHImage',
+    'Minc1Image',
+    'Minc2Image',
+    'Nifti1Header',
+    'Nifti1Image',
+    'Nifti1Pair',
+    'Nifti2Header',
+    'Nifti2Image',
+    'Nifti2Pair',
+    'OrientationError',
+    'Spm2AnalyzeHeader',
+    'Spm2AnalyzeImage',
+    'Spm99AnalyzeHeader',
+    'Spm99AnalyzeImage',
+    '__doc__',
+    '__version__',
+    '_get_pkg_info',
+    'aff2axcodes',
+    'all_image_classes',
+    'ana',
+    'apply_orientation',
+    'as_closest_canonical',
+    'bench',
+    'concat_images',
+    'ecat',
+    'flip_axis',
+    'four_to_three',
+    'get_info',
+    'imagestats',
+    'io_orientation',
+    'is_proxy',
+    'load',
+    'mriutils',
+    'ni1',
+    'orientations',
+    'os',
+    'save',
+    'spm2',
+    'spm99',
+    'squeeze_image',
+    'streamlines',
+    'test',
+    'viewers',
+]


### PR DESCRIPTION
Related to #1426 by @pcasl
Related to #1220 by @effigies 

## Description

This PR adds a stub file for the top-level `__init__.py`, including an `__all__` to expose the types of all symbols imported or defined therein.

## Screenshots

### Without the stub file

<img width="738" height="86" alt="warning: &quot;load&quot; is not exported from module &quot;nibabel&quot;" src="https://github.com/user-attachments/assets/24a3fe30-3a34-4df8-904b-7374a2ecfdf1" />

### With the stub file

<img width="430" height="78" alt="no warning" src="https://github.com/user-attachments/assets/34073054-2883-4af7-9108-a8db5bcc6784" />
