### PR TITLE
chore: Add Python 3.15 and Linux ARM to pre-release matrix

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         os-arch:
           - ['ubuntu-latest', 'x64']
+          - ['ubuntu-24.04-arm', 'arm64']
           - ['windows-latest', 'x64']
           - ['macos-latest', 'arm64']
         python-version:
@@ -48,8 +49,8 @@ jobs:
           - "3.14"
           - "3.14t"
           # Beta Python
-          # - "3.15"
-          # - "3.15t"
+          - "3.15"
+          - "3.15t"
 
     env:
       DEPENDS: pre

--- a/tox.ini
+++ b/tox.ini
@@ -92,13 +92,12 @@ extras =
   min: viewers
 
   # Matplotlib has wheels for everything except win32 (x86)
-  {full,pre}-{x,arm}64: viewers
+  py3{10-14}{,t}-{full,pre}-{x,arm}64: viewers
 
-  {full,pre}-{x,arm}64: spm
+  py3{10-14}{,t}-{full,pre}-{x,arm}64: spm
 
   # No free-threaded wheels for: h5py
   py3{10-14}-{full,pre}-{x,arm}64: minc2
-  py315-pre-{x,arm}64: minc2
 
 deps =
   pre: pydicom @ git+https://github.com/pydicom/pydicom.git@main

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,8 @@ python =
   3.13t: py313t
   3.14: py314
   3.14t: py314t
+  3.15: py315
+  3.15t: py315t
 
 [gh-actions:env]
 DEPENDS =


### PR DESCRIPTION
3.15 is not expected to install yet, since even numpy doesn't have wheels, so we won't merge until that's set.