### PR TITLE
BF: accept the copy keyword in __array__

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -80,11 +80,15 @@ class ArrayLike(ty.Protocol):
 
     # If no dtype is passed, any dtype might be returned, depending on the array-like
     @ty.overload
-    def __array__(self, dtype: None = ..., /) -> np.ndarray[ty.Any, np.dtype[ty.Any]]: ...
+    def __array__(
+        self, dtype: None = ..., /, *, copy: bool | None = ...
+    ) -> np.ndarray[ty.Any, np.dtype[ty.Any]]: ...
 
     # Any dtype might be passed, and *that* dtype must be returned
     @ty.overload
-    def __array__(self, dtype: _DType, /) -> np.ndarray[ty.Any, _DType]: ...
+    def __array__(
+        self, dtype: _DType, /, *, copy: bool | None = ...
+    ) -> np.ndarray[ty.Any, _DType]: ...
 
     def __getitem__(self, key, /) -> npt.NDArray: ...
 
@@ -431,7 +435,7 @@ class ArrayProxy(ArrayLike):
         """
         return self._get_unscaled(slicer=())
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Read data from file and apply scaling, casting to ``dtype``
 
         If ``dtype`` is unspecified, the dtype of the returned array is the
@@ -446,12 +450,23 @@ class ArrayProxy(ArrayLike):
         ----------
         dtype : numpy dtype specifier, optional
             A numpy dtype specifier specifying the type of the returned array.
+        copy : {None, True, False}, optional
+            Part of the numpy array protocol.  ``False`` asks for an array that
+            shares memory with this object, which it cannot provide, and so
+            raises ``ValueError``.  ``None`` and ``True`` both return a new
+            array.
 
         Returns
         -------
         array
             Scaled image data with type `dtype`.
         """
+        if copy is False:
+            raise ValueError(
+                'Unable to avoid copy while creating an array as requested.\n'
+                'The data is read from file and scaled on the way out, so there is '
+                'no existing array to return a view on.'
+            )
         arr = self._get_scaled(dtype=dtype, slicer=())
         if dtype is not None:
             arr = arr.astype(dtype, copy=False)

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -687,7 +687,7 @@ class EcatImageArrayProxy:
     def is_proxy(self):
         return True
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Read of data from file
 
         This reads ALL FRAMES into one array, can be memory expensive.
@@ -699,12 +699,23 @@ class EcatImageArrayProxy:
         ----------
         dtype : numpy dtype specifier, optional
             A numpy dtype specifier specifying the type of the returned array.
+        copy : {None, True, False}, optional
+            Part of the numpy array protocol.  ``False`` asks for an array that
+            shares memory with this object, which it cannot provide, and so
+            raises ``ValueError``.  ``None`` and ``True`` both return a new
+            array.
 
         Returns
         -------
         array
             Scaled image data with type `dtype`.
         """
+        if copy is False:
+            raise ValueError(
+                'Unable to avoid copy while creating an array as requested.\n'
+                'The frames are read from file and assembled into a new array, so '
+                'there is no existing array to return a view on.'
+            )
         # dtype=None is interpreted as float64
         data = np.empty(self.shape)
         frame_mapping = get_frame_order(self._subheader._mlist)

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -253,7 +253,7 @@ class MincImageArrayProxy:
     def is_proxy(self):
         return True
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Read data from file and apply scaling, casting to ``dtype``
 
         If ``dtype`` is unspecified, the dtype is automatically determined.
@@ -262,12 +262,23 @@ class MincImageArrayProxy:
         ----------
         dtype : numpy dtype specifier, optional
             A numpy dtype specifier specifying the type of the returned array.
+        copy : {None, True, False}, optional
+            Part of the numpy array protocol.  ``False`` asks for an array that
+            shares memory with this object, which it cannot provide, and so
+            raises ``ValueError``.  ``None`` and ``True`` both return a new
+            array.
 
         Returns
         -------
         array
             Scaled image data with type `dtype`.
         """
