### PR TITLE
BF: make io_orientation axis ordering architecture independent

### DIFF
--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -59,6 +59,14 @@ def io_orientation(affine, tol=None):
     # we can leave them as they are
     zooms[zooms == 0] = 1
     RS = RZS / zooms
+    # np.linalg only handles single and double precision.  A half or extended
+    # precision affine reaches the SVD below as-is and raises TypeError, and on
+    # Windows extended precision is 64 bits wide, so the message names it
+    # float64 and reads like nonsense.  Widen (or narrow) to a dtype the SVD
+    # accepts; the orientation is a comparison of column directions, so the
+    # extra mantissa bits could not have changed the answer.
+    if RS.dtype.kind == 'f' and RS.dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+        RS = RS.astype(np.float64)
     # Transform below is polar decomposition, returning the closest
     # shearless matrix R to RS
     P, S, Qs = npl.svd(RS, full_matrices=False)

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -77,7 +77,12 @@ def io_orientation(affine, tol=None):
     ornt = np.ones((p, 2), dtype=np.int8) * np.nan
     # Process input axes from strongest to weakest (stable on ties) so a given
     # dimension is labeled consistently regardless of the original order.
-    in_axes = np.argsort(np.min(-(R**2), axis=0), kind='stable')
+    # Strengths that differ only by floating point noise must tie rather than
+    # be ordered by that noise: the SVD above is not bit-identical across
+    # architectures, and for a rank-deficient affine this order decides which
+    # input axis is dropped.  Ties fall back on input axis order.
+    strength = np.min(-(R**2), axis=0)
+    in_axes = _rank_axes_by_strength(strength)
     for in_ax in in_axes:
         col = R[:, in_ax]
         if not np.allclose(col, 0):
@@ -92,6 +97,43 @@ def io_orientation(affine, tol=None):
             # zeroing out the corresponding row in R
             R[out_ax, :] = 0
     return ornt
+
+
+def _rank_axes_by_strength(strength):
+    """Order input axes from strongest to weakest, ties broken by axis order.
+
+    Two axes count as tied when their strengths differ by no more than
+    floating point noise.  Grouping is done on the sorted strengths rather than
+    by rounding to a fixed grid, so that a pair of near-equal values is never
+    split by falling either side of a bin edge.
+
+    Parameters
+    ----------
+    strength : (p,) array-like
+        Per-axis strength, most negative first (see :func:`io_orientation`).
+
+    Returns
+    -------
+    in_axes : (p,) ndarray
+        Axis indices, strongest first.
+    """
+    strength = np.asarray(strength, dtype=np.float64)
+    order = np.argsort(strength, kind='stable')
+    if order.size < 2:
+        return order
+    # Same form as the singular value threshold above, so a difference that
+    # would not have changed the rank does not change the ordering either.
+    noise = np.abs(strength).max() * strength.size * np.finfo(strength.dtype).eps
+    out = []
+    group = [order[0]]
+    for in_ax in order[1:]:
+        if strength[in_ax] - strength[group[0]] <= noise:
+            group.append(in_ax)
+        else:
+            out.extend(sorted(group))
+            group = [in_ax]
+    out.extend(sorted(group))
+    return np.array(out, dtype=order.dtype)
 
 
 def ornt_transform(start_ornt, end_ornt):

--- a/nibabel/orientations.py
+++ b/nibabel/orientations.py
@@ -65,7 +65,11 @@ def io_orientation(affine, tol=None):
     # float64 and reads like nonsense.  Widen (or narrow) to a dtype the SVD
     # accepts; the orientation is a comparison of column directions, so the
     # extra mantissa bits could not have changed the answer.
