### PR TITLE
BF: keep the sform and qform codes across a reorientation

### DIFF
--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -2402,6 +2402,21 @@ class Nifti1Pair(analyze.AnalyzeImage):
 
         img.header.set_dim_info(*new_dim)
 
+        # Reorienting permutes and flips axes; it does not move the image into
+        # a different space.  Writing the new affine into the header goes
+        # through _affine2header, which files it under the default 'aligned'
+        # sform code and drops the qform, so a scanner anat image came back
+        # labelled as merely aligned (gh-1427).  Restore whichever codes were
+        # set before.  A code of 0 is left alone: the image had no form of that
+        # kind to preserve, and clearing what _affine2header just set could
+        # leave the image with no valid form at all.
+        sform_code = int(self.header['sform_code'])
+        qform_code = int(self.header['qform_code'])
+        if sform_code != 0:
+            img.header.set_sform(img.affine, code=sform_code)
+        if qform_code != 0:
+            img.header.set_qform(img.affine, code=qform_code)
+
         return img
 
 

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -1573,6 +1573,37 @@ class TestNifti1General:
                 bias_thresh = np.max([max_miss / np.sqrt(count), eps])
                 assert np.abs(bias) < bias_thresh
 
+    def test_reoriented_preserves_xform_codes(self):
+        # gh-1427: reorienting permutes and flips axes, it does not move the
+        # image into another space, so the sform/qform codes must survive.
+        # dcm2niix writes scanner anat (code 1) for both.
+        affine = np.diag([-2.0, 2, 2, 1])
+        affine[:3, 3] = [10, -20, -30]
+        img = self.single_class(np.zeros((4, 4, 4)), affine)
+        img.header.set_sform(affine, code=1)
+        img.header.set_qform(affine, code=1)
+
+        reoriented = img.as_reoriented([[0, -1], [1, 1], [2, 1]])
+
+        assert int(reoriented.header['sform_code']) == 1
+        assert int(reoriented.header['qform_code']) == 1
+        # The header must still describe the affine the image reports.
+        assert_array_equal(reoriented.affine, reoriented.header.get_best_affine())
+
+    def test_reoriented_leaves_unset_xform_codes_alone(self):
+        # An image with no qform has nothing to preserve there, and clearing
+        # what the affine write-back set could leave it with no valid form.
+        affine = np.diag([-2.0, 2, 2, 1])
+        img = self.single_class(np.zeros((4, 4, 4)), affine)
+        img.header.set_sform(affine, code=4)
+        img.header.set_qform(None, code=0)
+
+        reoriented = img.as_reoriented([[0, -1], [1, 1], [2, 1]])
+
+        assert int(reoriented.header['sform_code']) == 4
+        assert int(reoriented.header['qform_code']) == 0
+        assert_array_equal(reoriented.affine, reoriented.header.get_best_affine())
+
     def test_reoriented_dim_info(self):
         # Check that dim_info is reoriented correctly
         arr = np.arange(24, dtype='f4').reshape((2, 3, 4))


### PR DESCRIPTION
Reorienting an image permutes and flips its axes, but it does not move the image
into a different space, so the sform and qform codes should survive it. At
present they do not.

Writing the reoriented affine back into the header goes through
`Nifti1Pair._affine2header`, which files the affine under the default 'aligned'
sform code and marks the qform unknown. An image that dcm2niix labelled scanner
anat therefore comes back from `as_closest_canonical` with `sform_code` 2 and
`qform_code` 0, exactly as reported.

This restores whichever codes were set on the way in, in the same place
`as_reoriented` already fixes up `dim_info`, which is what you suggested in the
thread, @effigies.

A code of 0 is deliberately left alone. There was no form of that kind to
preserve, and clearing what the affine write-back just set could leave the image
with no valid form at all.
