### PR TITLE
doc: Link to expired deprecation error class in docstrings

### DIFF
--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -4,24 +4,14 @@ from __future__ import annotations
 
 import functools
 import re
-import sys
 import typing as ty
 import warnings
-from textwrap import dedent
 
 if ty.TYPE_CHECKING:
     T = ty.TypeVar('T')
     P = ty.ParamSpec('P')
 
 _LEADING_WHITE = re.compile(r'^(\s*)')
-
-
-def _dedent_docstring(docstring):
-    """Compatibility with Python 3.13+.
-
-    xref: https://github.com/python/cpython/issues/81283
-    """
-    return '\n'.join([dedent(line) for line in docstring.split('\n')])
 
 
 TESTSETUP = """
@@ -43,10 +33,6 @@ TESTCLEANUP = """
     >>> _ = _suppress_warnings.__exit__(None, None, None)
 
 """
-
-if sys.version_info >= (3, 13):
-    TESTSETUP = _dedent_docstring(TESTSETUP)
-    TESTCLEANUP = _dedent_docstring(TESTCLEANUP)
 
 
 class ExpiredDeprecationError(RuntimeError):

--- a/nibabel/deprecator.py
+++ b/nibabel/deprecator.py
@@ -213,7 +213,8 @@ class Deprecator:
         if until:
             messages.append(
                 f'* {"Raises" if self.is_bad_version(until) else "Will raise"} '
-                f'{exception} as of version: {until}'
+                f':class:`~{exception.__module__}.{exception.__qualname__}` '
+                f'as of version: {until}'
             )
         message = '\n'.join(messages)
 

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -112,19 +112,19 @@ class TestDeprecatorFunc:
         with pytest.deprecated_call() as w:
             assert func() is None
             assert len(w) == 1
-        assert (
-            func.__doc__ == f'foo\n\n* Will raise {ExpiredDeprecationError} as of version: 99.4\n'
-        )
+        qualname = f'{ExpiredDeprecationError.__module__}.{ExpiredDeprecationError.__qualname__}'
+        rst_link = f':class:`~{qualname}`'
+        assert func.__doc__ == f'foo\n\n* Will raise {rst_link} as of version: 99.4\n'
         func = dec('foo', until='1.8')(func_no_doc)
         with pytest.raises(ExpiredDeprecationError):
             func()
-        assert func.__doc__ == f'foo\n\n* Raises {ExpiredDeprecationError} as of version: 1.8\n'
+        assert func.__doc__ == f'foo\n\n* Raises {rst_link} as of version: 1.8\n'
         func = dec('foo', '1.2', '1.8')(func_no_doc)
         with pytest.raises(ExpiredDeprecationError):
             func()
         assert (
             func.__doc__ == 'foo\n\n* deprecated from version: 1.2\n* Raises '
-            f'{ExpiredDeprecationError} as of version: 1.8\n'
+            f'{rst_link} as of version: 1.8\n'
         )
         func = dec('foo', '1.2', '1.8')(func_doc_long)
         assert (
@@ -135,7 +135,7 @@ A docstring
 foo
 
 * deprecated from version: 1.2
-* Raises {ExpiredDeprecationError} as of version: 1.8
+* Raises {rst_link} as of version: 1.8
 """
         )
         with pytest.raises(ExpiredDeprecationError):

--- a/nibabel/tests/test_deprecator.py
+++ b/nibabel/tests/test_deprecator.py
@@ -13,7 +13,6 @@ from nibabel.deprecator import (
     Deprecator,
     ExpiredDeprecationError,
     _add_dep_doc,
-    _dedent_docstring,
     _ensure_cr,
 )
 
@@ -21,13 +20,16 @@ from ..testing import clear_and_catch_warnings
 
 _OWN_MODULE = sys.modules[__name__]
 
-func_docstring = (
-    f'A docstring\n   \n   foo\n   \n{indent(TESTSETUP, "   ", lambda x: True)}'
-    f'   Some text\n{indent(TESTCLEANUP, "   ", lambda x: True)}'
-)
+func_docstring = f"""A docstring
 
-if sys.version_info >= (3, 13):
-    func_docstring = _dedent_docstring(func_docstring)
+foo
+
+{TESTSETUP}Some text
+{TESTCLEANUP}"""
+
+if sys.version_info < (3, 13):
+    # Pre-3.13, docstrings were not auto-dedented, so reinject the indentation
+    func_docstring = indent(func_docstring, '    ', lambda text: text != 'A docstring\n')
 
 
 def test__ensure_cr():
@@ -76,7 +78,10 @@ def func_doc(i):
 
 
 def func_doc_long(i, j):
-    """A docstring\n\n   Some text"""
+    """A docstring
+
+    Some text
+    """
 
 
 class TestDeprecatorFunc:


### PR DESCRIPTION
The docstring that reports the anticipated/effective deprecation error class looks like `<class ‘nibabel.deprecator.ExpiredDeprecationError’>` (the `repr()`). e.g.,

![](https://private-user-images.githubusercontent.com/83442/645175082-907747e9-58a8-4853-9fda-5063bd0be01b.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODgzNzI4MTQsIm5iZiI6MTc4ODM3MjUxNCwicGF0aCI6Ii84MzQ0Mi82NDUxNzUwODItOTA3NzQ3ZTktNThhOC00ODUzLTlmZGEtNTA2M2JkMGJlMDFiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA5MDIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwOTAyVDE4MDgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTc3ZDQ1NjMyMTRjNTc0YjA1NTBmODNiODc5MmY2ZjdkZTljZDlhOWRiZmZkZTAzZTdiMjA5YTA5YjVmNDVmYjcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.sn-PFmMhPLS3_R8oTG-ZtTvIGiJZANhQ2IkU0PO47AA)

Given that this is in a docstring that will mostly be rendered, an RST link is more appropriate. 

[Example](https://nibabel-draft--1545.org.readthedocs.build/en/1545/reference/nibabel.casting.html#as-int):

<img width="721" height="325" alt="image" src="https://github.com/user-attachments/assets/b6f4a281-df18-46de-a872-0bb610c97139" />

Edit: In passing cleaned up the formatting of the testsetup/testcleanup blocks. Looks like we fixed the tests but didn't make sure things rendered well in #1315.