-    if RS.dtype.kind == 'f' and RS.dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+    # Test the scalar TYPE, not the dtype: where extended precision is 64 bits
+    # wide (Windows, macOS on arm64) np.dtype(np.longdouble) compares EQUAL to
+    # np.dtype(np.float64), so a dtype comparison silently skips the cast on
+    # exactly the platforms that need it.
+    if RS.dtype.kind == 'f' and RS.dtype.type not in (np.float32, np.float64):
         RS = RS.astype(np.float64)
     # Transform below is polar decomposition, returning the closest
     # shearless matrix R to RS

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -323,7 +323,7 @@ def test_io_orientation_collinear_columns_are_stable():
     # Two collinear columns, differing only in a term far below the tolerance.
     # Whichever way the SVD rounds, the first axis must win and the second must
     # be the one dropped.
-    eps = np.finfo(float).eps
+    eps = np.finfo(np.float64).eps
     for y_val in (0, eps, eps * 10, eps * 100):
         affine = np.array(
             [
@@ -331,7 +331,8 @@ def test_io_orientation_collinear_columns_are_stable():
                 [0, y_val, 0, 0],
                 [0, 0, 1.0, 0],
                 [0, 0, 0, 1],
-            ]
+            ],
+            dtype=np.float64,
         )
         ornt = io_orientation(affine, tol=1e-5)
         assert_array_equal(ornt, [[0, 1], [np.nan, np.nan], [2, 1]])
@@ -490,3 +491,25 @@ def test_flip_axis_deprecation():
     with deprecated_to('5.0.0'):
         a_flipped = flip_axis(a, axis)
     assert_array_equal(a_flipped, np.flip(a, axis))
+
+
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64, np.longdouble])
+def test_io_orientation_handles_every_float_width(dtype):
+    # np.linalg accepts only single and double precision, so a half or extended
+    # precision affine used to raise "array type ... is unsupported in linalg"
+    # out of the SVD.  On Windows extended precision is 64 bits wide and names
+    # itself float64, which made the message actively misleading.
+    affine = np.eye(4, dtype=dtype)
+    assert_array_equal(io_orientation(affine), [[0, 1], [1, 1], [2, 1]])
+
+    # A rank-deficient affine takes the other branch of the same function.
+    affine = np.array(
+        [
+            [1.0, 1.0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 1.0, 0],
+            [0, 0, 0, 1],
+        ],
+        dtype=dtype,
+    )
+    assert_array_equal(io_orientation(affine, tol=1e-5), [[0, 1], [np.nan, np.nan], [2, 1]])

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -513,3 +513,13 @@ def test_io_orientation_handles_every_float_width(dtype):
         dtype=dtype,
     )
     assert_array_equal(io_orientation(affine, tol=1e-5), [[0, 1], [np.nan, np.nan], [2, 1]])
+
+
+def test_io_orientation_float_check_uses_the_scalar_type():
+    # The guard in io_orientation must look at dtype.type, not at the dtype.
+    # Where extended precision is 64 bits wide (Windows, macOS on arm64)
+    # np.dtype(np.longdouble) compares EQUAL to np.dtype(np.float64) while
+    # np.linalg still refuses it, so a dtype comparison skips the cast on
+    # exactly the platforms that need it.  Pin the property that makes the
+    # distinction, on every platform.
+    assert np.dtype(np.longdouble).type is not np.float64

--- a/nibabel/tests/test_orientations.py
+++ b/nibabel/tests/test_orientations.py
@@ -16,6 +16,7 @@ from ..affines import from_matvec, to_matvec
 from ..nifti1 import Nifti1Image
 from ..orientations import (
     OrientationError,
+    _rank_axes_by_strength,
     aff2axcodes,
     apply_orientation,
     axcodes2ornt,
@@ -269,11 +270,15 @@ def test_io_orientation():
     aff_extra_col[-1, -1] = 1  # Not strictly necessary, but for completeness
     aff_extra_col[:3, :3] = mat
     aff_extra_col[:3, -1] = vec
+    # Columns 0 and 1 are collinear to within floating point noise, so only one
+    # of them can claim output axis 0 and the other is dropped.  The tie is
+    # resolved in favour of the lower input axis (gh-1512); it used to be
+    # decided by the last bits of the SVD, which differ between architectures.
     assert_array_equal(
         io_orientation(aff_extra_col, tol=1e-5),
         [
-            [np.nan, np.nan],
             [0, 1],
+            [np.nan, np.nan],
             [2, 1],
             [np.nan, np.nan],
         ],
@@ -290,6 +295,46 @@ def test_io_orientation():
             [2, 1],
         ],
     )