+        if copy is False:
+            raise ValueError(
+                'Unable to avoid copy while creating an array as requested.\n'
+                'The data is read from file and scaled on the way out, so there is '
+                'no existing array to return a view on.'
+            )
         arr = self.minc_file.get_scaled_data(sliceobj=())
         if dtype is not None:
             arr = arr.astype(dtype, copy=False)

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -689,7 +689,7 @@ class PARRECArrayProxy:
         """
         return self._get_unscaled(slicer=())
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Read data from file and apply scaling, casting to ``dtype``
 
         If ``dtype`` is unspecified, the dtype of the returned array is the
@@ -700,12 +700,23 @@ class PARRECArrayProxy:
         ----------
         dtype : numpy dtype specifier, optional
             A numpy dtype specifier specifying the type of the returned array.
+        copy : {None, True, False}, optional
+            Part of the numpy array protocol.  ``False`` asks for an array that
+            shares memory with this object, which it cannot provide, and so
+            raises ``ValueError``.  ``None`` and ``True`` both return a new
+            array.
 
         Returns
         -------
         array
             Scaled image data with type `dtype`.
         """
+        if copy is False:
+            raise ValueError(
+                'Unable to avoid copy while creating an array as requested.\n'
+                'The data is read from file and scaled on the way out, so there is '
+                'no existing array to return a view on.'
+            )
         arr = self._get_scaled(dtype=dtype, slicer=())
         if dtype is not None:
             arr = arr.astype(dtype, copy=False)

--- a/nibabel/pointset.py
+++ b/nibabel/pointset.py
@@ -41,10 +41,14 @@ class CoordinateArray(ty.Protocol):
     shape: tuple[int, int]
 
     @ty.overload
-    def __array__(self, dtype: None = ..., /) -> np.ndarray[ty.Any, np.dtype[ty.Any]]: ...
+    def __array__(
+        self, dtype: None = ..., /, *, copy: bool | None = ...
+    ) -> np.ndarray[ty.Any, np.dtype[ty.Any]]: ...
 
     @ty.overload
-    def __array__(self, dtype: _DType, /) -> np.ndarray[ty.Any, _DType]: ...
+    def __array__(
+        self, dtype: _DType, /, *, copy: bool | None = ...
+    ) -> np.ndarray[ty.Any, _DType]: ...
 
 
 @dataclass
@@ -189,7 +193,13 @@ class GridIndices:
     def __repr__(self):
         return f'<{self.__class__.__name__}{self.gridshape}>'
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
+        if copy is False:
+            raise ValueError(
+                'Unable to avoid copy while creating an array as requested.\n'
+                'The coordinates are generated on demand, so there is no existing '
+                'array to return a view on.'
+            )
         if dtype is None:
             dtype = self.dtype
 

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -30,6 +30,8 @@ from ..tmpdirs import InTemporaryDirectory
 from .test_fileslice import slicer_samples
 from .test_openers import patch_indexed_gzip
 
+NUMPY_LT_2 = Version(np.__version__) < Version('2.0.0.dev0')
+
 
 class FunkyHeader:
     def __init__(self, shape):
@@ -624,10 +626,23 @@ def test_array_copy_keyword():
     bio.write(arr.tobytes(order='F'))
     prox = ArrayProxy(bio, hdr)
 
+    # The guard is ours, so it holds on every numpy we support.
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        prox.__array__(copy=False)
+
     with warnings.catch_warnings():
         warnings.simplefilter('error', DeprecationWarning)
         assert_array_equal(np.asarray(prox), arr)
         assert_array_equal(np.array(prox, copy=True), arr)
+
+    # numpy 1 never forwards copy= to __array__: it rejects copy=None outright
+    # and implements copy=False itself, so only on numpy 2 does np.array()
+    # reach the guard.
+    if NUMPY_LT_2:
+        return
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', DeprecationWarning)
         assert_array_equal(np.array(prox, copy=None), arr)
 
     with pytest.raises(ValueError, match='Unable to avoid copy'):

--- a/nibabel/tests/test_arrayproxy.py
+++ b/nibabel/tests/test_arrayproxy.py
@@ -11,6 +11,7 @@
 import contextlib
 import gzip
 import pickle
+import warnings
 from io import BytesIO
 from unittest import mock
 
@@ -606,3 +607,28 @@ def test_copy_with_indexed_gzip_handle(tmp_path):
         assert proxy.file_like is copied.file_like
         assert np.array_equal(proxy[0, 0, 0], copied[0, 0, 0])
         assert np.array_equal(proxy[-1, -1, -1], copied[-1, -1, -1])
