### PR TITLE
fix: Adjust tests to not depend on how pytest is invoked

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Run tests
         run: pytest --doctest-modules --doctest-plus -v --pyargs nibabel -n auto
 
-  test:
+  tox:
     # Check each OS, all supported Python, minimum versions and latest releases
     runs-on: ${{ matrix.os }}
     strategy:
@@ -227,6 +227,26 @@ jobs:
           path: test-results.xml
         if: ${{ always() }}
 
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.14']
+    steps:
+      - name: Shallow checkout
+        uses: actions/checkout@v6
+      - name: Setup uv and Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install with pytest
+        run: uv sync --extra=test --extra=all
+      - name: Run test suite
+        run: python -m pytest
+
   checks:
     runs-on: 'ubuntu-slim'
     continue-on-error: true
@@ -255,7 +275,7 @@ jobs:
   publish:
     runs-on: ubuntu-slim
     environment: "Package deployment"
-    needs: [test, test-package]
+    needs: [tox, pytest, test-package]
     permissions:
       # Required for trusted publishing
       id-token: write

--- a/nibabel/cmdline/tests/test_roi.py
+++ b/nibabel/cmdline/tests/test_roi.py
@@ -147,7 +147,7 @@ def test_entrypoint(capsys):
         with pytest.raises(SystemExit):
             main()
     captured = capsys.readouterr()
-    assert captured.out.startswith('usage: nib-roi')
+    assert captured.out.startswith('usage: ')
 
 
 def test_nib_roi_unknown_axes(capsys):

--- a/nibabel/tests/test_removalschedule.py
+++ b/nibabel/tests/test_removalschedule.py
@@ -173,3 +173,7 @@ def test_unremoved_object():
 def test_unremoved_attr():
     with pytest.raises(AssertionError):
         test_attribute_removal()
+
+
+if cmp_pkg_version('1.0.0') > -1:
+    pytest.skip('Shallow checkout, version unavailable', allow_module_level=True)


### PR DESCRIPTION
`python -m pytest` triggers changes in `argparse` behavior (relative to `pytest`) as of https://github.com/python/cpython/pull/124799. Let's start by running some of our CI jobs with `python -m pytest` to replicate #1446.

Edit: Test failures in #1446 and #1476 replicated. Patching both.

Closes #1446.
Closes #1476.