### PR TITLE
BF: Preserve MGH tag data across an unmodified round-trip (gh-1402)

### DIFF
--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -11,6 +11,8 @@
 Author: Krish Subramaniam
 """
 
+import warnings
+from io import UnsupportedOperation
 from os.path import splitext
 
 import numpy as np
@@ -29,6 +31,12 @@ from ..wrapstruct import LabeledWrapStruct
 # mgh header
 # See https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat
 DATA_OFFSET = 284
+# Upper bound on the tag data retained after the footer.  This has to be generous:
+# TAG_MRI_FRAME stores per-frame acquisition parameters, so a long BOLD run
+# legitimately carries megabytes of tags.  The bound exists only to stop a file whose
+# `dims` field understates the data -- which makes the voxel data itself look like
+# tag data -- from pulling an unbounded amount into memory.
+MAX_TAG_BYTES = 2**26
 # Note that mgh data is strictly big endian ( hence the > sign )
 # fmt: off
 header_dtd = [
@@ -98,6 +106,19 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
 
     The header also consists of the footer data which MGH places after the data
     chunk.
+
+    FreeSurfer may write additional, variable-length tag data after the footer
+    (e.g. ``TAG_CMDLINE`` history, auto-align matrices, embedded colour tables).
+    That data is not interpreted here, but is retained verbatim in ``_tags`` so
+    that an otherwise unmodified load/save round-trip does not discard it.
+
+    Tags are *not* portable between volumes.  Several are tied to the volume they
+    were written with -- ``TAG_MRI_FRAME`` carries per-frame state sized by the
+    frame count, and ``TAG_AUTO_ALIGN`` holds a geometry-specific transform -- so
+    writing them alongside a different volume yields a file FreeSurfer will
+    misparse.  The bytes are therefore recorded together with the header state they
+    were read with (``_tags_binaryblock``) and are only written back while the
+    header is unchanged; see ``_tags_valid``.
     """
 
     # Copies of module-level definitions
@@ -105,6 +126,10 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
     _hdrdtype = header_dtype
     _ftrdtype = footer_dtype
     _data_type_codes = data_type_codes
+    # Uninterpreted bytes following the footer; see class docstring
+    _tags = b''
+    # Header state `_tags` was read with; None when there are no tags
+    _tags_binaryblock = None
 
     def __init__(self, binaryblock=None, check=True):
         """Initialize header from binary data block
@@ -177,7 +202,21 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
             + int(klass._data_type_codes.bytespervox[tp]) * np.prod(hdr_str_to_np['dims'])
         )
         ftr_str = fileobj.read(klass._ftrdtype.itemsize)
-        return klass(hdr_str + ftr_str, check=check)
+        hdr = klass(hdr_str + ftr_str, check=check)
+        # Retain any tag data following the footer so that it survives an unmodified
+        # load/save round-trip (see class docstring).  Read one byte more than we are
+        # willing to keep so that an over-long trailing region can be detected.
+        tags = fileobj.read(MAX_TAG_BYTES + 1)
+        if len(tags) > MAX_TAG_BYTES:
+            warnings.warn(
+                f'MGH tag data exceeds {MAX_TAG_BYTES} bytes and will not be preserved; '
+                'the file may be malformed',
+                stacklevel=2,
+            )
+        elif tags:
+            hdr._tags = tags
+            hdr._tags_binaryblock = hdr.binaryblock
+        return hdr
 
     def get_affine(self):
         """Get the affine transform from the header information.
@@ -408,10 +447,22 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
         fileobj.seek(0)
         fileobj.write(hdr_nofooter.tobytes())
 
