### PR TITLE
TEST: simplify GIFTI warning check

### DIFF
--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -20,7 +20,7 @@ from numpy.testing import assert_array_almost_equal
 
 from ...loadsave import load, save
 from ...nifti1 import xform_codes
-from ...testing import clear_and_catch_warnings, suppress_warnings
+from ...testing import suppress_warnings
 from ...tmpdirs import InTemporaryDirectory
 from .. import gifti as gi
 from ..parse_gifti_fast import GiftiImageParser, GiftiParseError
@@ -397,11 +397,9 @@ def test_parse_dataarrays():
         with open(fn, 'w') as fp:
             fp.write(txt)
 
-        with clear_and_catch_warnings() as w:
-            warnings.filterwarnings('once', category=UserWarning)
+        with pytest.warns(UserWarning):
             load(fn)
-            assert len(w) == 1
-            assert img.numDA == 0
+        assert img.numDA == 0
 
 
 def test_parse_with_buffersize():

--- a/nibabel/gifti/tests/test_parse_gifti_fast.py
+++ b/nibabel/gifti/tests/test_parse_gifti_fast.py
@@ -9,7 +9,6 @@
 
 import shutil
 import sys
-import warnings
 from os.path import basename, dirname
 from os.path import join as pjoin
 from unittest import mock


### PR DESCRIPTION
## Summary

Simplifies the warning check in `test_parse_dataarrays` by replacing manual warning capture and length checking with `pytest.warns(UserWarning)`.

This also removes the now-unused `clear_and_catch_warnings` import from the test module.

Closes #810.

## Testing

- `python -m pytest nibabel/gifti/tests/test_parse_gifti_fast.py::test_parse_dataarrays -v`
- Result: 1 passed