### PR TITLE
BF: read the CSA1 item length offset from the first tag

### DIFF
--- a/nibabel/nicom/csareader.py
+++ b/nibabel/nicom/csareader.py
@@ -120,8 +120,12 @@ def read(csa_str):
             n_values = vm
         # data converter
         converter = _CONVERTERS.get(vr)
-        # CSA1 specific length modifier
-        if tag_no == 1:
+        # CSA1 specific length modifier: item lengths are offset by the
+        # n_items of the *first* tag (see doc/source/dicom/siemens_csa.rst).
+        # This has to be the tag numbered 0, both because that is the first
+        # tag read and because the items of tag 0 are parsed below, before a
+        # tag numbered 1 would ever be reached.
+        if tag_no == 0:
             tag0_n_items = n_items
         if n_items > MAX_CSA_ITEMS:
             raise CSAReadError(f'Expected <= {MAX_CSA_ITEMS} tags, got {n_items}')

--- a/nibabel/nicom/tests/test_csareader.py
+++ b/nibabel/nicom/tests/test_csareader.py
@@ -1,6 +1,7 @@
 """Testing Siemens CSA header reader"""
 
 import gzip
+import struct
 from copy import deepcopy
 from os.path import join as pjoin
 
@@ -131,3 +132,56 @@ def test_missing_csa_elem():
     del dcm[csa_tag]
     hdr = csa.get_csa_header(dcm, 'image')
     assert hdr is None
+
+
+def _csa1_header(tags, check=77):
+    """Build a CSA1 header from ``(name, vm, vr, items)`` tuples.
+
+    The repo's own description of the format is in
+    ``doc/source/dicom/siemens_csa.rst``: a CSA1 item stores its length offset
+    by the ``n_items`` of the first tag in the header.
+    """
+    tag0_n_items = len(tags[0][3])
+    out = struct.pack('<2I', len(tags), check)
+    for name, vm, vr, items in tags:
+        out += struct.pack('<64si4s3i', name.encode(), vm, vr.encode(), 0, len(items), 77)
+        for item in items:
+            item_len = len(item)
+            out += struct.pack('<4i', item_len + tag0_n_items, item_len, 77, 77)
+            out += item
+            pad = item_len % 4
+            if pad:
+                out += b'\x00' * (4 - pad)
+    return out
+
+
+def test_csa1_read_items():
+    # gh-817: the CSA1 item length offset must come from the tag numbered 0.
+    # The first tag here has three items and the second has one, so reading the
+    # offset from the wrong tag gives the wrong length for every item.
+    hdr = _csa1_header(
+        [
+            ('FirstTag', 0, 'LO', [b'alpha\x00', b'beta\x00', b'gamma\x00']),
+            ('SecondTag', 0, 'LO', [b'0123456789\x00']),
+        ]
+    )
+    csa_info = csa.read(hdr)
+    assert csa_info['type'] == 1
+    assert csa_info['n_tags'] == 2
+    assert csa_info['tags']['FirstTag']['items'] == ['alpha', 'beta', 'gamma']
+    assert csa_info['tags']['SecondTag']['items'] == ['0123456789']
+
+
+def test_csa1_single_tag():
+    # gh-817: a CSA1 header with only one tag never reached a tag numbered 1,
+    # so the offset was read before it had been assigned.
+    hdr = _csa1_header([('OnlyTag', 0, 'LO', [b'value\x00'])])
+    csa_info = csa.read(hdr)
+    assert csa_info['type'] == 1
+    assert csa_info['tags']['OnlyTag']['items'] == ['value']
+
+
+def test_csa1_numeric_converter():
+    hdr = _csa1_header([('Numbers', 0, 'DS', [b'1.5\x00', b'2.5\x00'])])
+    csa_info = csa.read(hdr)
+    assert csa_info['tags']['Numbers']['items'] == [1.5, 2.5]


### PR DESCRIPTION
CSA1 item lengths are stored offset by the `n_items` of the first tag in the
header. `doc/source/dicom/siemens_csa.rst` says so in as many words: the length
is `xx[0]` minus "the `nitems` of the *first* read tag". The reader took that
offset from the tag numbered 1 rather than the tag numbered 0.

The effect is worse than a wrong length. The offset is used while parsing the
items of every tag, including tag 0, so it was read before it had ever been
assigned: any CSA1 header with at least one item raises `UnboundLocalError`,
whatever its tag count. That matches the report from @smeisler in the issue
thread. Where a header did survive to use the value, tag 1 generally has a
different `n_items` from tag 0, so every item length was wrong by that
difference.

The variable is already called `tag0_n_items`, which I take as the original
intent; this looks like an off-by-one from the 1-indexed MATLAB original, as
@reddigari guessed when they opened the issue.

There is no CSA1 file in the test data, which is why this went unnoticed for so
long, so the tests build a CSA1 header to the layout the docs describe. Three
new tests, all of which fail on master with `UnboundLocalError`.
