### PR TITLE
chore(ci): Split pre-release tests into cron job

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,4 +73,22 @@ jobs:
       - name: Setup test suite
         run: tox run -vv --notest
       - name: Run test suite
+        id: pre
         run: tox -v --skip-pkg-install --exit-and-dump-after 1200
+      - name: Create issue
+        # Workflows triggered by schedule only notify the workflow creator
+        # So let's open an issue to make sure this is visible to all
+        if: ${{ steps.pre.outcome != 'success' }}
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          workflow_name: PRE-RELEASE TESTS
+        with:
+          filename: .github/workflow_failure.md
+          update_existing: true
+          search_existing: open
+      - name: Return failure
+        if: ${{ steps.pre.outcome != 'success' }}
+        run: exit 1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,76 @@
+name: Prerelease tests
+
+# This file tests against pre-release versions of dependencies
+#
+# Because an upstream tool can break things so easily, this is done as a
+# weekly cron job so notifications can be seen without making every PR fail.
+
+on:
+  push:
+    branches:
+      - ci/prerelease
+  schedule:
+    - cron: '0 0 * * 1'
+  # Allow job to be triggered manually from GitHub interface
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+# Force tox and pytest to use color
+env:
+  FORCE_COLOR: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os-arch[0] }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os-arch:
+          - ['ubuntu-latest', 'x64']
+          - ['windows-latest', 'x64']
+          - ['macos-latest', 'arm64']
+        python-version:
+          # Oldest SPEC0-supported Python (dependencies won't release for older)
+          - "3.12"
+          # Latest Python
+          - "3.14"
+          - "3.14t"
+          # Beta Python
+          # - "3.15"
+          # - "3.15t"
+
+    env:
+      DEPENDS: pre
+      ARCH: ${{ matrix.os-arch[1] }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup uv and Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install tox
+        run: uv tool install -v tox --with=tox-uv --with=tox-gh-actions
+      - name: Show tox config
+        run: tox c
+      - name: Setup test suite
+        run: tox run -vv --notest
+      - name: Run test suite
+        run: tox -v --skip-pkg-install --exit-and-dump-after 1200

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,6 @@ jobs:
   test:
     # Check each OS, all supported Python, minimum versions and latest releases
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.dependencies == 'pre' }}
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +121,7 @@ jobs:
           - "3.14"
           - "3.14t"
         architecture: ['x86', 'x64', 'arm64']
-        dependencies: ['full', 'pre']
+        dependencies: ['full']
         include:
           # Basic dependencies only
           - os: ubuntu-latest
@@ -185,16 +184,6 @@ jobs:
           # x64 is not available for macos-15
           - os: macos-latest
             architecture: x64
-
-          ## Reduced support
-          # Drop pre tests for macos-14
-          - os: macos-14
-            dependencies: pre
-          # Drop pre tests for SPEC-0-unsupported Python versions
-          - python-version: '3.10'
-            dependencies: pre
-          - python-version: '3.11'
-            dependencies: pre
 
     env:
       DEPENDS: ${{ matrix.dependencies }}

--- a/.github/workflows/workflow_failure.md
+++ b/.github/workflows/workflow_failure.md
@@ -1,0 +1,7 @@
+---
+title: ":rotating_light: {{ env.workflow_name }}: failure"
+---
+
+The run `{{ env.run_id }}` of the workflow {{ env.workflow_name }} failed.
+
+You can view [the log](https://github.com/{{ env.repository }}/actions/runs/{{ env.run_id }})


### PR DESCRIPTION
This splits pre-release tests into a cron job instead of on every PR/commit. It hasn't happened lately on this repository, but these tests are distracting for PRs that are unrelated.

This sets up the `ci/prerelease` branch to allow triggering these tests intentionally during a PR (such as this one).

@Remi-Gau If you wouldn't mind having a quick look, I would appreciate it.