+    @property
+    def _tags_valid(self):
+        """True if the retained tag data still matches this header
+
+        Tag data is tied to the volume it was read with, so it is only safe to write
+        it back out while the header is byte-for-byte unchanged.  Any edit that alters
+        the frame count, shape, data type or geometry invalidates it.
+        """
+        return bool(self._tags) and self.binaryblock == self._tags_binaryblock
+
     def writeftr_to(self, fileobj):
         """Write footer to fileobj
 
         Footer data is located after the data chunk. So move there and write.
+        Retained tag data (see class docstring) is written after the footer, but
+        only while it still corresponds to this header.
 
         Parameters
         ----------
@@ -428,10 +479,24 @@ class MGHHeader(LabeledWrapStruct, SpatialHeader):
         )
         fileobj.seek(self.get_footer_offset())
         fileobj.write(ftr_nd.tobytes())
+        if self._tags_valid:
+            fileobj.write(self._tags)
+        # The image ends here.  Without this, writing a smaller image over a reused
+        # stream (e.g. `to_file_map` with a `BytesIO`) would leave bytes from the
+        # previous, larger image behind, to be read back as tag data.
+        try:
+            fileobj.truncate()
+        except (AttributeError, OSError, UnsupportedOperation):
+            # Streams that cannot truncate, such as gzip, are written from the start
+            # each time, so they have no stale trailing bytes to remove.
+            pass
 
     def copy(self):
         """Return copy of structure"""
-        return self.__class__(self.binaryblock, check=False)
+        new = self.__class__(self.binaryblock, check=False)
+        new._tags = self._tags
+        new._tags_binaryblock = self._tags_binaryblock
+        return new
 
     def as_byteswapped(self, endianness=None):
         """Return new object with given ``endianness``

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -11,6 +11,7 @@
 import io
 import os
 import pathlib
+import struct
 
 import numpy as np
 import pytest
@@ -18,6 +19,7 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert
 
 from ... import imageglobals
 from ...fileholders import FileHolder
+from ...funcs import four_to_three
 from ...openers import ImageOpener
 from ...spatialimages import HeaderDataError
 from ...testing import data_path
@@ -27,7 +29,7 @@ from ...tmpdirs import InTemporaryDirectory
 from ...volumeutils import sys_is_le
 from ...wrapstruct import WrapStructError
 from .. import load, save
-from ..mghformat import MGHError, MGHHeader, MGHImage
+from ..mghformat import MAX_TAG_BYTES, MGHError, MGHHeader, MGHImage
 
 MGZ_FNAME = os.path.join(data_path, 'test.mgz')
 
@@ -188,6 +190,110 @@ def test_bad_dtype_mgh():
     # Now test the above function
     with pytest.raises(MGHError):
         bad_dtype_mgh()
