### PR TITLE
DOC: Clarify iter_structures return type

### DIFF
--- a/nibabel/cifti2/cifti2_axes.py
+++ b/nibabel/cifti2/cifti2_axes.py
@@ -479,7 +479,7 @@ class BrainModelAxis(Axis):
         tuple with 3 elements:
         - CIFTI-2 brain structure name
         - slice to select the data associated with the brain structure from the tensor
-        - brain model covering that specific brain structure
+        - BrainModelAxis covering that specific brain structure
         """
         idx_start = 0
         start_name = self.name[idx_start]


### PR DESCRIPTION
## Summary

- Clarify that the third value yielded by `BrainModelAxis.iter_structures()` is a `BrainModelAxis` covering the selected brain structure.

Closes #1440.

## Validation

- `python -m pytest nibabel/cifti2/tests/test_axes.py -q` (7 passed)
- `python -m pytest nibabel/cifti2/tests -q` (110 passed, 16 skipped, 1 xfailed)
- Ruff check and format check
- codespell
- `git diff --check`

## AI assistance

AI assistance was used to screen the issue, prepare the wording change, and review the patch. I verified the implementation, repository guidance, current issue and pull-request state, and all validation results listed above.
