### PR TITLE
BF: Handle frame indices where the slice index is not first (gh-1388)

### DIFF
--- a/nibabel/nicom/dicomwrappers.py
+++ b/nibabel/nicom/dicomwrappers.py
@@ -33,6 +33,14 @@ class WrapperError(Exception):
     pass
 
 
+class SliceIndexOrderError(WrapperError):
+    """Raised when a non-singular index precedes the slice index
+
+    Internal to `MultiframeWrapper.image_shape`, which retries with the slice
+    index moved to the front.
+    """
+
+
 class WrapperPrecisionError(WrapperError):
     pass
 
@@ -757,59 +765,20 @@ class MultiframeWrapper(Wrapper):
             _ = self.image_shape
         return np.lexsort(self._frame_indices.T)
 
-    @cached_property
-    def image_shape(self):
-        """The array shape as it will be returned by ``get_data()``
+    def _calc_shape(self, rows, cols, frame_indices, slice_dim_idx):
+        """Determine the array shape and the frame indices that order it
 
-        The shape is determined by the *Rows* DICOM attribute, *Columns*
-        DICOM attribute, and the set of frame indices given by the
-        *FrameContentSequence[0].DimensionIndexValues* DICOM attribute of each
-        element in the *PerFrameFunctionalGroupsSequence*.  The first two
-        axes of the returned shape correspond to the rows, and columns
-        respectively. The remaining axes correspond to those of the frame
-        indices with order preserved.
-
-        What each axis in the frame indices refers to is given by the
-        corresponding entry in the *DimensionIndexSequence* DICOM attribute.
-        **WARNING**: Any axis referring to the *StackID* DICOM attribute will
-        have been removed from the frame indices in determining the shape. This
-        is because only a file containing a single stack is currently allowed by
-        this wrapper.
-
-        References
-        ----------
-        * C.7.6.16 Multi-Frame Functional Groups Module:
-          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#sect_C.7.6.16
-        * C.7.6.17 Multi-Frame Dimension Module:
-          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#sect_C.7.6.17
-        * Diagram of DimensionIndexSequence and DimensionIndexValues:
-          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#figure_C.7.6.17-1
+        Returns the shape, and the (possibly reduced) `frame_indices` whose columns
+        correspond in order to the shape axes following rows and columns.  Raises
+        `SliceIndexOrderError` if a non-singular index precedes the slice index; the
+        caller resolves that by reordering the columns.
         """
-        rows, cols = self.get('Rows'), self.get('Columns')
-        if None in (rows, cols):
-            raise WrapperError('Rows and/or Columns are empty.')
-        # Check number of frames and handle single frame files
-        n_frames = len(self.frames)
-        if n_frames == 1:
-            self._frame_indices = np.array([[0]], dtype=np.int64)
-            return (rows, cols)
-        # Initialize array of frame indices
-        try:
-            frame_indices = np.array(
-                [frame.FrameContentSequence[0].DimensionIndexValues for frame in self.frames]
-            )
-        except AttributeError:
-            raise WrapperError("Can't find frame 'DimensionIndexValues'")
-        if len(frame_indices.shape) == 1:
-            frame_indices = frame_indices.reshape(frame_indices.shape + (1,))
         # Determine the shape and which indices to use
+        n_frames = len(frame_indices)
         shape = [rows, cols]
         curr_parts = n_frames
         frames_per_part = 1
         del_indices = {}
-        dim_seq = [dim.DimensionIndexPointer for dim in self.get('DimensionIndexSequence')]
-        stackpos_tag = pydicom.datadict.tag_for_keyword('InStackPositionNumber')
-        slice_dim_idx = dim_seq.index(stackpos_tag)
         for row_idx, row in enumerate(frame_indices.T):
             unique = np.unique(row)
             count = len(unique)
@@ -819,7 +788,7 @@ class MultiframeWrapper(Wrapper):
             # Replace slice indices with order determined from slice positions along normal
             if row_idx == slice_dim_idx:
                 if len(shape) > 2:
-                    raise WrapperError('Non-singular index precedes the slice index')
+                    raise SliceIndexOrderError('Non-singular index precedes the slice index')
                 row = self._frame_slc_ord
                 frame_indices.T[row_idx, :] = row
                 unique = np.unique(row)
@@ -879,9 +848,74 @@ class MultiframeWrapper(Wrapper):
                     )
         if curr_parts > 1:
             raise WrapperError('Unable to determine sorting of final dimension(s)')
+        return tuple(shape), frame_indices
+
+    @cached_property
+    def image_shape(self):
+        """The array shape as it will be returned by ``get_data()``
+
+        The shape is determined by the *Rows* DICOM attribute, *Columns*
+        DICOM attribute, and the set of frame indices given by the
+        *FrameContentSequence[0].DimensionIndexValues* DICOM attribute of each
+        element in the *PerFrameFunctionalGroupsSequence*.  The first two
+        axes of the returned shape correspond to the rows, and columns
+        respectively. The remaining axes correspond to those of the frame
+        indices with order preserved, except that a slice index preceded by a
+        non-singular index is moved ahead of it, so that the slice axis always
+        immediately follows the columns.
+
+        What each axis in the frame indices refers to is given by the
+        corresponding entry in the *DimensionIndexSequence* DICOM attribute.
+        **WARNING**: Any axis referring to the *StackID* DICOM attribute will
+        have been removed from the frame indices in determining the shape. This
+        is because only a file containing a single stack is currently allowed by
+        this wrapper.
+
+        References
+        ----------
+        * C.7.6.16 Multi-Frame Functional Groups Module:
+          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#sect_C.7.6.16
+        * C.7.6.17 Multi-Frame Dimension Module:
+          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#sect_C.7.6.17
+        * Diagram of DimensionIndexSequence and DimensionIndexValues:
+          http://dicom.nema.org/medical/dicom/current/output/pdf/part03.pdf#figure_C.7.6.17-1
+        """
+        rows, cols = self.get('Rows'), self.get('Columns')
+        if None in (rows, cols):
+            raise WrapperError('Rows and/or Columns are empty.')
+        # Check number of frames and handle single frame files
+        n_frames = len(self.frames)
+        if n_frames == 1:
+            self._frame_indices = np.array([[0]], dtype=np.int64)
+            return (rows, cols)
+        # Initialize array of frame indices
+        try:
+            frame_indices = np.array(
+                [frame.FrameContentSequence[0].DimensionIndexValues for frame in self.frames]
+            )
+        except AttributeError:
+            raise WrapperError("Can't find frame 'DimensionIndexValues'")
+        if len(frame_indices.shape) == 1:
+            frame_indices = frame_indices.reshape(frame_indices.shape + (1,))
+        dim_seq = [dim.DimensionIndexPointer for dim in self.get('DimensionIndexSequence')]
+        stackpos_tag = pydicom.datadict.tag_for_keyword('InStackPositionNumber')
+        slice_dim_idx = dim_seq.index(stackpos_tag)
+        try:
+            shape, frame_indices = self._calc_shape(rows, cols, frame_indices, slice_dim_idx)
+        except SliceIndexOrderError:
+            # The shape gains one axis per surviving column of `frame_indices`, in
+            # column order, and `frame_order` lexsorts those same columns, so the slice
+            # index must come first for frames to sort slice-fastest --
+            # `get_unscaled_data` reshapes with order='F'.  Some vendors order the
+            # dimension indices with a non-singular index (e.g. TemporalPositionIndex)
+            # ahead of InStackPositionNumber; retry those with the slice column moved to
+            # the front.  Files that already worked never raise, so they are unaffected.
+            n_dims = frame_indices.shape[1]
+            col_order = [slice_dim_idx] + [i for i in range(n_dims) if i != slice_dim_idx]
+            shape, frame_indices = self._calc_shape(rows, cols, frame_indices[:, col_order], 0)
         # Store frame indices
         self._frame_indices = frame_indices
-        return tuple(shape)
+        return shape
 
     @cached_property
     def image_orient_patient(self):

--- a/nibabel/nicom/tests/test_dicomwrappers.py
+++ b/nibabel/nicom/tests/test_dicomwrappers.py
@@ -680,11 +680,11 @@ class TestMultiFrameWrapper(TestCase):
         div_seq = ((1, 1, 1), (2, 1, 1), (1, 1, 2), (2, 1, 2), (1, 1, 3), (2, 1, 3))
         fake_mf.update(fake_shape_dependents(div_seq, sid_dim=1))
         assert MFW(fake_mf).image_shape == (32, 64, 2, 3)
-        # Check non-singular dimension preceding slice dim raises
+        # A non-singular dimension preceding the slice dim is supported by moving
+        # the slice dim to the front of the frame indices (gh-1388)
         div_seq = ((1, 1, 1), (1, 2, 1), (1, 1, 2), (1, 2, 2), (1, 1, 3), (1, 2, 3))
         fake_mf.update(fake_shape_dependents(div_seq, sid_dim=0, slice_dim=2))
-        with pytest.raises(didw.WrapperError):
-            MFW(fake_mf).image_shape
+        assert MFW(fake_mf).image_shape == (32, 64, 3, 2)
         # Test with combo indices, here with the last two needing to be combined into
         # a single index corresponding to [(1, 1), (1, 1), (2, 1), (2, 1), (2, 2), (2, 2)]
         div_seq = (
@@ -1010,6 +1010,55 @@ class TestMultiFrameWrapper(TestCase):
         sorted_data = sorted_data[..., np.argsort(order)]
         fake_mf.pixel_array = np.rollaxis(sorted_data, 2)
         assert_array_equal(MFW(fake_mf).get_data(), data * 2.0 - 1)
+
+    @dicom_test
+    @pytest.mark.thread_unsafe
+    def test_data_fake_slice_dim_not_first(self):
+        # Frame indices that place a non-singular index (here a temporal index)
+        # before InStackPositionNumber must still produce correctly ordered data.
+        # Shape is unpacked with order='F', so frames have to sort slice-fastest
+        # regardless of the DimensionIndexSequence order (gh-1388).
+        fake_mf = deepcopy(self.MINIMAL_MF)
+        MFW = self.WRAPCLASS
+        fake_mf.Rows = 2
+        fake_mf.Columns = 3
+        shape = (2, 3, 4, 2)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        # Columns are (TemporalPositionIndex, StackID, InStackPositionNumber),
+        # listed slice-fastest so they line up with an order='F' unpacking
+        div_seq = [(t, 1, s) for t in (1, 2) for s in (1, 2, 3, 4)]
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=1, slice_dim=2))
+        assert MFW(fake_mf).image_shape == shape
+        sorted_data = data.reshape(shape[:2] + (-1,), order='F')
+        object.__setattr__(fake_mf, 'pixel_array', np.rollaxis(sorted_data, 2))
+        assert_array_equal(MFW(fake_mf).get_data(), data)
+        # Same volume with the frames stored in a scrambled order
+        order = [5, 0, 7, 2, 1, 4, 3, 6]
+        div_seq = [div_seq[i] for i in order]
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=1, slice_dim=2))
+        object.__setattr__(fake_mf, 'pixel_array', np.rollaxis(sorted_data[..., order], 2))
+        assert_array_equal(MFW(fake_mf).get_data(), data)
+
+    @dicom_test
+    @pytest.mark.thread_unsafe
+    def test_data_fake_slice_dim_not_first_5d(self):
+        # As above, but with two differently sized non-slice dimensions after the
+        # slice index, so that any misordering *among* the non-slice axes shows up
+        # in the shape and the data, not just the slice axis (gh-1388).
+        fake_mf = deepcopy(self.MINIMAL_MF)
+        MFW = self.WRAPCLASS
+        fake_mf.Rows = 2
+        fake_mf.Columns = 3
+        shape = (2, 3, 4, 2, 3)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        # Columns are (TemporalPositionIndex, StackID, InStackPositionNumber, B),
+        # listed slice-fastest, then temporal, then B, to match an order='F' unpacking
+        div_seq = [(t, 1, s, b) for b in (1, 2, 3) for t in (1, 2) for s in (1, 2, 3, 4)]
+        fake_mf.update(fake_shape_dependents(div_seq, sid_dim=1, slice_dim=2))
+        assert MFW(fake_mf).image_shape == shape
+        sorted_data = data.reshape(shape[:2] + (-1,), order='F')
+        object.__setattr__(fake_mf, 'pixel_array', np.rollaxis(sorted_data, 2))
+        assert_array_equal(MFW(fake_mf).get_data(), data)
 
     @dicom_test
     def test_scale_data(self):


### PR DESCRIPTION
Closes #1388.

## Problem

`MultiframeWrapper.image_shape` rejects any file whose `DimensionIndexSequence`
places a non-singular index before `InStackPositionNumber`:

```
WrapperError: Non-singular index precedes the slice index
```

The Bruker enhanced DICOM in #1388 has frame index order
`TemporalPositionIndex`, `StackID`, `InStackPositionNumber`, so the series
cannot be read at all.

That layout is conformant. DICOM PS3.3
[C.7.6.17](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.17.html)
ties the value order to the sequence order — *"The ordering of the Items in the
Sequence defines the ordering in the Dimension Index Values Attribute"* — and
leaves that choice to the writer: *"It is up to the generating applications to
decide what Attributes are important to describe the multi-frame dimensions"*,
and *"The actual order of the Frames in the object is up to the generating
application."* Nothing requires `InStackPositionNumber` to come first.

## Why the restriction exists

There is a real invariant behind it:

* the shape gains one axis per surviving column of `frame_indices`, **in column
  order**;
* `frame_order` sorts with `np.lexsort(self._frame_indices.T)`, where the
  **last** column is the primary key;
* `get_unscaled_data` reshapes with `order='F'`, so frames must sort
  slice-fastest.

Those agree only when the slice column comes first, which today happens by
accident: in the layouts that work, the columns preceding the slice index are
singular and get dropped.

This is worth stating because it constrains the fix. Simply relaxing the
`len(shape) > 2` check returns the correct shape with **silently transposed
volumes**, since the lexsort would then take the slice column as its primary
key. That is worse than the exception.

## Fix

The shape calculation moves into `_calc_shape`, and `image_shape` retries it
with the slice column moved to the front **only if** the original column order
raises. The reorder keeps the shape axes aligned with the index columns, so the
retried files also unpack in the right order.

Scoping it as a retry rather than an unconditional reorder is deliberate: a file
that is handled today never raises, so it never reaches the fallback, and its
shape, frame order and data are bit-identical to before. I first wrote this as
an unconditional reorder and it caused three regressions — a file with uneven
`InStackPositionNumber` values became a hard `WrapperError: Missing slices`, a
single-slice multiframe gained a spurious singleton axis, and one layout was
silently reinterpreted. All three now match `master` exactly.

## Behaviour change

`test_shape` previously asserted that this layout raises:

```python
# Check non-singular dimension preceding slice dim raises
```

It now asserts `(32, 64, 3, 2)`. That is the point of the issue, and matches
@moloney's reading on the thread:

> The code currently assumes we don't need to reorder the DimensionIndexValues,
> mostly out of expediency and lack of a clear need. Your dataset appears to
> show that we do need to check for and allow this.

The class docstring is updated, since the remaining axes are no longer strictly
"order preserved". No `Changelog` entry — that file looks to be maintained by
the release manager rather than per-PR; happy to add one if you'd prefer.

## Tests

The issue stalled waiting on a sample dataset, so this uses the existing
`fake_shape_dependents` harness and needs no external data:

* `test_shape` — the previously rejected layout returns `(32, 64, 3, 2)`.
* `test_data_fake_slice_dim_not_first` — checks the **data**, for a 4D volume
  with the temporal index ahead of the slice index, in acquisition order and
  with the frames scrambled.
* `test_data_fake_slice_dim_not_first_5d` — two differently sized non-slice
  dimensions after the slice index, so misordering *among* the non-slice axes is
  caught too.

Verified failing on `master` and passing here. I also sabotaged the fix to
confirm the tests bite: reversing the non-slice column order and disabling the
retry each fail the suite. `nibabel/nicom` is green serially and under
`--parallel-threads 16`; the full suite is 5288 passed, 270 skipped.

---

_AI-assisted, human-reviewed._