+
+
+def test_array_copy_keyword():
+    # gh-1318: numpy 2 passes copy= to __array__ and deprecates implementations
+    # that do not accept it.  The data is read from file and scaled, so there is
+    # never an array to share, and copy=False has to raise rather than quietly
+    # hand back a copy.
+    shape = (2, 3, 4)
+    arr = np.arange(24, dtype=np.int16).reshape(shape)
+    bio = BytesIO()
+    hdr = Nifti1Header()
+    hdr.set_data_shape(shape)
+    hdr.set_data_dtype(np.int16)
+    bio.write(b'\x00' * hdr.get_data_offset())
+    bio.write(arr.tobytes(order='F'))
+    prox = ArrayProxy(bio, hdr)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', DeprecationWarning)
+        assert_array_equal(np.asarray(prox), arr)
+        assert_array_equal(np.array(prox, copy=True), arr)
+        assert_array_equal(np.array(prox, copy=None), arr)
+
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        np.array(prox, copy=False)

--- a/nibabel/tests/test_ecat.py
+++ b/nibabel/tests/test_ecat.py
@@ -279,3 +279,11 @@ class TestEcatImage(TestCase):
     def test_mlist_regression(self):
         # Test mlist is as same as for nibabel 1.3.0
         assert_array_equal(self.img.get_mlist(), [[16842758, 3, 3011, 1]])
+
+
+def test_array_copy_false_raises():
+    # gh-1318: every frame is read from file into a new array, so there is no
+    # existing array for copy=False to return a view on.
+    img = EcatImage.from_filename(ecat_file)
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        img.dataobj.__array__(copy=False)

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -213,3 +213,11 @@ class TestMinc1Image(tsi.TestSpatialImage):
                 img.header.data_to_fileobj(arr, bio)
             with pytest.raises(NotImplementedError):
                 img.header.data_from_fileobj(bio)
+
+
+def test_array_copy_false_raises():
+    # gh-1318: the data is read from the netcdf variable and scaled on the way
+    # out, so there is no existing array for copy=False to return a view on.
+    img = Minc1Image.from_filename(EG_FNAME)
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        img.dataobj.__array__(copy=False)

--- a/nibabel/tests/test_parrec.py
+++ b/nibabel/tests/test_parrec.py
@@ -918,3 +918,12 @@ def test_alternative_header_field_names():
     # Diffusion values" in the General Information section. This tests that
     # the key is read correctly regardless of case.
     assert HDR_INFO['max_diffusion_values'] == 1
+
+
+def test_array_copy_false_raises():
+    # gh-1318: the REC data is read and scaled on the way out, so there is no
+    # existing array for copy=False to return a view on.
+    hdr = PARRECHeader(HDR_INFO, HDR_DEFS)
+    prox = PARRECArrayProxy(EG_REC, hdr, scaling='dv')
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        prox.__array__(copy=False)

--- a/nibabel/tests/test_pointset.py
+++ b/nibabel/tests/test_pointset.py
@@ -179,3 +179,11 @@ class TestGrids(TestPointsets):
             ],
         )
         assert np.array_equal(mask_img.affine, np.eye(4))
+
+
+def test_GridIndices_array_copy_false_raises():
+    # gh-1318: the coordinates are generated on demand, so there is no existing
+    # array for copy=False to return a view on.
+    gi = ps.GridIndices((2, 3, 4))
+    with pytest.raises(ValueError, match='Unable to avoid copy'):
+        gi.__array__(copy=False)


### PR DESCRIPTION
numpy 2 passes `copy=` to `__array__` and deprecates implementations that do not
accept it, so `np.array(img.dataobj, copy=False)` raises a `DeprecationWarning`
from every nibabel array proxy and will stop working once the deprecation
expires. Still reproduces on numpy 2.5.2.

There are five implementations rather than the one the issue points at:
`arrayproxy`, `ecat`, `parrec`, `minc1` and `pointset`. All five now take the
keyword, and both `ArrayLike` protocols are updated to match.

All five build a new array, whether by reading and scaling from file or by
generating coordinates on demand, so none of them can return something that
shares memory with the object. `copy=False` therefore raises `ValueError`, which
is what the array protocol asks for, rather than quietly returning a copy as it
does today. That is a behaviour change for anyone passing `copy=False`, though
it is the behaviour numpy will enforce itself before long.

The guard is written out in each implementation rather than shared. The five
live in modules that do not currently import from one another and a three line
check did not seem worth a new import edge; happy to factor it out if you would
rather.
