### PR TITLE
FIX: Set `patient_birth_date` dtype in ecat header to signed int32 (gh-1434)

### DIFF
--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -90,7 +90,9 @@ main_header_dtd = [
     ('patient_age', np.float32),
     ('patient_height', np.float32),
     ('patient_weight', np.float32),
-    ('patient_birth_date', np.uint32),
+    # time_t (seconds since the Unix epoch); signed so that birth dates
+    # before 1970 are representable as negative values (see gh-1434)
+    ('patient_birth_date', np.int32),
     ('physician_name', '32S'),
     ('operator_name', '32S'),
     ('study_description', '32S'),

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -77,7 +77,9 @@ class TestEcatHeader(tws._TestWrapStructBase):
         # patient_birth_date is a time_t (seconds since the Unix epoch) and
         # must be signed so that pre-1970 birth dates survive as negative
         # values rather than wrapping to a far-future unsigned value (gh-1434).
-        assert np.issubdtype(self.header_class.template_dtype['patient_birth_date'], np.signedinteger)
+        assert np.issubdtype(
+            self.header_class.template_dtype['patient_birth_date'], np.signedinteger
+        )
         hdr = self.header_class()
         # 19 Dec 1915, i.e. -1704153600 seconds from the epoch
         hdr['patient_birth_date'] = -1704153600

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -73,6 +73,16 @@ class TestEcatHeader(tws._TestWrapStructBase):
         hdr['num_frames'] = 2
         assert hdr['num_frames'] == 2
 
+    def test_patient_birth_date_signed(self):
+        # patient_birth_date is a time_t (seconds since the Unix epoch) and
+        # must be signed so that pre-1970 birth dates survive as negative
+        # values rather than wrapping to a far-future unsigned value (gh-1434).
+        assert np.issubdtype(self.header_class.template_dtype['patient_birth_date'], np.signedinteger)
+        hdr = self.header_class()
+        # 19 Dec 1915, i.e. -1704153600 seconds from the epoch
+        hdr['patient_birth_date'] = -1704153600
+        assert hdr['patient_birth_date'] == -1704153600
+
     def test_from_eg_file(self):
         # Example header is big-endian
         with Opener(self.example_file) as fileobj:


### PR DESCRIPTION
## Summary

Fixes #1434.

`nibabel/ecat.py` types `patient_birth_date` in the main header as `np.uint32`. The field is a `time_t` (seconds since the Unix epoch), which is signed — negative for dates before 1970. With the unsigned type, any pre-1970 birth date is reinterpreted as a far-future date:

```python
# 19 Dec 1915  ->  ts = -1704153600
uint32(int32(ts)) -> 2590813696  -> 2052-02-06   # bug
int32(ts)         -> -1704153600 -> 1915          # correct
```

The issue reporter confirmed against 100+ ECAT v7.0 and v7.3 files that unsigned is never correct for their data, and other tools (e.g. Vinci) read the field as signed. There is a single `main_header_dtd` (no version-specific variants), so the change applies uniformly.

## Changes

- `nibabel/ecat.py`: `patient_birth_date` dtype `np.uint32` -> `np.int32`, with a comment noting the `time_t` semantics.
- `nibabel/tests/test_ecat.py`: add `test_patient_birth_date_signed` — asserts the field dtype is signed and that a pre-1970 timestamp round-trips through the header unchanged.

## Testing

```
$ pytest nibabel/tests/test_ecat.py -q
32 passed
```