### PR TITLE
Add Cedric Conday to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -342,3 +342,5 @@ authors:
     given-names: Kabilar
     affiliation: McGovern Institute for Brain Research, Massachusetts Institute of Technology, Cambridge, MA, USA
     orcid: https://orcid.org/0000-0001-6964-4865
+  - family-names: Conday
+    given-names: Cedric


### PR DESCRIPTION
As kindly invited by @effigies in #1522, this adds me to the author list in `CITATION.cff` (at the end, per the suggestion — order can be updated at release time).