### PR TITLE
MNT: `__package__` → `__spec__.parent`

### DIFF
--- a/nibabel/tests/scriptrunner.py
+++ b/nibabel/tests/scriptrunner.py
@@ -19,7 +19,7 @@ from os.path import dirname, isdir, isfile, pathsep, realpath
 from os.path import join as pjoin
 from subprocess import PIPE, Popen
 
-MY_PACKAGE = __package__
+MY_PACKAGE = __spec__.parent
 
 
 def local_script_dir(script_sdir):


### PR DESCRIPTION
Remove deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).