+
+
+@pytest.mark.thread_unsafe
+def test_tag_data_roundtrip():
+    # FreeSurfer may append variable-length tag data (command history,
+    # colour tables, ...) after the footer. nibabel does not interpret it, but
+    # must not drop it on a load/save round-trip (gh-1402).
+    v = np.arange(24, dtype=np.uint8).reshape((2, 3, 4))
+    # Stand-in for FreeSurfer tag data: a tag id (TAG_CMDLINE == 3, per FreeSurfer
+    # include/tags.h) followed by a length and a payload. nibabel does not interpret
+    # the tag data, so the exact encoding is immaterial here -- what matters is that
+    # trailing bytes of any length survive unchanged.
+    cmdline = b'mri_convert wm.mgz wm.mgz\x00'
+    tags = struct.pack('>i', 3) + struct.pack('>q', len(cmdline)) + cmdline
+    with InTemporaryDirectory():
+        MGHImage(v, np.eye(4)).to_filename('tagless.mgz')
+        with ImageOpener('tagless.mgz') as fobj:
+            tagless = fobj.read()
+        with ImageOpener('tagged.mgz', 'wb') as fobj:
+            fobj.write(tagless + tags)
+        # The tag data must survive a load/save round-trip byte for byte
+        img = load('tagged.mgz')
+        img.to_filename('roundtrip.mgz')
+        with ImageOpener('roundtrip.mgz') as fobj:
+            assert fobj.read() == tagless + tags
+        assert img.header._tags == tags
+        # Copying a header carries the tag data with it
+        assert MGHHeader.from_header(img.header)._tags == tags
+        # Editing the voxel data but not the header still round-trips the tags;
+        # this is the case reported in gh-1402
+        edited = MGHImage(v * 2, img.affine, header=img.header)
+        edited.to_filename('edited.mgz')
+        with ImageOpener('edited.mgz') as fobj:
+            assert fobj.read().endswith(tags)
+        # Images without tag data are unaffected
+        reloaded = load('tagless.mgz')
+        reloaded.to_filename('tagless2.mgz')
+        with ImageOpener('tagless2.mgz') as fobj:
+            assert fobj.read() == tagless
+        assert reloaded.header._tags == b''
+
+
+@pytest.mark.thread_unsafe
+def test_tag_data_not_reused_across_volumes():
+    # Tag data is tied to the volume it was written with (TAG_MRI_FRAME is sized
+    # by the frame count, TAG_AUTO_ALIGN is geometry-specific), so it must not be
+    # carried onto a derived image with a different shape (gh-1402).
+    img = load(os.path.join(data_path, 'test.mgz'))
+    assert img.header._tags != b''
+    assert img.header._tags_valid
+    with InTemporaryDirectory():
+        # An unmodified round-trip keeps them
+        img.to_filename('same.mgz')
+        assert load('same.mgz').header._tags == img.header._tags
+        # Dropping a frame invalidates them
+        single = four_to_three(img)[0]
+        assert single.header._tags_valid is False
+        single.to_filename('single.mgz')
+        assert load('single.mgz').header._tags == b''
+        # As does changing the shape or the data type. The header is only
+        # brought up to date as the image is written, so check the output.
+        others = {
+            'reshaped.mgz': MGHImage(
+                np.zeros((2, 3, 4), dtype=np.float32), img.affine, header=img.header
+            ),
+            'retyped.mgz': MGHImage(
+                np.zeros(img.shape, dtype=np.int16), img.affine, header=img.header
+            ),
+        }
+        others['retyped.mgz'].set_data_dtype(np.int16)
+        for fname, other in others.items():
+            other.to_filename(fname)
+            assert load(fname).header._tags == b''
+
+
+@pytest.mark.thread_unsafe
+def test_tag_data_not_laundered_from_reused_stream():
+    # Writing a smaller image over a reused stream must not leave bytes from the
+    # previous, larger image behind to be read back as tag data (gh-1402).
+    fmap = lambda fobj: {'image': FileHolder(fileobj=fobj)}
+    bio = io.BytesIO()
+    MGHImage(np.ones((8, 8, 8), dtype=np.uint8), np.eye(4)).to_file_map(fmap(bio))
+    bio.seek(0)
+    MGHImage(np.ones((2, 2, 2), dtype=np.uint8), np.eye(4)).to_file_map(fmap(bio))
+    reread = MGHImage.from_file_map(fmap(io.BytesIO(bio.getvalue())))
+    assert reread.shape == (2, 2, 2)
+    assert reread.header._tags == b''
+
+
+@pytest.mark.thread_unsafe
+def test_tag_data_bounded():
+    # A file whose `dims` understate the data makes the voxel data itself look
+    # like tag data; that must not be read without bound (gh-1402).
+    v = np.zeros((2, 3, 4), dtype=np.uint8)
+    with InTemporaryDirectory():
+        MGHImage(v, np.eye(4)).to_filename('base.mgz')
+        with ImageOpener('base.mgz') as fobj:
+            base = fobj.read()
+        with ImageOpener('huge.mgz', 'wb') as fobj:
+            fobj.write(base + b'\x00' * (MAX_TAG_BYTES + 1))
+        with pytest.warns(UserWarning, match='exceeds'):
+            img = load('huge.mgz')
+        assert img.header._tags == b''
+        assert img.header._tags_valid is False
 
 
 @pytest.mark.thread_unsafe

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -168,6 +168,9 @@ class Opener:
     def tell(self, /) -> int:
         return self.fobj.tell()
 
+    def truncate(self, size: int | None = None, /) -> int:
+        return self.fobj.truncate(size)
+
     def close(self, /) -> None:
         return self.fobj.close()
 


### PR DESCRIPTION
Closes #1402.

## Problem

