### PR TITLE
Preserve data dtype in concat_images to fix save/load round-trip (gh-986)

### DIFF
--- a/nibabel/funcs.py
+++ b/nibabel/funcs.py
@@ -115,13 +115,10 @@ def concat_images(images, check_affines=True, axis=None):
     klass = img0.__class__
     shape0 = img0.shape
     n_dim = len(shape0)
-    if axis is None:
-        # collect images in output array for efficiency
-        out_shape = (n_imgs,) + shape0
-        out_data = np.empty(out_shape)
-    else:
-        # collect images in list for use with np.concatenate
-        out_data = [None] * n_imgs
+    # collect images in a list; stacking/concatenating later preserves the input
+    # data dtype instead of upcasting to float64, so an integer image round-trips
+    # through save/load without precision loss (gh-986)
+    out_data = [None] * n_imgs
     # Get part of shape we need to check inside loop
     idx_mask = np.ones((n_dim,), dtype=bool)
     if axis is not None:
@@ -141,7 +138,7 @@ def concat_images(images, check_affines=True, axis=None):
         out_data[i] = np.asanyarray(img.dataobj)
 
     if axis is None:
-        out_data = np.rollaxis(out_data, 0, out_data.ndim)
+        out_data = np.stack(out_data, axis=-1)
     else:
         out_data = np.concatenate(out_data, axis=axis)
 

--- a/nibabel/tests/test_funcs.py
+++ b/nibabel/tests/test_funcs.py
@@ -211,5 +211,8 @@ def test_concat_integer_roundtrip():
 
     with InTemporaryDirectory():
         save(concat, 'concat.nii')
-        reloaded = np.asarray(load('concat.nii').dataobj)
+        # Load with mmap=False so the file handle is released before the
+        # temporary directory is torn down; Windows cannot delete a file
+        # that is still memory-mapped, which otherwise fails cleanup here.
+        reloaded = np.asarray(load('concat.nii', mmap=False).dataobj)
     assert_array_equal(in_memory, reloaded)

--- a/nibabel/tests/test_funcs.py
+++ b/nibabel/tests/test_funcs.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 
 from ..analyze import AnalyzeImage
 from ..funcs import OrientationError, as_closest_canonical, concat_images
-from ..loadsave import save
+from ..loadsave import load, save
 from ..nifti1 import Nifti1Image
 from ..tmpdirs import InTemporaryDirectory
 
@@ -192,3 +192,24 @@ def test_closest_canonical():
     img.header.set_dim_info(None, None, 2)
     xyz_img = as_closest_canonical(img)
     assert xyz_img.header.get_dim_info() == (None, None, 1)
+
+
+def test_concat_integer_roundtrip():
+    # Regression test for gh-986: concatenating integer images with the default
+    # ``axis=None`` must preserve the input dtype rather than upcasting to float64,
+    # so the saved-and-reloaded data equals the in-memory data instead of being
+    # quantized back to the integer storage dtype on save.
+    arr0 = np.arange(24, dtype=np.uint16).reshape(2, 3, 4)
+    arr1 = arr0 + 1000
+    img0 = Nifti1Image(arr0, np.eye(4))
+    img1 = Nifti1Image(arr1, np.eye(4))
+
+    concat = concat_images([img0, img1])
+    assert concat.get_data_dtype() == np.dtype(np.uint16)
+    in_memory = np.asarray(concat.dataobj)
+    assert in_memory.dtype == np.uint16
+
+    with InTemporaryDirectory():
+        save(concat, 'concat.nii')
+        reloaded = np.asarray(load('concat.nii').dataobj)
+    assert_array_equal(in_memory, reloaded)


### PR DESCRIPTION
Fixes gh-986.

`concat_images(..., axis=None)` pre-allocated the output array with `np.empty(out_shape)`, which defaults to `float64`. Integer input data (e.g. `uint16`) was therefore upcast to `float64` in memory, but the returned image reuses the first image's header, whose data dtype is still `uint16`. On save, the `float64` values are cast back to the `uint16` storage dtype (with scaling), so the reloaded data no longer equals the in-memory data.

Minimal reproducer:

```python
import numpy as np, nibabel as nib, tempfile, os
a = np.arange(24, dtype=np.uint16).reshape(2, 3, 4)
img1 = nib.Nifti1Image(a, np.eye(4))
img2 = nib.Nifti1Image(a + 1000, np.eye(4))
cat = nib.funcs.concat_images([img1, img2])
p = os.path.join(tempfile.mkdtemp(), "c.nii"); nib.save(cat, p)
in_mem = np.asarray(cat.dataobj)
reloaded = np.asarray(nib.load(p).dataobj)
np.array_equal(in_mem, reloaded)   # False on main, True with this change
```

The `axis`-specified branch already avoids this because it uses `np.concatenate`, which preserves the input dtype. This change makes the `axis=None` branch consistent: collect the loaded arrays in a list and combine them with `np.stack(..., axis=-1)` instead of filling a `float64` `np.empty` and calling `np.rollaxis`. `np.stack` produces the same shape and ordering as the previous `empty`+`rollaxis` approach but keeps the natural (result) dtype, so the header dtype and the data agree and the image round-trips losslessly.

Verified that `uint16`, `int16`, `int32`, `float32` and `float64` inputs all round-trip exactly (both `axis=None` and an explicit axis), that the stacked data matches `np.stack([a, b], axis=-1)`, and that the existing `test_concat` (which exercises many shapes/axes and mem/file/mixed inputs) still passes. Added `test_concat_integer_roundtrip`, which fails on `main` and passes here.

*Disclosure: this change was written with AI assistance. I reviewed it, confirmed the root cause, and verified the behaviour and tests described above before submitting.*