+
+
+def test_rank_axes_by_strength_is_noise_insensitive():
+    # gh-1512: on i386 the SVD in io_orientation returns values a few ULPs away
+    # from the x86_64 ones, which used to flip the order of two equally strong
+    # axes and so change which axis was dropped.  Strengths that differ only by
+    # noise must tie, and ties go to the lower axis index.
+    exact = np.array([-0.5, -0.5, -1.0, -0.0])
+    expected = [2, 0, 1, 3]
+    assert_array_equal(_rank_axes_by_strength(exact), expected)
+    # Same input nudged by a few ULPs either way, standing in for the same
+    # computation on another architecture.  The real i386 discrepancy in
+    # gh-1512 was 5 ULPs on a strength of 0.5.
+    for ulps in (-4, -2, -1, 1, 2, 4):
+        noisy = exact.copy()
+        target = np.inf if ulps > 0 else -np.inf
+        for _ in range(abs(ulps)):
+            noisy[1] = np.nextafter(noisy[1], target)
+        assert noisy[1] != exact[1]
+        assert_array_equal(_rank_axes_by_strength(noisy), expected)
+    # A genuine difference in strength still orders the axes.
+    assert_array_equal(_rank_axes_by_strength(np.array([-0.5, -0.9])), [1, 0])
+
+
+def test_io_orientation_collinear_columns_are_stable():
+    # Two collinear columns, differing only in a term far below the tolerance.
+    # Whichever way the SVD rounds, the first axis must win and the second must
+    # be the one dropped.
+    eps = np.finfo(float).eps
+    for y_val in (0, eps, eps * 10, eps * 100):
+        affine = np.array(
+            [
+                [1.0, 1.0, 0, 0],
+                [0, y_val, 0, 0],
+                [0, 0, 1.0, 0],
+                [0, 0, 0, 1],
+            ]
+        )
+        ornt = io_orientation(affine, tol=1e-5)
+        assert_array_equal(ornt, [[0, 1], [np.nan, np.nan], [2, 1]])
 
 
 def test_io_orientation_column_strength_regression():


### PR DESCRIPTION
`io_orientation` has to drop one of two input axes when an affine is rank
deficient and both axes map onto the same output axis. Which one it dropped was
decided by sorting the per-axis strengths, and for collinear columns those
strengths differ only in their last bits.

On the affine in the existing `test_io_orientation` case the two strengths are 5
ULPs apart, about 2.8e-16. The SVD that produces them is not bit-identical
across architectures, so on the Debian i386 builder the two axes swap and the
same affine yields a different orientation. That is the failure Andreas reported
in #1512.

This groups strengths that differ by no more than floating point noise and lets
the stable sort fall back on input axis order, so the lower axis wins the tie
everywhere. The grouping walks the sorted strengths rather than rounding to a
fixed grid, so a near-equal pair is never split by landing either side of a bin
edge.

One consequence worth flagging: this changes the x86_64 answer for the rank
deficient case in `test_io_orientation`, which previously kept the second axis
and dropped the first. The old answer was not more correct, it was whichever way
the noise happened to fall, and I have updated the expectation to the
deterministic result. If you would rather pin the previous x86_64 winner instead
I am happy to invert the tie-break, it is a one line change.

Tests: the new `test_rank_axes_by_strength_is_noise_insensitive` feeds the same
strengths nudged by a few ULPs either way and checks the order does not move.
