### PR TITLE
fix: Adapt to numpy 2.5 deprecations

### DIFF
--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -359,7 +359,7 @@ def _process_gen_dict(gen_dict):
             value = np.fromstring(value, props[1], sep=' ')
             # if shape is None, allow arbitrary length
             if props[2] is not None:
-                value.shape = props[2]
+                value = value.reshape(props[2])
         general_info[props[0]] = value
     return general_info
 

--- a/nibabel/streamlines/tractogram.py
+++ b/nibabel/streamlines/tractogram.py
@@ -115,8 +115,7 @@ class PerArrayDict(SliceableDataDict):
         value = np.asarray(value, dtype=dtype)
 
         if value.ndim == 1 and value.dtype != object:
-            # Reshape without copy
-            value.shape = (len(value), 1)
+            value = value.reshape(len(value), 1)
 
         if value.ndim != 2 and value.dtype != object:
             raise ValueError('data_per_streamline must be a 2D array.')

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -847,10 +847,10 @@ class TestAnalyzeImage(tsi.TestSpatialImage, tsi.MmapImageMixin):
         assert_array_equal(hdr.get_zooms(), (9, 3, 4))
         # Modify data in-place?  Update on save
         data = img.get_fdata()
-        data.shape = (3, 2, 4)
+        data[0, 0, 0] = 1
         img.to_file_map()
         img_back = img.from_file_map(img.file_map)
-        assert_array_equal(img_back.shape, (3, 2, 4))
+        assert img_back.get_fdata()[0, 0, 0] == 1
 
     def test_pickle(self):
         # Test that images pickle


### PR DESCRIPTION
This feature was also used in the vendored copy of `scipy.io.netcdf`, so update that as well.