FreeSurfer may write variable-length tag data after the MGH footer —
`TAG_CMDLINE` history, `TAG_AUTO_ALIGN`, `TAG_MRI_FRAME`, embedded colour
tables. `MGHHeader.from_fileobj` reads exactly `footer_dtype.itemsize` bytes and
`writeftr_to` writes back only that struct, so everything after the footer is
silently dropped on a load/save round-trip.

This is reproducible with the file already in the repo:

```python
import gzip, tempfile, nibabel as nib
d = tempfile.mkdtemp()
img = nib.load('nibabel/tests/data/test.mgz')
img.to_filename(f'{d}/rt.mgz')
len(gzip.open('nibabel/tests/data/test.mgz', 'rb').read())  # 23215
len(gzip.open(f'{d}/rt.mgz', 'rb').read())                  # 784  -> 22431 bytes lost
```

That file's tags are `[(41, 7), (42, 22400)]` — `TAG_PEDIR` and `TAG_MRI_FRAME`.

It presents confusingly, which is probably why the original thread stalled: the
header compares as identical in both nibabel and `mri_info`, and only the file
size differs. That is exactly what the reporter described — *"Both nibabel and
FreeSurfer's mri_info says that both images have identical headers. However
after decompressing the mgz to mgh I noticed the size of both files are not the
same."* — and it is consistent with their `recon-all` failure.

## Fix

Retain the trailing bytes on read and write them back after the footer. They are
not interpreted.

**Tags are not portable between volumes.** `TAG_MRI_FRAME` stores per-frame
acquisition parameters — 11200 bytes per frame in the bundled file — and
`TAG_AUTO_ALIGN` holds a geometry-specific transform. Writing them next to a
different volume produces a file FreeSurfer will misparse: it would read
per-frame state for frames that no longer exist. So the bytes are recorded
together with the header state they were read with, and written back only while
that header is unchanged:

```python
img = nib.load('.../test.mgz')          # nframes 2, 22431 tag bytes
nib.funcs.four_to_three(img)[0]         # nframes 1 -> tags dropped, not rewritten
img.slicer[:2, :2, :2]                  # tags dropped
img.to_filename(...)                    # unchanged header -> all 22431 bytes preserved
```

Editing voxel data while leaving the header alone — the case in the issue — keeps
the tags.

Two supporting changes:

* The read is bounded by `MAX_TAG_BYTES`. A file whose `dims` field understates
  the data makes the voxel data itself look like tag data; unbounded, a 597 KB
  `.mgz` can expand to over a gigabyte resident, on what is otherwise a lazy
  header read. The bound is deliberately generous (64 MiB) because
  `TAG_MRI_FRAME` grows with the frame count — a long BOLD run legitimately
  carries megabytes of tags. Over the bound, it warns and keeps none.
* `writeftr_to` truncates. Writing a smaller image over a reused stream (e.g.
  `to_file_map` with a `BytesIO`) previously left bytes from the larger image
  behind; harmless before, but they would now be read back as tag data and
  become sticky. `ImageOpener` gains a `truncate` passthrough for this.

## Tests

* `test_tag_data_roundtrip` — byte-exact round-trip; tags survive a data-only
  edit; tagless files are untouched.
* `test_tag_data_not_reused_across_volumes` — uses the bundled `test.mgz`, and
  asserts tags are dropped for `four_to_three`, a reshape and a dtype change.
* `test_tag_data_bounded` — over-long trailing region warns and keeps no tags.
* `test_tag_data_not_laundered_from_reused_stream` — the truncation case.

Verified against `master`: the round-trip above loses 22431 bytes there and 0
here. Full suite 5290 passed, 270 skipped; `nibabel/freesurfer` is also green
under `--parallel-threads 16`.

One judgement call worth flagging: because the fingerprint is the header, editing
only voxel data keeps the tags. That is right for `TAG_MRI_FRAME` and
`TAG_CMDLINE`, but a segmentation whose labels are rewritten in place would keep
a colour table that no longer matches. Distinguishing those needs the tags to be
parsed, which is a larger change than this. Happy to go further if you'd prefer.

---

_AI-assisted, human-reviewed._
