### PR TITLE
BF: Return complex data from get_fdata() for complex images

### DIFF
--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -30,7 +30,7 @@ class DataobjImage(FileBasedImage):
     """Template class for images that have dataobj data stores"""
 
     _data_cache: np.ndarray | None
-    _fdata_cache: np.ndarray[ty.Any, np.dtype[np.floating]] | None
+    _fdata_cache: np.ndarray[ty.Any, np.dtype[np.inexact]] | None
 
     def __init__(
         self,
@@ -226,9 +226,9 @@ class DataobjImage(FileBasedImage):
     def get_fdata(
         self,
         caching: ty.Literal['fill', 'unchanged'] = 'fill',
-        dtype: npt.DTypeLike = np.float64,
-    ) -> np.ndarray[ty.Any, np.dtype[np.floating]]:
-        """Return floating point image data with necessary scaling applied
+        dtype: npt.DTypeLike | None = None,
+    ) -> np.ndarray[ty.Any, np.dtype[np.inexact]]:
+        """Return floating point or complex image data with necessary scaling applied
 
         The image ``dataobj`` property can be an array proxy or an array.  An
         array proxy is an object that knows how to load the image data from
@@ -261,9 +261,12 @@ class DataobjImage(FileBasedImage):
             the call to ``get_fdata`` does not create an extra (cached)
             reference to the returned array.  In this case it is easier for
             Python to free the memory from the returned array.
-        dtype : numpy dtype specifier
-            A numpy dtype specifier specifying a floating point type.  Data is
-            returned as this floating point type.  Default is ``np.float64``.
+        dtype : numpy dtype specifier, optional
+            A numpy dtype specifier specifying a floating point or complex
+            type.  Data is returned as this type.  If not specified, the
+            default is ``np.complex128`` (or wider, e.g. ``np.complex256``,
+            preserving the input precision) for images with a complex data
+            type, and ``np.float64`` otherwise.
 
         Returns
         -------
@@ -360,9 +363,21 @@ class DataobjImage(FileBasedImage):
         """
         if caching not in ('fill', 'unchanged'):
             raise ValueError('caching value should be "fill" or "unchanged"')
-        dtype = np.dtype(dtype)
+        if dtype is None:
+            # Preserve the imaginary part of complex images by default;
+            # otherwise return float64 as before.  An explicit dtype is
+            # always respected.
+            obj_dtype = getattr(self._dataobj, 'dtype', None)
+            if obj_dtype is not None and np.issubdtype(obj_dtype, np.complexfloating):
+                # At least complex128, but preserve wider complex types
+                # (e.g. complex256) so their precision is not silently lost.
+                dtype = np.promote_types(obj_dtype, np.complex128)
+            else:
+                dtype = np.dtype(np.float64)
+        else:
+            dtype = np.dtype(dtype)
         if not issubclass(dtype.type, np.inexact):
-            raise ValueError(f'{dtype} should be floating point type')
+            raise ValueError(f'{dtype} should be floating point or complex type')
         # Return cache if cache present and of correct dtype.
         if self._fdata_cache is not None:
             if self._fdata_cache.dtype.type == dtype.type:

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -814,3 +814,61 @@ class TestAFNIAPI(LoadImageAPI):
     loader = brikhead.load
     klass = image_maker = brikhead.AFNIImage
     example_images = AFNI_EXAMPLE_IMAGES
+
+
+@pytest.mark.parametrize('dtype', (np.complex64, np.complex128))
+def test_get_fdata_complex(dtype):
+    # get_fdata() preserves complex data by default (gh-975), while still
+    # respecting an explicit ``dtype`` argument.
+    real = np.arange(24).reshape(2, 3, 4)
+    imag = np.arange(24, 48).reshape(2, 3, 4)
+    arr = (real + 1j * imag).astype(dtype)
+    img = Nifti1Image(arr, np.eye(4))
+    # Test both array images and proxy images (loaded from disk)
+    for cimg in (img, bytesio_round_trip(img)):
+        # Default: preserve the imaginary part, returning complex128
+        fdata = cimg.get_fdata()
+        assert fdata.dtype == np.complex128
+        assert_array_equal(fdata, arr)
+        assert np.any(fdata.imag != 0)
+        # An explicit complex dtype is respected exactly
+        narrow = cimg.get_fdata(caching='unchanged', dtype=dtype)
+        assert narrow.dtype == dtype
+        assert_array_equal(narrow, arr)
+        # An explicit floating point dtype is respected (imaginary part dropped)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            fdata_real = cimg.get_fdata(caching='unchanged', dtype=np.float64)
+        assert fdata_real.dtype == np.float64
+        assert_array_equal(fdata_real, real)
+
+
+@pytest.mark.parametrize('dtype', (np.uint8, np.int16, np.float32, np.float64))
+def test_get_fdata_real_unchanged(dtype):
+    # Real-valued images are unaffected by the complex handling (gh-975):
+    # the default remains float64.
+    arr = np.arange(24).reshape(2, 3, 4).astype(dtype)
+    img = Nifti1Image(arr, np.eye(4))
+    for cimg in (img, bytesio_round_trip(img)):
+        fdata = cimg.get_fdata()
+        assert fdata.dtype == np.float64
+        assert not np.iscomplexobj(fdata)
+        assert_array_equal(fdata, arr)
+
+
+@pytest.mark.skipif(
+    np.dtype(np.clongdouble) == np.dtype(np.complex128),
+    reason='clongdouble == complex128 on this platform',
+)
+def test_get_fdata_complex256():
+    # The default must not silently downcast complex data wider than
+    # complex128 (e.g. complex256 on Linux/x86); it floors at complex128 but
+    # preserves wider complex types (gh-975).
+    real = np.arange(24).reshape(2, 3, 4)
+    imag = np.arange(24, 48).reshape(2, 3, 4)
+    arr = (real + 1j * imag).astype(np.clongdouble)
+    img = Nifti1Image(arr, np.eye(4))
+    fdata = img.get_fdata()
+    assert fdata.dtype == np.dtype(np.clongdouble)
+    assert_array_equal(fdata, arr)
+    assert np.any(fdata.imag != 0)


### PR DESCRIPTION
Closes #975.

## Why

`get_fdata()` defaults to `dtype=np.float64`. For a complex-valued image this
silently discards the imaginary part (emitting a NumPy `ComplexWarning`), so
users of complex data (e.g. MR spectroscopy via spec2nii) lose data unless they
know to pass `dtype=np.complex64/128` explicitly.

In #975 both maintainers agreed on the fix. The last substantive comment
(@matthew-brett, 2020-12-05) settles the scope:

> "if the image-implied dtype was complex, we'd return complex128 by default,
> instead of float64, and we'd respect the explicit dtype whatever that was."

@effigies (2020-12-03): "I think detecting the `complex` case is worth doing."
(He also floated a broader dtype-resolution overhaul with a new `mode` argument;
this PR implements only the minimal, agreed behavior and does not preclude that
larger work.)

## What

In `DataobjImage.get_fdata()`:
- Change the signature default from `dtype=np.float64` to `dtype=None` (sentinel
  for "not specified").
- When `dtype is None`: if `self._dataobj.dtype` is complex, resolve to
  `np.promote_types(obj_dtype, np.complex128)` (floors at `complex128` but
  **preserves wider complex types**, e.g. `complex256`); otherwise `np.float64`
  (unchanged).
- When `dtype` is passed: respect it exactly (unchanged).
- Update the return / `_fdata_cache` type hints from `np.floating` to
  `np.inexact`, the docstring, and broaden the validation error message to
  "floating point or complex type".

Real-valued images and every explicit-`dtype` call are unaffected. Caching is
unchanged (dtype is resolved to a concrete dtype before the cache lookup).

### Design note — wider-than-complex128 data (complex256)

NIfTI datatype code 2048 maps to `np.clongdouble`, which on Linux/x86 (the
primary CI platform) is `complex256` — *wider* than `complex128`. A naive
`dtype = np.complex128` default would silently downcast such data (the same class
of silent loss this PR fixes). Using `np.promote_types(obj_dtype, np.complex128)`
returns `complex128` for `complex64`/`complex128` and `complex256` for
`complex256` — never narrower, never lossy.

## Tests

Added to `nibabel/tests/test_image_api.py`:
- `test_get_fdata_complex[complex64/complex128]` — array and proxy images:
  default `get_fdata()` returns `complex128` and preserves the imaginary part;
  explicit `dtype=complex64/128` respected; explicit `dtype=float64` still drops
  imag.
- `test_get_fdata_real_unchanged[uint8/int16/float32/float64]` — real images
  still default to `float64` (no regression).
- `test_get_fdata_complex256` — `clongdouble` image preserves `complex256`,
  guarded with `skipif(np.dtype(np.clongdouble) == np.dtype(np.complex128))` so
  it runs on Linux/x86 CI and no-ops where `clongdouble` isn't wider.

Fail-before / pass-after verified. Full suite adds no regressions (the complex
cases fail on `master` with the imaginary part dropped, pass here).

## ⚠️ Default behavior change (please confirm)

This changes the default return dtype for complex images (`float64` →
`complex128`). Code that calls `get_fdata()` on a complex image and assumes a
real `float64` array would now receive complex output. This is the intended fix
(the old behavior was lossy and warned), but it is a behavior change — happy to
add an "API changes" changelog note, or a deprecation cycle if you'd prefer.
Callers wanting the old behavior can pass `dtype=np.float64`.

Since #975 is from 2020, flagging for @effigies / @matthew-brett: is the minimal
`complex128`-default approach (vs. the broader dtype-`mode` idea) still what you'd
like? Glad to adjust.

(Changelog fragment omitted from the commit — nibabel entries reference the PR
number and there's no open "upcoming" section at HEAD; happy to add one.)
